### PR TITLE
Update SetSyncAimImmediate to function across network roles

### DIFF
--- a/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp
@@ -27,13 +27,13 @@ namespace MultiplayerSample
         // Synchronize aim angles with initial transform
         AZ::Vector3& aimAngles = ModifyAimAngles();
         aimAngles.SetZ(GetEntity()->GetTransform()->GetLocalRotation().GetZ());
-        SetSyncAimImmediate(true);
 
         if (IsAutonomous())
         {
             m_aiEnabled = FindComponent<NetworkAiComponent>()->GetEnabled();
             if (!m_aiEnabled)
             {
+                SetSyncAimImmediate(true);
                 AZ::EntityId activeCameraId;
                 Camera::CameraSystemRequestBus::BroadcastResult(activeCameraId, &Camera::CameraSystemRequestBus::Events::GetActiveCamera);
                 m_activeCameraEntity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(activeCameraId);

--- a/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.cpp
@@ -27,28 +27,25 @@ namespace MultiplayerSample
         // Synchronize aim angles with initial transform
         AZ::Vector3& aimAngles = ModifyAimAngles();
         aimAngles.SetZ(GetEntity()->GetTransform()->GetLocalRotation().GetZ());
+        SetSyncAimImmediate(true);
 
         if (IsAutonomous())
         {
             m_aiEnabled = FindComponent<NetworkAiComponent>()->GetEnabled();
             if (!m_aiEnabled)
             {
-                SetSyncAimImmediate(true);
                 AZ::EntityId activeCameraId;
                 Camera::CameraSystemRequestBus::BroadcastResult(activeCameraId, &Camera::CameraSystemRequestBus::Events::GetActiveCamera);
                 m_activeCameraEntity = AZ::Interface<AZ::ComponentApplicationRequests>::Get()->FindEntity(activeCameraId);
-
-                AZ::TickBus::Handler::BusConnect();
             }
         }
+
+        AZ::TickBus::Handler::BusConnect();
     }
 
     void NetworkSimplePlayerCameraComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        if (IsAutonomous() && !m_aiEnabled)
-        {
-            AZ::TickBus::Handler::BusDisconnect();
-        }
+        AZ::TickBus::Handler::BusDisconnect();
     }
 
     float NetworkSimplePlayerCameraComponentController::GetCameraYaw() const


### PR DESCRIPTION
`SetSyncAimImmediate` is called in `NetworkSimplePlayerCameraComponentController::OnActivate` changing a replicated value from its default of false to true. Presently, it is only ever updated in OnTick which is only enabled in an Autonomous entity. This meant that an Autonomous end point would constantly desync.

Enabling TickBus on all end points allows SyncAimImmediate to be set uniformly across all entity roles.

Signed-off-by: puvvadar <puvvadar@amazon.com>