### PR TITLE
Cmake Update: Remove Depreciated Use of ly_get_list_relative_pal_filename

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -5,7 +5,7 @@
 #
 #
 
-ly_get_list_relative_pal_filename(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME})
+o3de_pal_dir(pal_dir ${CMAKE_CURRENT_LIST_DIR}/Platform/${PAL_PLATFORM_NAME} "${gem_restricted_path}" "${gem_path}" "${gem_parent_relative_path}")
 
 ly_add_target(
     NAME MultiplayerSample.Static STATIC


### PR DESCRIPTION
Remove depreciated use of ly_get_list_relative_pal_filename; replaced with o3de_pal_dir

Tested by reconfiguring and building MultiplayerSample on Windows and seeing the warnings go away.
Signed-off-by: Gene Walters <genewalt@amazon.com>