### PR TITLE
Update spawn nodes in SpawnIfAuthority

### DIFF
--- a/scriptcanvas/SpawnIfAuthority.scriptcanvas
+++ b/scriptcanvas/SpawnIfAuthority.scriptcanvas
@@ -5,22 +5,54 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 5748427407530
+                "id": 744312986674
             },
             "Name": "SpawnIfAuthority",
             "Components": {
                 "Component_[11160906310313544800]": {
                     "$type": "EditorGraphVariableManagerComponent",
-                    "Id": 11160906310313544800
+                    "Id": 11160906310313544800,
+                    "m_variableData": {
+                        "m_nameVariableMap": [
+                            {
+                                "Key": {
+                                    "m_id": "{DA8B04C5-A23C-40E0-8577-56A74B6B2086}"
+                                },
+                                "Value": {
+                                    "Datum": {
+                                        "scriptCanvasType": {
+                                            "m_type": 4,
+                                            "m_azType": "{A96A5037-AD0D-43B6-9948-ED63438C4A52}"
+                                        },
+                                        "isNullPointer": false,
+                                        "$type": "SpawnableAsset",
+                                        "value": {
+                                            "Asset": {
+                                                "assetId": {
+                                                    "guid": "{13BAFCBF-6669-5E4E-B3B0-8610349B2C01}",
+                                                    "subId": 1084915735
+                                                },
+                                                "assetHint": "prefabs/player.spawnable"
+                                            }
+                                        }
+                                    },
+                                    "VariableId": {
+                                        "m_id": "{DA8B04C5-A23C-40E0-8577-56A74B6B2086}"
+                                    },
+                                    "VariableName": "Player"
+                                }
+                            }
+                        ]
+                    }
                 },
                 "Component_[13752069858907098540]": {
-                    "$type": "{4D755CA9-AB92-462C-B24F-0B3376F19967} Graph",
+                    "$type": "EditorGraph",
                     "Id": 13752069858907098540,
                     "m_graphData": {
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 5752722374826
+                                    "id": 770082790450
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -199,7 +231,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -262,7 +293,349 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5757017342122
+                                    "id": 765787823154
+                                },
+                                "Name": "SC-Node(SpawnNodeableNode)",
+                                "Components": {
+                                    "Component_[12697291398119811480]": {
+                                        "$type": "SpawnNodeableNode",
+                                        "Id": 12697291398119811480,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{69AD9BD3-9556-414B-BC97-C487EA487ABC}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Request Spawn",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{96A2379F-1147-4A20-B843-ED1621A32A4C}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "SpawnTicket",
+                                                "toolTip": "Ticket instance assosiated with spawnable asset.",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{08965288-5365-4117-AFD0-BB44F679B07C}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ParentId",
+                                                "toolTip": "Optional parent to assign spawned container entity to.",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{411AC6D8-74DF-4CF5-AFE5-32F716F733F9}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Local Translation",
+                                                "toolTip": "Position to spawn.",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{5C241B17-6DEB-47A2-AE97-44F91FADE6ED}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Local Rotation",
+                                                "toolTip": "Rotation of spawn (in degrees).",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{BB8D6323-5AE0-485A-A7B1-58080E96FB36}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Local Scale",
+                                                "toolTip": "Scale of spawn.",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{AFE3244F-ECC3-4F37-82D2-5F2024D69D6D}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Spawn Requested",
+                                                "DisplayGroup": {
+                                                    "Value": 929942742
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A10B2BEC-5D3D-45C9-B4B1-CD54FC5BF7DA}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "On Spawn Completed",
+                                                "toolTip": "Called when spawning entities is completed.",
+                                                "DisplayGroup": {
+                                                    "Value": 3165055374
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                },
+                                                "IsLatent": true
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{18C15A57-8AC8-456F-B475-BF0C8B167B81}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "SpawnTicket",
+                                                "toolTip": "Ticket instance of the spawn result.",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{2B5EB938-8962-4A43-A97B-112F398C604B}"
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 3165055374
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{2F264F33-94A6-477B-82BD-E79A9B9BA798}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "SpawnedEntitiesList",
+                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 3165055374
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{2B5EB938-8962-4A43-A97B-112F398C604B}"
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "SpawnTicketInstance",
+                                                "label": "SpawnTicket"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 1
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "EntityId",
+                                                "value": {
+                                                    "id": 2901262558
+                                                },
+                                                "label": "ParentId"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Local Translation"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Local Rotation"
+                                            },
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 1.0,
+                                                "label": "Local Scale"
+                                            }
+                                        ],
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{69AD9BD3-9556-414B-BC97-C487EA487ABC}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{96A2379F-1147-4A20-B843-ED1621A32A4C}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{08965288-5365-4117-AFD0-BB44F679B07C}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{411AC6D8-74DF-4CF5-AFE5-32F716F733F9}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{5C241B17-6DEB-47A2-AE97-44F91FADE6ED}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{BB8D6323-5AE0-485A-A7B1-58080E96FB36}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{AFE3244F-ECC3-4F37-82D2-5F2024D69D6D}"
+                                                            },
+                                                            "_name": "Spawn Requested",
+                                                            "_interfaceSourceId": "{E9ECDA1C-0000-0000-C769-D15EF77F0000}"
+                                                        }
+                                                    ],
+                                                    "_interfaceSourceId": "{406E6F35-F501-0000-7B7E-9CF4FE7F0000}"
+                                                }
+                                            ],
+                                            "latents": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{A10B2BEC-5D3D-45C9-B4B1-CD54FC5BF7DA}"
+                                                    },
+                                                    "_name": "On Spawn Completed",
+                                                    "_outputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{18C15A57-8AC8-456F-B475-BF0C8B167B81}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{2F264F33-94A6-477B-82BD-E79A9B9BA798}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_interfaceSourceId": "{406E6F35-F501-0000-7B7E-9CF4FE7F0000}"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 761492855858
                                 },
                                 "Name": "SC-Node(Gate)",
                                 "Components": {
@@ -339,7 +712,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 0
                                                 },
