### PR TITLE
Moving rewind out of WASD into NetworkCharacter::TryMove

### DIFF
--- a/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/WasdPlayerMovementComponent.cpp
@@ -115,16 +115,6 @@ namespace MultiplayerSample
         // Update velocity
         UpdateVelocity(*wasdInput);
 
-        // Ensure any entities that we might interact with are properly synchronized to their rewind state
-        if (IsAuthority())
-        {
-            const AZ::Aabb entityStartBounds = AZ::Interface<AzFramework::IEntityBoundsUnion>::Get()->GetEntityLocalBoundsUnion(GetEntity()->GetId());
-            const AZ::Aabb entityFinalBounds = entityStartBounds.GetTranslated(GetVelocity());
-            AZ::Aabb entitySweptBounds = entityStartBounds;
-            entitySweptBounds.AddAabb(entityFinalBounds);
-            Multiplayer::GetNetworkTime()->SyncEntitiesToRewindState(entitySweptBounds);
-        }
-
         GetNetworkCharacterComponentController()->TryMoveWithVelocity(GetVelocity(), deltaTime);
     }
 


### PR DESCRIPTION
Moving rewind out of WASD Character Controller into NetworkCharacter::TryMove. Anyone wanting to move would want to make sure they rewind other entities they potentially will come in contact with...
Signed-off-by: Gene Walters <genewalt@amazon.com>