### PR TITLE
Replace Lumberyard Beaver preview image with default O3DE image

### DIFF
--- a/preview.png
+++ b/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:a18fae4040a22d2bb359a8ca642b97bb8f6468eeb52e2826b3b029bd8f1350b6
-size 5466
+oid sha256:1cf8339fb51f82a68d2ab475c0476960e75a79d96d239c5b7cd272fbe4990ffe
+size 2770


### PR DESCRIPTION

![preview](https://user-images.githubusercontent.com/52797929/130499443-c70a230d-7f4a-482a-95fa-8482ee9cb580.png)
Signed-off-by: nggieber <nggieber@amazon.com>