### PR TITLE
Fix various issues leading to desyncs while shooting

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml
@@ -16,7 +16,7 @@
 
     <NetworkInput Type="bool" Name="Draw" Init="false" />
     <NetworkInput Type="WeaponActivationBitset" Name="Firing"  Init="" />
-	<NetworkInput Type="AZ::Vector3" Name="FireTranslation" Init="" Container="Array" Count="MaxWeaponsPerComponent"/>
+	<NetworkInput Type="AZ::Vector3" Name="ShotStartPosition" Init="" />
 
     <NetworkProperty Type="FireParams"  Name="ActivationParams" Init=""  Container="Array" Count="MaxWeaponsPerComponent" ReplicateFrom="Authority" ReplicateTo="Client"     IsPublic="false" IsRewindable="false" IsPredictable="false" ExposeToEditor="false" GenerateEventBindings="false" Description="Parameters for the current weapon activation" />
     <NetworkProperty Type="uint8_t"     Name="ActivationCounts" Init="0" Container="Array" Count="MaxWeaponsPerComponent" ReplicateFrom="Authority" ReplicateTo="Client"     IsPublic="false" IsRewindable="false" IsPredictable="false" ExposeToEditor="false" GenerateEventBindings="true"  Description="The number of activations" />

--- a/Gem/Code/Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkWeaponsComponent.AutoComponent.xml
@@ -16,6 +16,7 @@
 
     <NetworkInput Type="bool" Name="Draw" Init="false" />
     <NetworkInput Type="WeaponActivationBitset" Name="Firing"  Init="" />
+	<NetworkInput Type="AZ::Vector3" Name="FireTranslation" Init="" Container="Array" Count="MaxWeaponsPerComponent"/>
 
     <NetworkProperty Type="FireParams"  Name="ActivationParams" Init=""  Container="Array" Count="MaxWeaponsPerComponent" ReplicateFrom="Authority" ReplicateTo="Client"     IsPublic="false" IsRewindable="false" IsPredictable="false" ExposeToEditor="false" GenerateEventBindings="false" Description="Parameters for the current weapon activation" />
     <NetworkProperty Type="uint8_t"     Name="ActivationCounts" Init="0" Container="Array" Count="MaxWeaponsPerComponent" ReplicateFrom="Authority" ReplicateTo="Client"     IsPublic="false" IsRewindable="false" IsPredictable="false" ExposeToEditor="false" GenerateEventBindings="true"  Description="The number of activations" />

--- a/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkWeaponsComponent.cpp
@@ -363,7 +363,7 @@ namespace MultiplayerSample
                 // TODO: This should probably be a physx raycast out to some maxDistance
                 const AZ::Vector3 fwd = AZ::Vector3::CreateAxisY();
                 const AZ::Vector3 aimTarget = worldTm.GetTranslation() + aimRotation.TransformVector(fwd * 5.0f);
-                FireParams fireParams{ aimTarget, weaponInput->m_fireTranslation, Multiplayer::InvalidNetEntityId };
+                FireParams fireParams{ weaponInput->m_fireTranslation, aimTarget, Multiplayer::InvalidNetEntityId };
                 TryStartFire(aznumeric_cast<WeaponIndex>(weaponIndexInt), fireParams);
             }
         }

