### PR TITLE
WIP: Updating MultiplayerSample to use the Normal Spawnable API

### DIFF
--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.h
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.h
@@ -57,13 +57,18 @@ namespace MultiplayerSample
 
         ////////////////////////////////////////////////////////////////////////
         // IMultiplayerSpawner overrides
-        Multiplayer::NetworkEntityHandle OnPlayerJoin(uint64_t userId, const Multiplayer::MultiplayerAgentDatum& agentDatum) override;
+        void OnPlayerJoin(
+            uint64_t userId, 
+            const Multiplayer::MultiplayerAgentDatum& agentDatum, 
+            AzFramework::EntitySpawnCallback playerSpawnedCallback) override;
+
         void OnPlayerLeave(
             Multiplayer::ConstNetworkEntityHandle entityHandle,
             const Multiplayer::ReplicationSet& replicationSet,
             AzNetworking::DisconnectReason reason) override;
         ////////////////////////////////////////////////////////////////////////
 
-        AZStd::unique_ptr<MultiplayerSample::IPlayerSpawner> m_playerSpawner;
+        AZStd::unique_ptr<IPlayerSpawner> m_playerSpawner;
+        AZStd::vector<AZStd::unique_ptr<AzFramework::EntitySpawnTicket>> m_playerSpawnTickets;
     };
 }

--- a/Gem/Code/Source/Spawners/IPlayerSpawner.h
+++ b/Gem/Code/Source/Spawners/IPlayerSpawner.h
@@ -34,7 +34,7 @@ namespace MultiplayerSample
         virtual ~IPlayerSpawner() = default;
 
         virtual bool RegisterPlayerSpawner(NetworkPlayerSpawnerComponent* spawner) = 0;
-        virtual AZStd::pair<Multiplayer::PrefabEntityId, AZ::Transform> GetNextPlayerSpawn() = 0;
+        virtual AZStd::pair<AZ::Data::Asset<AzFramework::Spawnable>, AZ::Transform> GetNextPlayerSpawn() = 0;
         virtual bool UnregisterPlayerSpawner(NetworkPlayerSpawnerComponent* spawner) = 0;
     };
 } // namespace MultiplayerSample

--- a/Gem/Code/Source/Spawners/RoundRobinSpawner.cpp
+++ b/Gem/Code/Source/Spawners/RoundRobinSpawner.cpp
@@ -22,21 +22,18 @@ namespace MultiplayerSample
         return false;
     }
 
-    AZStd::pair<Multiplayer::PrefabEntityId, AZ::Transform> RoundRobinSpawner::GetNextPlayerSpawn()
+    AZStd::pair<AZ::Data::Asset<AzFramework::Spawnable>, AZ::Transform> RoundRobinSpawner::GetNextPlayerSpawn()
     {
         if (m_spawners.empty())
         {
             AZLOG_WARN("No active NetworkPlayerSpawnerComponents were found on player spawn request.")
-            return AZStd::make_pair<Multiplayer::PrefabEntityId, AZ::Transform>(Multiplayer::PrefabEntityId(), AZ::Transform::CreateIdentity());
+            return AZStd::make_pair(AZ::Data::Asset<AzFramework::Spawnable>(), AZ::Transform::CreateIdentity());
         }
 
-        NetworkPlayerSpawnerComponent* spawner = m_spawners[m_spawnIndex];
+        const NetworkPlayerSpawnerComponent* spawner = m_spawners[m_spawnIndex];
         m_spawnIndex = m_spawnIndex + 1 == m_spawners.size() ? 0 : m_spawnIndex + 1;
-        // NetworkEntityManager currently operates against/validates AssetId or Path, opt for Path via Hint
-        Multiplayer::PrefabEntityId prefabEntityId(AZ::Name(spawner->GetSpawnableAsset().GetHint().c_str()));
 
-        return AZStd::make_pair<Multiplayer::PrefabEntityId, AZ::Transform>(
-            prefabEntityId, spawner->GetEntity()->GetTransform()->GetWorldTM());
+        return AZStd::make_pair(spawner->GetSpawnableAsset(), spawner->GetEntity()->GetTransform()->GetWorldTM());
     }
 
     bool RoundRobinSpawner::UnregisterPlayerSpawner(NetworkPlayerSpawnerComponent* spawner)

--- a/Gem/Code/Source/Spawners/RoundRobinSpawner.h
+++ b/Gem/Code/Source/Spawners/RoundRobinSpawner.h
@@ -32,7 +32,7 @@ namespace MultiplayerSample
         ////////////////////////////////////////////////////////////////////////
         // IPlayerSpawner overrides
         bool RegisterPlayerSpawner(NetworkPlayerSpawnerComponent* spawner) override;
-        AZStd::pair<Multiplayer::PrefabEntityId, AZ::Transform> GetNextPlayerSpawn() override;
+        AZStd::pair<AZ::Data::Asset<AzFramework::Spawnable>, AZ::Transform> GetNextPlayerSpawn() override;
         bool UnregisterPlayerSpawner(NetworkPlayerSpawnerComponent* spawner) override;
         ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Updating MP Sample project to use the normal spawnable api when creating players instead of networking CreateEntitiesImmediate

Tested by running the BaseSample level and making sure no errors/warnings occur when the player is loaded.

WIP: Still need to handle player disconnects.

Signed-off-by: Gene Walters <genewalt@amazon.com>