### PR TITLE
Tools Dependency TextureAtlas Fix

### DIFF
--- a/Gem/Code/tool_dependencies.cmake
+++ b/Gem/Code/tool_dependencies.cmake
@@ -22,7 +22,7 @@ set(GEM_DEPENDENCIES
     Gem::ExpressionEvaluation
     Gem::PhysX.Editor
     Gem::PhysXDebug.Editor
-    Gem::TextureAtlas
+    Gem::TextureAtlas.Editor
     Gem::SurfaceData.Editor
     Gem::DebugDraw.Editor
     Gem::AudioSystem.Editor


### PR DESCRIPTION
Update tool_dependencies to use the new AtlasTexture.Editor gem so that AP.exe works