### PR TITLE
Update autogen cmake to accomodate relocated jinja in MP Gem

### DIFF
--- a/Gem/Code/multiplayersample_autogen_files.cmake
+++ b/Gem/Code/multiplayersample_autogen_files.cmake
@@ -6,9 +6,9 @@
 #
 
 set(FILES
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Common.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Header.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Source/AutoGen/AutoComponent_Source.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Source/AutoGen/AutoComponentTypes_Header.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Source/AutoGen/AutoComponentTypes_Source.jinja
+    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
+    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
+    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Header.jinja
+    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
 )


### PR DESCRIPTION
This change corresponds to changes proposed in o3de at https://github.com/o3de/o3de/pull/4321 

Signed-off-by: puvvadar <puvvadar@amazon.com>