### PR TITLE
Added a workaround switch to avoid issues with deactivating network entities.

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
@@ -12,6 +12,7 @@
 	<ComponentRelation Constraint="Required" HasController="false" Name="NetworkPrefabSpawnerComponent" Namespace="MultiplayerSample" Include="Source/Components/PerfTest/NetworkPrefabSpawnerComponent.h" />
 
 	<ArchetypeProperty Type="bool" Name="Enabled" Init="true" ExposeToEditor="true" Description="Enables spawning of test prefabs." />
+	<ArchetypeProperty Type="bool" Name="RespawnEnabled" Init="false" ExposeToEditor="true" Description="Deletes old instances and spawns new ones when at the maximum live count." />
 	<ArchetypeProperty Type="int" Name="MaxLiveCount" Init="100" ExposeToEditor="true" Description="Maximum objects to keep alive, will delete older objects when the count goes above this value." />
 	<ArchetypeProperty Type="int" Name="SpawnPerSecond" Init="10" ExposeToEditor="true" Description="How many prefabs to spawn per second." />
 

--- a/Gem/Code/Source/Components/PerfTest/NetworkRandomImpulseComponent.cpp
+++ b/Gem/Code/Source/Components/PerfTest/NetworkRandomImpulseComponent.cpp
@@ -40,7 +40,8 @@ namespace MultiplayerSample
 
             if (PhysX::RigidBodyComponent* body = GetEntity()->FindComponent<PhysX::RigidBodyComponent>())
             {
-                body->ApplyLinearImpulse(AZ::Vector3::CreateAxisZ(GetParent().GetHopForce()));
+                const AZ::Quaternion rotation = GetEntity()->GetTransform()->GetWorldRotationQuaternion();
+                body->ApplyLinearImpulse(rotation.TransformVector(AZ::Vector3::CreateAxisZ(GetParent().GetHopForce())));
             }
         }
     }

--- a/Levels/SpawningPerfTest/SpawningPerfTest.prefab
+++ b/Levels/SpawningPerfTest/SpawningPerfTest.prefab
@@ -525,8 +525,9 @@
                     "m_template": {
                         "$type": "MultiplayerSample::NetworkTestSpawnerComponent",
                         "Enabled": true,
-                        "MaxLiveCount": 1000,
-                        "SpawnPerSecond": 10
+                        "RespawnEnabled": false,
+                        "MaxLiveCount": 20,
+                        "SpawnPerSecond": 5
                     }
                 },
                 "Component_[12075594064273029366]": {
@@ -602,8 +603,8 @@
                     "BoxShape": {
                         "Configuration": {
                             "Dimensions": [
-                                50.0,
-                                50.0,
+                                5.0,
+                                5.0,
                                 1.0
                             ]
                         }


### PR DESCRIPTION
"Respawn Enabled", if true will delete old entities, and spawn new ones. Otherwise, will stop spawning once the desired maximum count of instances is reached.

Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>