### PR TITLE
Fix wasd input nullptr issues and transform state for autonomous

### DIFF
--- a/Gem/Code/Source/Components/CharacterComponent.cpp
+++ b/Gem/Code/Source/Components/CharacterComponent.cpp
@@ -41,7 +41,7 @@ namespace MultiplayerSample
         m_physicsCharacter = (characterRequests != nullptr) ? characterRequests->GetCharacter() : nullptr;
         GetNetBindComponent()->AddEntitySyncRewindEventHandler(m_syncRewindHandler);
 
-        if (!HasController())
+        if (!HasController() || GetController()->IsAutonomous())
         {
             GetNetworkTransformComponent()->TranslationAddEvent(m_translationEventHandler);
         }
@@ -54,7 +54,22 @@ namespace MultiplayerSample
 
     void CharacterComponent::OnTranslationChangedEvent([[maybe_unused]] const AZ::Vector3& translation)
     {
-        OnSyncRewind();
+        if (m_physicsCharacter == nullptr)
+        {
+            return;
+        }
+
+        const AZ::Vector3 currPosition = m_physicsCharacter->GetBasePosition();
+        if (!currPosition.IsClose(translation))
+        {
+            uint32_t frameId = static_cast<uint32_t>(Multiplayer::GetNetworkTime()->GetHostFrameId());
+            m_physicsCharacter->SetFrameId(frameId);
+            if (GetController() && GetController()->IsAutonomous())
+            {
+                m_physicsCharacter->SetBasePosition(translation);
+                GetEntity()->GetTransform()->SetLocalTranslation(translation);
+            }
+        }
     }
 
     void CharacterComponent::OnSyncRewind()
@@ -69,7 +84,6 @@ namespace MultiplayerSample
         {
             uint32_t frameId = static_cast<uint32_t>(Multiplayer::GetNetworkTime()->GetHostFrameId());
             m_physicsCharacter->SetFrameId(frameId);
-            //m_physicsCharacter->SetBasePosition(GetNetworkTransformComponent()->GetTranslation());
         }
     }
 

--- a/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
@@ -70,20 +70,24 @@ namespace MultiplayerSample
         // inputs for your own component always exist
         WasdPlayerMovementComponentNetworkInput* wasdInput = input.FindComponentInput<WasdPlayerMovementComponentNetworkInput>();
 
-        wasdInput->m_forwardAxis = StickAxis(m_forwardWeight - m_backwardWeight);
-        wasdInput->m_strafeAxis = StickAxis(m_leftWeight - m_rightWeight);
+        if (wasdInput)
+        {
+            wasdInput->m_forwardAxis = StickAxis(m_forwardWeight - m_backwardWeight);
+            wasdInput->m_strafeAxis = StickAxis(m_leftWeight - m_rightWeight);
 
-        // View Axis
-        wasdInput->m_viewYaw = MouseAxis(m_viewYaw);
-        wasdInput->m_viewPitch = MouseAxis(m_viewPitch);
+            // View Axis
+            wasdInput->m_viewYaw = MouseAxis(m_viewYaw);
+            wasdInput->m_viewPitch = MouseAxis(m_viewPitch);
 
-        // Strafe input
-        wasdInput->m_sprint = m_sprinting;
-        wasdInput->m_jump = m_jumping;
-        wasdInput->m_crouch = m_crouching;
+            // Strafe input
+            wasdInput->m_sprint = m_sprinting;
+            wasdInput->m_jump = m_jumping;
+            wasdInput->m_crouch = m_crouching;
 
-        // Just a note for anyone who is super confused by this, ResetCount is a predictable network property, it gets set on the client through correction packets
-        wasdInput->m_resetCount = GetNetworkTransformComponentController()->GetResetCount();
+            // Just a note for anyone who is super confused by this, ResetCount is a predictable network property, it gets set on the client
+            // through correction packets
+            wasdInput->m_resetCount = GetNetworkTransformComponentController()->GetResetCount();
+        }
     }
 
     void WasdPlayerMovementComponentController::ProcessInput(Multiplayer::NetworkInput& input, float deltaTime)
@@ -93,7 +97,7 @@ namespace MultiplayerSample
         //  2) On the client: we were reset and we are replaying old inputs after being corrected
         // In both cases we don't want to process these inputs
         WasdPlayerMovementComponentNetworkInput* wasdInput = input.FindComponentInput<WasdPlayerMovementComponentNetworkInput>();
-        if (wasdInput->m_resetCount != GetNetworkTransformComponentController()->GetResetCount())
+        if (!wasdInput || wasdInput->m_resetCount != GetNetworkTransformComponentController()->GetResetCount())
         {
             return;
         }


### PR DESCRIPTION
Fixes nullptr issues during cleanup for WasdInput and properly sets transform state for Autonomous character entities to prevent desync of transform.