### PR TITLE
Updated the MultiplayerSampleData ScanFolder to use a portable reference to the Atom gem.

### DIFF
--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -39,7 +39,7 @@ set(ENABLED_GEMS
     LmbrCentral
     LyShine
     HttpRequestor
-    Atom_AtomBridge
+    Atom
     AWSCore
     AWSClientAuth
     AWSMetrics

--- a/Registry/assetsprocessor_settings.setreg
+++ b/Registry/assetsprocessor_settings.setreg
@@ -9,7 +9,7 @@
                     "ignore": true
                 },
                 "ScanFolder MultiplayerSampleData": {
-                    "watch": "@ENGINEROOT@/Gems/Atom/TestData",
+                    "watch": "@GEMROOT:Atom@/TestData",
                     "recursive": 1,
                     "order": 1000
                 },


### PR DESCRIPTION
Replaced the Atom_AtomBridge dependency with Atom.

Signed-off-by: lumberyard-employee-dm <56135373+lumberyard-employee-dm@users.noreply.github.com>