### PR TITLE
Add editor.cfg to enable local server from editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ MultiplayerSample.ServerLauncher.exe --console-command-file=server.cfg
 
 #### Running the Server in the Editor
 
-Refer to the O3DE document [Test Multiplayer Games in the O3DE Editor](https://o3de.org/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/test-in-editor/), to set up required console variables (cvar) to support play in editor with servers. Ensure you configure ```editorsv_enabled``` and ```editorsv_launch``` as required. See the [Console Variable Tutorial](https://o3de.org/docs/user-guide/engine/cvars) for more details on setting and using cvars.
+By default, launching a local server from the editor during Play Mode is enabled. To disable this behavior, update the `editorsv_enabled` value in the `editor.cfg` file to `false`.
+
+Refer to the O3DE document [Test Multiplayer Games in the O3DE Editor](https://o3de.org/docs/user-guide/gems/reference/multiplayer/multiplayer-gem/test-in-editor/) for the complete list of console variables (cvar) which support play in the editor with servers.
 
 
 #### Running the Client

--- a/editor.cfg
+++ b/editor.cfg
@@ -1,0 +1,1 @@
+editorsv_enabled=true


### PR DESCRIPTION
While running through [this tutorial](https://www.o3de.org/docs/learning-guide/tutorials/multiplayer/first-multiplayer-component/) with @AMZN-Gene, discovered local server launch from within the editor wasn't enabled by default. Feels like it should be for this project, so this change adds an `editor.cfg` file with `editorsv_enabled=true` and updates the README accordingly. 

NOTE: the [CVAR](https://www.o3de.org/docs/user-guide/programming/cvars/) link doesn't actually contain any content, so I removed it. (and created [this issue](https://github.com/o3de/o3de.org/issues/1441))

## Testing

1. Run the editor
2. Type `editorsv_enabled` in the console
3. the output should reflect this value is set to "true"
![image](https://user-images.githubusercontent.com/34254888/155431761-3bb1e2ac-2b3a-420c-9d64-f10f89d97bbe.png)
