### PR TITLE
Shorten copyright headers by splitting into 2 lines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -1,6 +1,7 @@
 # {BEGIN_LICENSE}
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/EngineFinder.cmake
+++ b/EngineFinder.cmake
@@ -2,7 +2,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/CMakeLists.txt
+++ b/Gem/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Platform/Android/multiplayersample_android_files.cmake
+++ b/Gem/Code/Platform/Android/multiplayersample_android_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Platform/Android/multiplayersample_android_files.cmake
+++ b/Gem/Code/Platform/Android/multiplayersample_android_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Platform/Linux/multiplayersample_linux_files.cmake
+++ b/Gem/Code/Platform/Linux/multiplayersample_linux_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Platform/Linux/multiplayersample_linux_files.cmake
+++ b/Gem/Code/Platform/Linux/multiplayersample_linux_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Platform/Mac/multiplayersample_mac_files.cmake
+++ b/Gem/Code/Platform/Mac/multiplayersample_mac_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Platform/Mac/multiplayersample_mac_files.cmake
+++ b/Gem/Code/Platform/Mac/multiplayersample_mac_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Platform/Windows/multiplayersample_windows_files.cmake
+++ b/Gem/Code/Platform/Windows/multiplayersample_windows_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Platform/Windows/multiplayersample_windows_files.cmake
+++ b/Gem/Code/Platform/Windows/multiplayersample_windows_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Platform/iOS/multiplayer_ios_files.cmake
+++ b/Gem/Code/Platform/iOS/multiplayer_ios_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/Platform/iOS/multiplayer_ios_files.cmake
+++ b/Gem/Code/Platform/iOS/multiplayer_ios_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/Source/Components/AnimatedHitVolumesComponent.cpp
+++ b/Gem/Code/Source/Components/AnimatedHitVolumesComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/AnimatedHitVolumesComponent.cpp
+++ b/Gem/Code/Source/Components/AnimatedHitVolumesComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/AnimatedHitVolumesComponent.h
+++ b/Gem/Code/Source/Components/AnimatedHitVolumesComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/AnimatedHitVolumesComponent.h
+++ b/Gem/Code/Source/Components/AnimatedHitVolumesComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/CharacterComponent.cpp
+++ b/Gem/Code/Source/Components/CharacterComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/CharacterComponent.cpp
+++ b/Gem/Code/Source/Components/CharacterComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/CharacterComponent.h
+++ b/Gem/Code/Source/Components/CharacterComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/CharacterComponent.h
+++ b/Gem/Code/Source/Components/CharacterComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/ExampleFilteredEntityComponent.cpp
+++ b/Gem/Code/Source/Components/ExampleFilteredEntityComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/ExampleFilteredEntityComponent.h
+++ b/Gem/Code/Source/Components/ExampleFilteredEntityComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/NetworkAnimationComponent.h
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/NetworkAnimationComponent.h
+++ b/Gem/Code/Source/Components/NetworkAnimationComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.h
+++ b/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.h
+++ b/Gem/Code/Source/Components/NetworkPlayerSpawnerComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/NetworkRigidBodyComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkRigidBodyComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/NetworkRigidBodyComponent.h
+++ b/Gem/Code/Source/Components/NetworkRigidBodyComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/NetworkRigidBodyComponent.h
+++ b/Gem/Code/Source/Components/NetworkRigidBodyComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/SimplePlayerCameraComponent.cpp
+++ b/Gem/Code/Source/Components/SimplePlayerCameraComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/SimplePlayerCameraComponent.cpp
+++ b/Gem/Code/Source/Components/SimplePlayerCameraComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/SimplePlayerCameraComponent.h
+++ b/Gem/Code/Source/Components/SimplePlayerCameraComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/SimplePlayerCameraComponent.h
+++ b/Gem/Code/Source/Components/SimplePlayerCameraComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/Components/WasdPlayerMovementComponent.h
+++ b/Gem/Code/Source/Components/WasdPlayerMovementComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/Components/WasdPlayerMovementComponent.h
+++ b/Gem/Code/Source/Components/WasdPlayerMovementComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.h
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.h
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/Source/MultiplayerSampleTypes.h
+++ b/Gem/Code/Source/MultiplayerSampleTypes.h
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/Gem/Code/Source/MultiplayerSampleTypes.h
+++ b/Gem/Code/Source/MultiplayerSampleTypes.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/multiplayersample_autogen_files.cmake
+++ b/Gem/Code/multiplayersample_autogen_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/multiplayersample_autogen_files.cmake
+++ b/Gem/Code/multiplayersample_autogen_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Gem/Code/multiplayersample_shared_files.cmake
+++ b/Gem/Code/multiplayersample_shared_files.cmake
@@ -1,5 +1,6 @@
 #
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/Gem/Code/multiplayersample_shared_files.cmake
+++ b/Gem/Code/multiplayersample_shared_files.cmake
@@ -1,7 +1,7 @@
 #
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 #