@@ -354,7 +726,148 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5761312309418
+                                    "id": 757197888562
+                                },
+                                "Name": "SC-Node(CreateSpawnTicketNodeableNode)",
+                                "Components": {
+                                    "Component_[436207136216439706]": {
+                                        "$type": "CreateSpawnTicketNodeableNode",
+                                        "Id": 436207136216439706,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{828860F9-BB5B-4909-BB68-E125DAED686A}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Create Ticket",
+                                                "DisplayGroup": {
+                                                    "Value": 3070342103
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{45C69FD9-8392-4CA5-96E9-2AA18D5404D5}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Prefab",
+                                                "toolTip": "Prefab source asset to spawn",
+                                                "DisplayGroup": {
+                                                    "Value": 3070342103
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1,
+                                                "IsReference": true,
+                                                "VariableReference": {
+                                                    "m_id": "{DA8B04C5-A23C-40E0-8577-56A74B6B2086}"
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{F4DF48F9-8707-4067-BF70-E6240EF7DD2F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Ticket Created",
+                                                "DisplayGroup": {
+                                                    "Value": 3070342103
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{73DE083D-0C34-48C5-93A3-05E05A84B2DE}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "SpawnTicket",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{2B5EB938-8962-4A43-A97B-112F398C604B}"
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 3070342103
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{A96A5037-AD0D-43B6-9948-ED63438C4A52}"
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "SpawnableAsset",
+                                                "label": "Prefab"
+                                            }
+                                        ],
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{828860F9-BB5B-4909-BB68-E125DAED686A}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{45C69FD9-8392-4CA5-96E9-2AA18D5404D5}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{F4DF48F9-8707-4067-BF70-E6240EF7DD2F}"
+                                                            },
+                                                            "_name": "Ticket Created",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{73DE083D-0C34-48C5-93A3-05E05A84B2DE}"
+                                                                    }
+                                                                }
+                                                            ],
+                                                            "_interfaceSourceId": "{F03F3EB7-F201-0000-708A-EFD929000000}"
+                                                        }
+                                                    ],
+                                                    "_interfaceSourceId": "{C00593B8-F201-0000-406E-6F35F5010000}"
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 752902921266
                                 },
                                 "Name": "SC-Node(IsNetEntityRoleAuthority)",
                                 "Components": {
@@ -431,7 +944,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -455,264 +967,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5769902244010
-                                },
-                                "Name": "SC-Node(SpawnNodeableNode)",
-                                "Components": {
-                                    "Component_[4496831673767245008]": {
-                                        "$type": "SpawnNodeableNode",
-                                        "Id": 4496831673767245008,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{DF59D0F1-A4E3-401F-A6AB-F558CC35B7E1}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Request Spawn",
-                                                "DisplayGroup": {
-                                                    "Value": 929942742
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{34B6FC60-FD4D-4CA9-AE6A-F6A8C21646F7}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    },
-                                                    null
-                                                ],
-                                                "slotName": "Translation",
-                                                "toolTip": "Position to spawn",
-                                                "DisplayGroup": {
-                                                    "Value": 929942742
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{9A1ADEF9-5F78-49E9-8806-3F20B7812BB2}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    },
-                                                    null
-                                                ],
-                                                "slotName": "Rotation",
-                                                "toolTip": "Rotation of spawn (in degrees)",
-                                                "DisplayGroup": {
-                                                    "Value": 929942742
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{C9C0D916-C823-4E34-A651-3A0386337BD7}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    },
-                                                    null
-                                                ],
-                                                "slotName": "Scale",
-                                                "toolTip": "Scale of spawn",
-                                                "DisplayGroup": {
-                                                    "Value": 929942742
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{A5E747BD-9403-48D3-8812-8C3A2BBB6DBE}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Spawn Requested",
-                                                "DisplayGroup": {
-                                                    "Value": 929942742
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{D68BDC57-A68B-4E72-8DB8-FD2919960C2E}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "On Spawn",
-                                                "DisplayGroup": {
-                                                    "Value": 3873466122
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                },
-                                                "IsLatent": true
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{90AEB43E-0C16-4AD3-95C7-4EED42B5E777}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "SpawnedEntitiesList",
-                                                "toolTip": "List of spawned entities sorted by hierarchy with the root being first",
-                                                "DisplayDataType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
-                                                },
-                                                "DisplayGroup": {
-                                                    "Value": 3873466122
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 8
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "Vector3",
-                                                "value": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.0
-                                                ],
-                                                "label": "Translation"
-                                            },
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 8
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "Vector3",
-                                                "value": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.0
-                                                ],
-                                                "label": "Rotation"
-                                            },
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 3
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "double",
-                                                "value": 1.0,
-                                                "label": "Scale"
-                                            }
-                                        ],
-                                        "nodeable": {
-                                            "m_spawnableAsset": {
-                                                "assetId": {
-                                                    "guid": "{F6990C4F-540A-56EF-8C07-3ECECB09BBE7}",
-                                                    "subId": 2960582392
-                                                },
-                                                "assetHint": "prefabs/filteredgroup.spawnable"
-                                            }
-                                        },
-                                        "slotExecutionMap": {
-                                            "ins": [
-                                                {
-                                                    "_slotId": {
-                                                        "m_id": "{DF59D0F1-A4E3-401F-A6AB-F558CC35B7E1}"
-                                                    },
-                                                    "_inputs": [
-                                                        {
-                                                            "_slotId": {
-                                                                "m_id": "{34B6FC60-FD4D-4CA9-AE6A-F6A8C21646F7}"
-                                                            }
-                                                        },
-                                                        {
-                                                            "_slotId": {
-                                                                "m_id": "{9A1ADEF9-5F78-49E9-8806-3F20B7812BB2}"
-                                                            }
-                                                        },
-                                                        {
-                                                            "_slotId": {
-                                                                "m_id": "{C9C0D916-C823-4E34-A651-3A0386337BD7}"
-                                                            }
-                                                        }
-                                                    ],
-                                                    "_outs": [
-                                                        {
-                                                            "_slotId": {
-                                                                "m_id": "{A5E747BD-9403-48D3-8812-8C3A2BBB6DBE}"
-                                                            },
-                                                            "_name": "Spawn Requested",
-                                                            "_interfaceSourceId": "{6867F7E3-1800-0000-8066-F7E318000000}"
-                                                        }
-                                                    ],
-                                                    "_interfaceSourceId": "{00000002-F3FF-FFFF-3900-000000000000}"
-                                                }
-                                            ],
-                                            "latents": [
-                                                {
-                                                    "_slotId": {
-                                                        "m_id": "{D68BDC57-A68B-4E72-8DB8-FD2919960C2E}"
-                                                    },
-                                                    "_name": "On Spawn",
-                                                    "_outputs": [
-                                                        {
-                                                            "_slotId": {
-                                                                "m_id": "{90AEB43E-0C16-4AD3-95C7-4EED42B5E777}"
-                                                            }
-                                                        }
-                                                    ],
-                                                    "_interfaceSourceId": "{00000002-F3FF-FFFF-3900-000000000000}"
-                                                }
-                                            ]
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 5765607276714
+                                    "id": 748607953970
                                 },
                                 "Name": "SC-Node(GetWorldTranslation)",
                                 "Components": {
@@ -789,7 +1044,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 1
                                                 },
