### PR TITLE
Updated the MultiplayerSample `ly_enable_gems` call to remove the deprecated arguments

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -69,31 +69,10 @@ ly_create_alias(NAME MultiplayerSample.Servers  NAMESPACE Gem TARGETS Gem::Multi
 # Gem dependencies
 ################################################################################
 
-# The GameLauncher uses "Clients" gem variants:
-ly_enable_gems(PROJECT_NAME MultiplayerSample GEM_FILE enabled_gems.cmake
-    TARGETS MultiplayerSample.GameLauncher
-    VARIANTS Clients)
+# Maps tthe MultiplayerSample Project with the specified list of enabled gems
+ly_enable_gems(PROJECT_NAME MultiplayerSample GEM_FILE enabled_gems.cmake)
 
 # If we build a server, then apply the gems to the server
 if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
-    # if we're making a server, then add the "Server" gem variants to it:
-    ly_enable_gems(PROJECT_NAME MultiplayerSample GEM_FILE enabled_gems.cmake
-        TARGETS MultiplayerSample.ServerLauncher
-        VARIANTS Servers)
-    
     set_property(GLOBAL APPEND PROPERTY LY_LAUNCHER_SERVER_PROJECTS MultiplayerSample)
-endif()
-
-if (PAL_TRAIT_BUILD_HOST_TOOLS)
-    # The Editor uses "Tools" gem variants:
-    ly_enable_gems(
-        PROJECT_NAME MultiplayerSample GEM_FILE enabled_gems.cmake
-        TARGETS Editor
-        VARIANTS Tools)
-
-    # The pipeline tools use "Builders" gem variants:
-    ly_enable_gems(
-        PROJECT_NAME MultiplayerSample GEM_FILE enabled_gems.cmake
-        TARGETS AssetBuilder AssetProcessor AssetProcessorBatch
-        VARIANTS Builders)
 endif()

--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -69,10 +69,10 @@ ly_create_alias(NAME MultiplayerSample.Servers  NAMESPACE Gem TARGETS Gem::Multi
 # Gem dependencies
 ################################################################################
 
-# Maps tthe MultiplayerSample Project with the specified list of enabled gems
+# Maps the MultiplayerSample Project with the specified list of enabled gems
 ly_enable_gems(PROJECT_NAME MultiplayerSample GEM_FILE enabled_gems.cmake)
 
-# If we build a server, then apply the gems to the server
+# If we build a server, then add the project name to the list of server launcher projects
 if(PAL_TRAIT_BUILD_SERVER_SUPPORTED)
     set_property(GLOBAL APPEND PROPERTY LY_LAUNCHER_SERVER_PROJECTS MultiplayerSample)
 endif()


### PR DESCRIPTION
This simplifies the `ly_enable_gems` call down to a single call for the MultiplayerSample gem.

 Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>