### PR TITLE
Enables Keep Editor Ticking option

### DIFF
--- a/editor.cfg
+++ b/editor.cfg
@@ -1,2 +1,2 @@
 editorsv_enabled=true
-ed_KeepEditorAlive=true
+ed_keepEditorAlive=true

--- a/editor.cfg
+++ b/editor.cfg
@@ -1,1 +1,2 @@
 editorsv_enabled=true
+ed_KeepEditorAlive=true


### PR DESCRIPTION
That resolves the issue with ctrl-g multiplayer experience stuck waiting on the Editor to tick to send the level data to the started server process in the foreground.

Signed-off-by: AMZN-Olex <5432499+AMZN-Olex@users.noreply.github.com>