@@ -798,7 +1052,7 @@
                                                 "value": {
                                                     "id": 2901262558
                                                 },
-                                                "label": "Source"
+                                                "label": "EntityID: 0"
                                             }
                                         ],
                                         "methodType": 0,
@@ -815,7 +1069,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 5774197211306
+                                    "id": 774377757746
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(IsNetEntityRoleAuthority: In)",
                                 "Components": {
@@ -824,7 +1078,7 @@
                                         "Id": 623912724610228967,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5752722374826
+                                                "id": 770082790450
                                             },
                                             "slotId": {
                                                 "m_id": "{FCEA454C-727C-4D5E-BC15-AB56BA5A39AE}"
@@ -832,7 +1086,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5761312309418
+                                                "id": 752902921266
                                             },
                                             "slotId": {
                                                 "m_id": "{FD0F08BD-2B4C-49F8-84E0-A60CF854D157}"
@@ -843,7 +1097,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5778492178602
+                                    "id": 778672725042
                                 },
                                 "Name": "srcEndpoint=(IsNetEntityRoleAuthority: Out), destEndpoint=(If: In)",
                                 "Components": {
@@ -852,7 +1106,7 @@
                                         "Id": 15117390462186534323,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5761312309418
+                                                "id": 752902921266
                                             },
                                             "slotId": {
                                                 "m_id": "{25AA7A16-F5D8-4014-B829-0BD0EEA6B555}"
@@ -860,7 +1114,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5757017342122
+                                                "id": 761492855858
                                             },
                                             "slotId": {
                                                 "m_id": "{FC311D8E-B2BA-4E16-8E0C-04077CE752D1}"
@@ -871,7 +1125,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5782787145898
+                                    "id": 782967692338
                                 },
                                 "Name": "srcEndpoint=(IsNetEntityRoleAuthority: Result: Boolean), destEndpoint=(If: Condition)",
                                 "Components": {
@@ -880,7 +1134,7 @@
                                         "Id": 11157494866445858874,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5761312309418
+                                                "id": 752902921266
                                             },
                                             "slotId": {
                                                 "m_id": "{ABAE4BDB-E6F7-44DE-814F-838208D47892}"
@@ -888,7 +1142,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5757017342122
+                                                "id": 761492855858
                                             },
                                             "slotId": {
                                                 "m_id": "{CACFB235-8553-4A31-8595-779028A50CA1}"
@@ -899,7 +1153,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5787082113194
+                                    "id": 787262659634
                                 },
                                 "Name": "srcEndpoint=(If: True), destEndpoint=(GetWorldTranslation: In)",
                                 "Components": {
@@ -908,7 +1162,7 @@
                                         "Id": 8173811067217743380,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5757017342122
+                                                "id": 761492855858
                                             },
                                             "slotId": {
                                                 "m_id": "{3CDC2B4A-25B9-4CAD-9F7D-38C3D212F40F}"
@@ -916,7 +1170,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5765607276714
+                                                "id": 748607953970
                                             },
                                             "slotId": {
                                                 "m_id": "{65AD80A5-A210-42D6-895B-160DF013A626}"
@@ -927,27 +1181,27 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5791377080490
+                                    "id": 791557626930
                                 },