--- a/Gem/Code/Source/Weapons/SceneQuery.cpp
+++ b/Gem/Code/Source/Weapons/SceneQuery.cpp
@@ -80,9 +80,9 @@ namespace MultiplayerSample
             auto ignoreEntitiesFilterCallback =
                 [&filter, networkEntityManager](const AzPhysics::SimulatedBody* body, [[maybe_unused]] const Physics::Shape* shape)
             {
-                // Exclude the dynamic bodies from another rewind frame
-                if (filter.m_rewindFrameId != Multiplayer::InvalidHostFrameId
-                    && body->GetNativeType() != PhysX::NativeTypeIdentifiers::RigidBodyStatic
+                // Exclude bodies from another rewind frame
+                if (filter.m_rewindFrameId != Multiplayer::InvalidHostFrameId 
+                    && (body->GetFrameId() != AzPhysics::SimulatedBody::UndefinedFrameId)
                      && (body->GetFrameId() != static_cast<uint32_t>(filter.m_rewindFrameId)))
                 {
                     return AzPhysics::SceneQuery::QueryHitType::None;

--- a/Gem/Code/Source/Weapons/SceneQuery.cpp
+++ b/Gem/Code/Source/Weapons/SceneQuery.cpp
@@ -13,6 +13,7 @@
 #include <Multiplayer/IMultiplayer.h>
 #include <Multiplayer/NetworkEntity/INetworkEntityManager.h>
 #include <Multiplayer/NetworkTime/INetworkTime.h>
+#include <PhysX/NativeTypeIdentifiers.h>
 
 namespace MultiplayerSample
 {
@@ -79,8 +80,9 @@ namespace MultiplayerSample
             auto ignoreEntitiesFilterCallback =
                 [&filter, networkEntityManager](const AzPhysics::SimulatedBody* body, [[maybe_unused]] const Physics::Shape* shape)
             {
-                // Exclude the bodies from another rewind frame
-                if ((filter.m_rewindFrameId != Multiplayer::InvalidHostFrameId)
+                // Exclude the dynamic bodies from another rewind frame
+                if (filter.m_rewindFrameId != Multiplayer::InvalidHostFrameId
+                    && body->GetNativeType() != PhysX::NativeTypeIdentifiers::RigidBodyStatic
                      && (body->GetFrameId() != static_cast<uint32_t>(filter.m_rewindFrameId)))
                 {
                     return AzPhysics::SceneQuery::QueryHitType::None;

--- a/Gem/Code/Source/Weapons/WeaponGathers.cpp
+++ b/Gem/Code/Source/Weapons/WeaponGathers.cpp
@@ -129,7 +129,7 @@ namespace MultiplayerSample
                     &DebugDraw::DebugDrawRequests::DrawLineLocationToLocation,
                     currSegmentPosition,
                     nextSegmentPosition,
-                    AZ::Colors::Red,
+                    segment % 2 == 0 ? AZ::Colors::Red : AZ::Colors::Yellow,
                     10.0f
                 );
             }

--- a/Gem/Code/Source/Weapons/WeaponGathers.cpp
+++ b/Gem/Code/Source/Weapons/WeaponGathers.cpp
@@ -109,14 +109,14 @@ namespace MultiplayerSample
 
         float currSegmentStartTime = inOutActiveShot.m_lifetimeSeconds;
         AZ::Vector3 currSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + (segmentStepOffset * currSegmentStartTime) + (gravity * 0.5f * currSegmentStartTime * currSegmentStartTime);
+        const AZ::Transform currSegTransform = AZ::Transform::CreateFromQuaternionAndTranslation(inOutActiveShot.m_initialTransform.GetRotation(), currSegmentPosition);
+
         for (uint32_t segment = 0; segment < bg_MultitraceNumTraceSegments; ++segment)
         {
             float nextSegmentStartTime = currSegmentStartTime + segmentTickSize;
             AZ::Vector3 travelDistance = (segmentStepOffset * nextSegmentStartTime); // Total distance our shot has traveled as of this cast, ignoring arc-length due to gravity
-            AZ::Vector3 nextSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + travelDistance + (gravity * 0.5f * nextSegmentStartTime * nextSegmentStartTime);
-
-            const AZ::Transform currSegTransform = AZ::Transform::CreateFromQuaternionAndTranslation(inOutActiveShot.m_initialTransform.GetRotation(), currSegmentPosition);
-            const AZ::Vector3   segSweep = nextSegmentPosition - currSegmentPosition;
+            AZ::Vector3 nextSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + travelDistance + (gravity * 0.5f * nextSegmentStartTime * nextSegmentStartTime);         
+            const AZ::Vector3 segSweep = nextSegmentPosition - currSegmentPosition;
 
             IntersectFilter filter(currSegTransform, segSweep, AzPhysics::SceneQuery::QueryType::StaticAndDynamic,
                 hitMultiple, collisionGroup, filteredNetEntityIds, gatherParams.GetCurrentShapeConfiguration());

--- a/Gem/Code/Source/Weapons/WeaponGathers.cpp
+++ b/Gem/Code/Source/Weapons/WeaponGathers.cpp
@@ -109,13 +109,14 @@ namespace MultiplayerSample
 
         float currSegmentStartTime = inOutActiveShot.m_lifetimeSeconds;
         AZ::Vector3 currSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + (segmentStepOffset * currSegmentStartTime) + (gravity * 0.5f * currSegmentStartTime * currSegmentStartTime);
-        const AZ::Transform currSegTransform = AZ::Transform::CreateFromQuaternionAndTranslation(inOutActiveShot.m_initialTransform.GetRotation(), currSegmentPosition);
 
         for (uint32_t segment = 0; segment < bg_MultitraceNumTraceSegments; ++segment)
         {
             float nextSegmentStartTime = currSegmentStartTime + segmentTickSize;
             AZ::Vector3 travelDistance = (segmentStepOffset * nextSegmentStartTime); // Total distance our shot has traveled as of this cast, ignoring arc-length due to gravity
             AZ::Vector3 nextSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + travelDistance + (gravity * 0.5f * nextSegmentStartTime * nextSegmentStartTime);         
+
+            const AZ::Transform currSegTransform = AZ::Transform::CreateFromQuaternionAndTranslation(inOutActiveShot.m_initialTransform.GetRotation(), currSegmentPosition);
             const AZ::Vector3 segSweep = nextSegmentPosition - currSegmentPosition;
 
             IntersectFilter filter(currSegTransform, segSweep, AzPhysics::SceneQuery::QueryType::StaticAndDynamic,

--- a/Gem/Code/Source/Weapons/WeaponGathers.cpp
+++ b/Gem/Code/Source/Weapons/WeaponGathers.cpp
@@ -109,12 +109,11 @@ namespace MultiplayerSample
 
         float currSegmentStartTime = inOutActiveShot.m_lifetimeSeconds;
         AZ::Vector3 currSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + (segmentStepOffset * currSegmentStartTime) + (gravity * 0.5f * currSegmentStartTime * currSegmentStartTime);
-
         for (uint32_t segment = 0; segment < bg_MultitraceNumTraceSegments; ++segment)
         {
             float nextSegmentStartTime = currSegmentStartTime + segmentTickSize;
             AZ::Vector3 travelDistance = (segmentStepOffset * nextSegmentStartTime); // Total distance our shot has traveled as of this cast, ignoring arc-length due to gravity
-            AZ::Vector3 nextSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + travelDistance + (gravity * 0.5f * nextSegmentStartTime * nextSegmentStartTime);         
+            AZ::Vector3 nextSegmentPosition = inOutActiveShot.m_initialTransform.GetTranslation() + travelDistance + (gravity * 0.5f * nextSegmentStartTime * nextSegmentStartTime);
 
             const AZ::Transform currSegTransform = AZ::Transform::CreateFromQuaternionAndTranslation(inOutActiveShot.m_initialTransform.GetRotation(), currSegmentPosition);
             const AZ::Vector3 segSweep = nextSegmentPosition - currSegmentPosition;

--- a/Gem/Code/Source/Weapons/WeaponTypes.h
+++ b/Gem/Code/Source/Weapons/WeaponTypes.h
@@ -205,7 +205,8 @@ namespace MultiplayerSample
     //! Structure containing details for a single fire event.
     struct FireParams
     {
-        AZ::Vector3 m_targetPosition = AZ::Vector3::CreateZero(); // Location of the activate event.
+        AZ::Vector3 m_sourcePosition = AZ::Vector3::CreateZero(); // Source location of the activate event
+        AZ::Vector3 m_targetPosition = AZ::Vector3::CreateZero(); // Target location of the activate event.
         Multiplayer::NetEntityId m_targetId = Multiplayer::InvalidNetEntityId; // Entity Id of the target (for homing weapons)
 
         bool operator!=(const FireParams& rhs) const;


### PR DESCRIPTION
This change addresses a few issues causing desyncs in MultiplayerSample when firing the player's weapon

1. Replicates the start position of the shot as animation bones are not synced making the fire position unreliable
2. When filtering rewindable objects, prevent checking static rigid bodies as they're expected to be stationary so their rewindable frame shouldn't be relevant. This fixes the floor being filtered out of collision logic.

https://github.com/o3de/o3de/pull/7534/files addressed changes in the core around NetworkTime and Rewindables.