### PR TITLE
Remove references involving IFilteredEntityManager

### DIFF
--- a/Gem/Code/Source/MultiplayerSampleModule.cpp
+++ b/Gem/Code/Source/MultiplayerSampleModule.cpp
@@ -7,7 +7,6 @@
 
 #include <AzCore/Memory/SystemAllocator.h>
 #include <AzCore/Module/Module.h>
-#include <Components/ExampleFilteredEntityComponent.h>
 #include <Source/AutoGen/AutoComponentTypes.h>
 
 #include "MultiplayerSampleSystemComponent.h"
@@ -26,8 +25,7 @@ namespace MultiplayerSample
         {
             // Push results of [MyComponent]::CreateDescriptor() into m_descriptors here.
             m_descriptors.insert(m_descriptors.end(), {
-                MultiplayerSampleSystemComponent::CreateDescriptor(),
-                ExampleFilteredEntityComponent::CreateDescriptor(),
+                MultiplayerSampleSystemComponent::CreateDescriptor()
             });
 
             CreateComponentDescriptors(m_descriptors);

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -17,8 +17,6 @@ set(FILES
     Source/Components/AnimatedHitVolumesComponent.h
     Source/Components/CharacterComponent.cpp
     Source/Components/CharacterComponent.h
-    Source/Components/ExampleFilteredEntityComponent.h
-    Source/Components/ExampleFilteredEntityComponent.cpp
     Source/Components/NetworkAnimationComponent.cpp
     Source/Components/NetworkAnimationComponent.h
     Source/Components/NetworkPlayerSpawnerComponent.cpp


### PR DESCRIPTION
Removes references to code not yet in o3de main.

Signed-off-by: puvvadar <puvvadar@amazon.com>