-                                "Name": "srcEndpoint=(GetWorldTranslation: Out), destEndpoint=(Spawn: Request Spawn)",
+                                "Name": "srcEndpoint=(CreateSpawnTicket: Ticket Created), destEndpoint=(Spawn: Request Spawn)",
                                 "Components": {
-                                    "Component_[4443120657995663120]": {
+                                    "Component_[6427710639037589106]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 4443120657995663120,
+                                        "Id": 6427710639037589106,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5765607276714
+                                                "id": 757197888562
                                             },
                                             "slotId": {
-                                                "m_id": "{F17998D4-1F55-4C29-B7EC-493804BB3BB5}"
+                                                "m_id": "{F4DF48F9-8707-4067-BF70-E6240EF7DD2F}"
                                             }
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5769902244010
+                                                "id": 765787823154
                                             },
                                             "slotId": {
-                                                "m_id": "{DF59D0F1-A4E3-401F-A6AB-F558CC35B7E1}"
+                                                "m_id": "{69AD9BD3-9556-414B-BC97-C487EA487ABC}"
                                             }
                                         }
                                     }
@@ -955,16 +1209,72 @@
                             },
                             {
                                 "Id": {
-                                    "id": 5795672047786
+                                    "id": 795852594226
                                 },
-                                "Name": "srcEndpoint=(GetWorldTranslation: Result: Vector3), destEndpoint=(Spawn: Translation)",
+                                "Name": "srcEndpoint=(CreateSpawnTicket: SpawnTicket), destEndpoint=(Spawn: SpawnTicket)",
                                 "Components": {
-                                    "Component_[9076934972907588967]": {
+                                    "Component_[767872420311571744]": {
                                         "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 9076934972907588967,
+                                        "Id": 767872420311571744,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 5765607276714
+                                                "id": 757197888562
+                                            },
+                                            "slotId": {
+                                                "m_id": "{73DE083D-0C34-48C5-93A3-05E05A84B2DE}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 765787823154
+                                            },
+                                            "slotId": {
+                                                "m_id": "{96A2379F-1147-4A20-B843-ED1621A32A4C}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 800147561522
+                                },
+                                "Name": "srcEndpoint=(GetWorldTranslation: Out), destEndpoint=(CreateSpawnTicket: Create Ticket)",
+                                "Components": {
+                                    "Component_[12817578276561072748]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12817578276561072748,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 748607953970
+                                            },
+                                            "slotId": {
+                                                "m_id": "{F17998D4-1F55-4C29-B7EC-493804BB3BB5}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 757197888562
+                                            },
+                                            "slotId": {
+                                                "m_id": "{828860F9-BB5B-4909-BB68-E125DAED686A}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 804442528818
+                                },
+                                "Name": "srcEndpoint=(GetWorldTranslation: Result: Vector3), destEndpoint=(Spawn: Local Translation)",
+                                "Components": {
+                                    "Component_[12001439484058061595]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12001439484058061595,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 748607953970
                                             },
                                             "slotId": {
                                                 "m_id": "{A9DEC503-1141-44C2-9BA6-E740B716CB92}"
@@ -972,10 +1282,10 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 5769902244010
+                                                "id": 765787823154
                                             },
                                             "slotId": {
-                                                "m_id": "{34B6FC60-FD4D-4CA9-AE6A-F6A8C21646F7}"
+                                                "m_id": "{411AC6D8-74DF-4CF5-AFE5-32F716F733F9}"
                                             }
                                         }
                                     }
@@ -989,20 +1299,20 @@
                         "_runtimeVersion": 1,
                         "_fileVersion": 1
                     },
