### PR TITLE
Adds some simple automation capabilities to the  network stress test component

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkStressTestComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkStressTestComponent.AutoComponent.xml
@@ -8,7 +8,12 @@
     OverrideInclude="Source/Components/NetworkStressTestComponent.h"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
 
+    <ArchetypeProperty Type="AZ::TimeMs" Name="AutoSpawnIntervalMs" Init="0" ExposeToEditor="true" Description="If > 0, will autospawn an AI using the provided interval" />
+    <ArchetypeProperty Type="uint32_t" Name="MaxSpawns" Init="0" ExposeToEditor="true" Description="If > 0, will cap the total number of spawned AI to the provided value" />
+
     <NetworkProperty Type="bool" Name="Enabled" Init="true" ReplicateFrom="Authority" ReplicateTo="Client" Container="Object" IsPublic="true" IsRewindable="false" IsPredictable="false" ExposeToEditor="true" ExposeToScript="false" GenerateEventBindings="false" Description="If enabled, this AI component overrides movement and camera components." />
+    <NetworkProperty Type="uint32_t" Name="SpawnCount" Init="0" ReplicateFrom="Authority" ReplicateTo="Server" Container="Object" IsPublic="true" IsRewindable="false" IsPredictable="false" ExposeToEditor="false" ExposeToScript="false" GenerateEventBindings="false" Description="Tracks the total number of spawns by this component." />
+    
     <RemoteProcedure Name="SpawnAIEntity" InvokeFrom="Autonomous" HandleOn="Authority" IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="Spawn AI Entity RPC">
         <Param Type="float" Name="fireIntervalMinMs"/>
         <Param Type="float" Name="fireIntervalMaxMs"/>

--- a/Gem/Code/Source/Components/NetworkStressTestComponent.h
+++ b/Gem/Code/Source/Components/NetworkStressTestComponent.h
@@ -39,8 +39,12 @@ namespace MultiplayerSample
     public:
         using NetworkStressTestComponentControllerBase::NetworkStressTestComponentControllerBase;
 
+        NetworkStressTestComponentController(NetworkStressTestComponent& owner);
+
         void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
         void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+
+        void HandleSpawnAiEntity();
 
         void HandleSpawnAIEntity(
             AzNetworking::IConnection* invokingConnection,
@@ -61,6 +65,7 @@ namespace MultiplayerSample
         void DrawEntitySpawner();
 
         bool m_displayEntitySpawner = false;
+#endif
         bool m_isServer = false;
         int m_quantity = 1;
         float m_fireIntervalMinMs = 100.f;
@@ -69,6 +74,6 @@ namespace MultiplayerSample
         float m_actionIntervalMaxMs = 10000.f;
         uint64_t m_seed = 0;
         int m_teamID = 0;
-#endif
+        AZ::ScheduledEvent m_autoSpawnTimer;
     };
 } // namespace MultiplayerSample


### PR DESCRIPTION
Adding configuration options that allow the stress test to autospawn a number of entities at a given interval without imgui interaction