--- a/Materials/UVs.azsl
+++ b/Materials/UVs.azsl
@@ -1,6 +1,7 @@
 
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Materials/UVs.azsl
+++ b/Materials/UVs.azsl
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,7 +1,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/CommonVS.azsli
+++ b/Shaders/CommonVS.azsli
@@ -1,6 +1,7 @@
 
 /*
- * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+ * Copyright (c) Contributors to the Open 3D Engine Project.
+ * For complete copyright and license terms please see the LICENSE at the root of this distribution.
  * 
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *

--- a/Shaders/CommonVS.azsli
+++ b/Shaders/CommonVS.azsli
@@ -2,7 +2,7 @@
 /*
  * Copyright (c) Contributors to the Open 3D Engine Project.
  * For complete copyright and license terms please see the LICENSE at the root of this distribution.
- * 
+ *
  * SPDX-License-Identifier: Apache-2.0 OR MIT
  *
  */

--- a/generate_asset_cmake.bat
+++ b/generate_asset_cmake.bat
@@ -1,7 +1,7 @@
 @ECHO off
 REM Copyright (c) Contributors to the Open 3D Engine Project.
 REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
-REM 
+REM
 REM SPDX-License-Identifier: Apache-2.0 OR MIT
 
 setlocal enabledelayedexpansion

--- a/generate_asset_cmake.bat
+++ b/generate_asset_cmake.bat
@@ -1,5 +1,6 @@
 @ECHO off
-REM Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+REM Copyright (c) Contributors to the Open 3D Engine Project.
+REM For complete copyright and license terms please see the LICENSE at the root of this distribution.
 REM 
 REM SPDX-License-Identifier: Apache-2.0 OR MIT
 
@@ -16,7 +17,8 @@ set OUTPUT_FILE=multiplayersample_asset_files.cmake
 
 :: Write copyright header to top of file
 echo # > %OUTPUT_FILE%
-echo # Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution. >> %OUTPUT_FILE%
+echo # Copyright (c) Contributors to the Open 3D Engine Project. >> %OUTPUT_FILE%
+echo # For complete copyright and license terms please see the LICENSE at the root of this distribution. >> %OUTPUT_FILE%
 echo # >> %OUTPUT_FILE%
 echo # SPDX-License-Identifier: Apache-2.0 OR MIT >> %OUTPUT_FILE%
 echo # >> %OUTPUT_FILE%

--- a/multiplayersample_asset_files.cmake
+++ b/multiplayersample_asset_files.cmake
@@ -1,5 +1,6 @@
 # 
-# Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
+# Copyright (c) Contributors to the Open 3D Engine Project.
+# For complete copyright and license terms please see the LICENSE at the root of this distribution.
 # 
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #

--- a/multiplayersample_asset_files.cmake
+++ b/multiplayersample_asset_files.cmake
@@ -1,7 +1,7 @@
 # 
 # Copyright (c) Contributors to the Open 3D Engine Project.
 # For complete copyright and license terms please see the LICENSE at the root of this distribution.
-# 
+#
 # SPDX-License-Identifier: Apache-2.0 OR MIT
 #
 # 


### PR DESCRIPTION
The original copyright headers for O3DE went over 140 characters, which is causing clang-format to automatically wrap it from:

```
/*
 * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of this distribution.
 * 
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 to:
 
 ```
 /*
 * Copyright (c) Contributors to the Open 3D Engine Project. For complete copyright and license terms please see the LICENSE at the root of
 * this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 So to reduce this unnecessary reformatting, and to make the copyright statement shorter in general (for all source code files), we are updating it to (C-style example):
 
 ```
 /*
 * Copyright (c) Contributors to the Open 3D Engine Project. 
 * For complete copyright and license terms please see the LICENSE at the root of this distribution.
 *
 * SPDX-License-Identifier: Apache-2.0 OR MIT
 *
 */
 ```
 
 Note: The copyright submission validator will still pass the original single-line version, as it is still a valid statement.
 