-                    "m_variableCounter": 1,
+                    "m_variableCounter": 2,
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 5748427407530
+                                "id": 744312986674
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "ViewParams": {
-                                            "Scale": 0.8121803,
-                                            "AnchorX": -145.28793334960938,
-                                            "AnchorY": -414.9324951171875
+                                            "Scale": 0.6287510700734436,
+                                            "AnchorX": 206.75909423828125,
+                                            "AnchorY": -79.5227279663086
                                         }
                                     }
                                 }
@@ -1010,102 +1320,7 @@
                         },
                         {
                             "Key": {
-                                "id": 5752722374826
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            40.0,
-                                            80.0
-                                        ]
-                                    },
-                                    "{9E81C95F-89C0-4476-8E82-63CCC4E52E04}": {
-                                        "$type": "EBusHandlerNodeDescriptorSaveData",
-                                        "EventIds": [
-                                            {
-                                                "Value": 245425936
-                                            }
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{856AC888-5242-45FE-98C8-9551CDF90181}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5757017342122
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "LogicNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            860.0,
-                                            160.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{8784A9E8-C08C-4833-8707-522A51518804}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5761312309418
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            380.0,
-                                            140.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{98476AAD-4352-4408-BBBC-FDDA49B35675}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 5765607276714
+                                "id": 748607953970
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1136,7 +1351,38 @@
                         },
                         {
                             "Key": {
-                                "id": 5769902244010
+                                "id": 752902921266
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            380.0,
+                                            140.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{98476AAD-4352-4408-BBBC-FDDA49B35675}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 757197888562
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1151,6 +1397,36 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             1620.0,
+                                            80.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{A4F278B3-739C-41FD-B86E-C595CDE7B724}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 761492855858
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "LogicNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            860.0,
                                             160.0
                                         ]
                                     },
@@ -1159,7 +1435,71 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{B99F9431-776B-4AB3-A837-C3EA12625D30}"
+                                        "PersistentId": "{8784A9E8-C08C-4833-8707-522A51518804}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 765787823154
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2060.0,
+                                            100.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{D6CB7292-715A-4087-826E-CA637D30FDFA}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 770082790450
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            40.0,
+                                            80.0
+                                        ]
+                                    },
+                                    "{9E81C95F-89C0-4476-8E82-63CCC4E52E04}": {
+                                        "$type": "EBusHandlerNodeDescriptorSaveData",
+                                        "EventIds": [
+                                            {
+                                                "Value": 245425936
+                                            }
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{856AC888-5242-45FE-98C8-9551CDF90181}"
                                     }
                                 }
                             }
@@ -1167,6 +1507,10 @@
                     ],
                     "StatisticsHelper": {
                         "InstanceCounter": [
+                            {
+                                "Key": 2970552779286763396,
+                                "Value": 1
+                            },
                             {
                                 "Key": 5842116761103598202,
                                 "Value": 1


### PR DESCRIPTION
Updating to use updated `Spawn` and new `Create Spawn Ticket` Script Canvas nodes, per https://github.com/o3de/o3de/pull/7887

NOTE: removes bad `"m_spawnableAsset"` block highlighted in https://github.com/o3de/o3de/issues/8206

### Testing

SpawnIfAuthority.scripcanvas graph _before_
![image](https://user-images.githubusercontent.com/34254888/158691566-182daa94-dd17-4a9d-8a3d-e0fa4238bf1f.png)

SpawnIfAuthority.scripcanvas graph **after**
![image](https://user-images.githubusercontent.com/34254888/158691661-bf296b5a-9f14-4813-b8f7-de931873fb84.png)

Screen shot of testing server + client with spawned player
![image](https://user-images.githubusercontent.com/34254888/158691737-ccefa24f-8e87-42f9-88b9-5bbe6bb2079a.png)

