### PR TITLE
Camera component build fix

### DIFF
--- a/Gem/Code/Source/Components/SimplePlayerCameraComponent.cpp
+++ b/Gem/Code/Source/Components/SimplePlayerCameraComponent.cpp
@@ -5,6 +5,7 @@
  *
  */
 
+#include <AzCore/Component/ComponentApplicationBus.h>
 #include <Source/Components/SimplePlayerCameraComponent.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzFramework/Components/CameraBus.h>


### PR DESCRIPTION
It looks like unity build might work but non-unity has a compile error. This fixes that.

Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>