### PR TITLE
Set MPS Editor to update in background

### DIFF
--- a/editor.cfg
+++ b/editor.cfg
@@ -2,3 +2,4 @@ editorsv_enabled=true
 ed_keepEditorAlive=true
 editorsv_hidden=true
 editorsv_rhi_override=null
+ed_backgroundUpdatePeriod=-1


### PR DESCRIPTION
This change sets `ed_backgroundUpdatePeriod` for the Editor in MP Sample. This cvar change will mean that TickBus will tick at the normal rate (per frame) in the background.

Signed-off-by: puvvadar <puvvadar@amazon.com>