### PR TITLE
Fix physx base position reconciliation against network

### DIFF
--- a/Gem/Code/Source/Components/CharacterComponent.h
+++ b/Gem/Code/Source/Components/CharacterComponent.h
@@ -35,13 +35,11 @@ namespace MultiplayerSample
 
     private:
         void OnTranslationChangedEvent(const AZ::Vector3& translation);
-        void OnTranslationAutonomousChangedEvent(const AZ::Vector3& translation);
         void OnSyncRewind();
 
         Physics::Character* m_physicsCharacter = nullptr;
         Multiplayer::EntitySyncRewindEvent::Handler m_syncRewindHandler = Multiplayer::EntitySyncRewindEvent::Handler([this]() { OnSyncRewind(); });
         AZ::Event<AZ::Vector3>::Handler m_translationEventHandler;
-        AZ::Event<AZ::Vector3>::Handler m_translationAutonomousEventHandler;
     };
 
     class CharacterComponentController


### PR DESCRIPTION
This ensures that when translation is updated, the update is propagated to the PhysX body. The PhysX sim in turn updates local networked values for transform so without this PhysX effectively operates without any knowledge of networked position.