### PR TITLE
SpawningPerfTest Fix: Updated to Use Player Spawner

### DIFF
--- a/Gem/Code/Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+
+<Component
+	Name="NetworkRandomTranslateComponent"
+	Namespace="MultiplayerSample"
+	OverrideComponent="false"
+	OverrideController="true"
+	OverrideInclude="Source/Components/PerfTest/NetworkRandomTranslateComponent.h"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  
+  <ComponentRelation Constraint="Required" HasController="false" Name="NetworkTransformComponent" Namespace="Multiplayer" Include="Multiplayer/Components/NetworkTransformComponent.h" />
+
+	<ArchetypeProperty Type="float" Name="MovementDuration" Init="2.f" ExposeToEditor="true" Description="The number of seconds it takes to make a move."/>
+	<ArchetypeProperty Type="float" Name="MaxMoveDistance" Init="10.f" ExposeToEditor="true" Description="The max distance to move in a period."/>
+
+</Component>

--- a/Gem/Code/Source/Components/PerfTest/NetworkRandomTranslateComponent.cpp
+++ b/Gem/Code/Source/Components/PerfTest/NetworkRandomTranslateComponent.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#include <Components/PerfTest/NetworkRandomTranslateComponent.h>
+#include <AzCore/std/time.h>
+
+namespace MultiplayerSample
+{
+    NetworkRandomTranslateComponentController::NetworkRandomTranslateComponentController(NetworkRandomTranslateComponent& parent)
+        : NetworkRandomTranslateComponentControllerBase(parent), m_simpleLcgRandom(AZStd::GetTimeUTCMilliSecond())
+    {
+    }
+
+    void NetworkRandomTranslateComponentController::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        m_originalPosition = GetParent().GetEntity()->GetTransform()->GetWorldTranslation();
+        m_destination = CalculateNextDestination();
+        AZ::TickBus::Handler::BusConnect();
+    }
+
+    void NetworkRandomTranslateComponentController::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
+    {
+        AZ::TickBus::Handler::BusDisconnect();
+    }
+
+    void NetworkRandomTranslateComponentController::OnTick(float deltaTime, [[maybe_unused]] AZ::ScriptTimePoint time)
+    {
+        m_travelTime += deltaTime;
+
+        const AZ::Vector3 currentPosition = GetParent().GetEntity()->GetTransform()->GetWorldTranslation();
+        const float t = m_travelTime/GetParent().GetMovementDuration();
+        const AZ::Vector3 newPosition = currentPosition.Lerp(m_destination, t);
+        GetParent().GetEntity()->GetTransform()->SetWorldTranslation(newPosition);
+        
+        if (m_travelTime > GetParent().GetMovementDuration())
+        {
+            m_travelTime = 0.0f;
+            m_destination = CalculateNextDestination();
+        }
+    }
+
+    AZ::Vector3 NetworkRandomTranslateComponentController::CalculateNextDestination()
+    {
+        AZ::Vector3 random(0.5f - m_simpleLcgRandom.GetRandomFloat(), 0.5f - m_simpleLcgRandom.GetRandomFloat(), 0.5f - m_simpleLcgRandom.GetRandomFloat());
+        random = GetParent().GetMaxMoveDistance() * random.GetNormalizedEstimate();
+        return m_originalPosition+random;
+    }
+}

--- a/Gem/Code/Source/Components/PerfTest/NetworkRandomTranslateComponent.h
+++ b/Gem/Code/Source/Components/PerfTest/NetworkRandomTranslateComponent.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) Contributors to the Open 3D Engine Project
+ *
+ * SPDX-License-Identifier: Apache-2.0 OR MIT
+ *
+ */
+
+#pragma once
+
+#include <Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.h>
+#include <AzCore/Component/TickBus.h>
+#include <AzCore/Math/Vector3.h>
+#include <AzCore/Math/Random.h>
+
+namespace MultiplayerSample
+{
+    class NetworkRandomTranslateComponentController
+        : public NetworkRandomTranslateComponentControllerBase,
+          AZ::TickBus::Handler
+    {
+    public:
+        NetworkRandomTranslateComponentController(NetworkRandomTranslateComponent& parent);
+
+        //////////////////////////////////////////////////////////////////////////
+        // NetworkRandomTranslateComponentControllerBase overrides
+        void OnActivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        void OnDeactivate(Multiplayer::EntityIsMigrating entityIsMigrating) override;
+        //////////////////////////////////////////////////////////////////////////
+
+    private:
+        //////////////////////////////////////////////////////////////////////////
+        // AZ::TickBus::Handler overrides
+        void OnTick(float deltaTime, AZ::ScriptTimePoint time) override;
+        //////////////////////////////////////////////////////////////////////////
+
+        AZ::Vector3 CalculateNextDestination();
+
+        AZ::Vector3 m_originalPosition = AZ::Vector3::CreateZero();
+        AZ::Vector3 m_destination = AZ::Vector3::CreateZero();
+        float m_travelTime = 0.0f;
+        AZ::SimpleLcgRandom m_simpleLcgRandom;
+    };
+}

--- a/Gem/Code/multiplayersample_files.cmake
+++ b/Gem/Code/multiplayersample_files.cmake
@@ -18,6 +18,7 @@ set(FILES
     Source/AutoGen/NetworkPlayerMovementComponent.AutoComponent.xml
     Source/AutoGen/NetworkTestSpawnerComponent.AutoComponent.xml
     Source/AutoGen/NetworkRandomImpulseComponent.AutoComponent.xml
+    Source/AutoGen/NetworkRandomTranslateComponent.AutoComponent.xml
     Source/Components/ExampleFilteredEntityComponent.h
     Source/Components/ExampleFilteredEntityComponent.cpp
     Source/Components/NetworkAiComponent.cpp
@@ -40,6 +41,8 @@ set(FILES
     Source/Components/PerfTest/NetworkRandomImpulseComponent.h
     Source/Components/PerfTest/NetworkTestSpawnerComponent.cpp
     Source/Components/PerfTest/NetworkTestSpawnerComponent.h
+    Source/Components/PerfTest/NetworkRandomTranslateComponent.cpp
+    Source/Components/PerfTest/NetworkRandomTranslateComponent.h
     Source/Components/NetworkStressTestComponent.cpp
     Source/Components/NetworkStressTestComponent.h
     Source/Components/NetworkPlayerMovementComponent.cpp

--- a/Levels/SpawningPerfTest/Player_SpawningPerfTest.prefab
+++ b/Levels/SpawningPerfTest/Player_SpawningPerfTest.prefab
@@ -1,0 +1,172 @@
+{
+    "ContainerEntity": {
+        "Id": "ContainerEntity",
+        "Name": "Player_SpawningPerfTest",
+        "Components": {
+            "Component_[10596702065635784962]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 10596702065635784962,
+                "Child Entity Order": [
+                    "Entity_[481247202459]"
+                ]
+            },
+            "Component_[12580556714960743299]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12580556714960743299
+            },
+            "Component_[13688091756673490796]": {
+                "$type": "EditorLockComponent",
+                "Id": 13688091756673490796
+            },
+            "Component_[17606414558060982620]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 17606414558060982620
+            },
+            "Component_[3645633170898125754]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 3645633170898125754
+            },
+            "Component_[376053612567333430]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 376053612567333430
+            },
+            "Component_[489861869047807566]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 489861869047807566
+            },
+            "Component_[525294303509567484]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 525294303509567484
+            },
+            "Component_[8292012900030302774]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 8292012900030302774,
+                "Parent Entity": ""
+            },
+            "Component_[8454252592774193570]": {
+                "$type": "SelectionComponent",
+                "Id": 8454252592774193570
+            },
+            "Component_[8561290942146171464]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 8561290942146171464
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[481247202459]": {
+            "Id": "Entity_[481247202459]",
+            "Name": "Player_SpawningPerfTest",
+            "Components": {
+                "Component_[11239072220376882582]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11239072220376882582
+                },
+                "Component_[1169675617638491795]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1169675617638491795
+                },
+                "Component_[1270609048172837707]": {
+                    "$type": "SelectionComponent",
+                    "Id": 1270609048172837707
+                },
+                "Component_[1430499456156535209]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 1430499456156535209,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0C6BBB76-4EC2-583A-B8C6-1A4C4FD1FE9D}",
+                                    "subId": 283109893
+                                },
+                                "assetHint": "objects/bunny.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[14719349855833720433]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 14719349855833720433,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[15009826499951389033]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15009826499951389033
+                },
+                "Component_[16801850486357727363]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16801850486357727363,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 2222094408678306736
+                        },
+                        {
+                            "ComponentId": 14719349855833720433,
+                            "SortIndex": 1
+                        },
+                        {
+                            "ComponentId": 18296186361961861976,
+                            "SortIndex": 2
+                        },
+                        {
+                            "ComponentId": 1430499456156535209,
+                            "SortIndex": 3
+                        }
+                    ]
+                },
+                "Component_[18140658598914985021]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 18140658598914985021
+                },
+                "Component_[18268225295801329235]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 18268225295801329235
+                },
+                "Component_[18296186361961861976]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 18296186361961861976,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[2222094408678306736]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 2222094408678306736,
+                    "Parent Entity": "ContainerEntity"
+                },
+                "Component_[4269963621511337485]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4269963621511337485
+                },
+                "Component_[459447293499378318]": {
+                    "$type": "EditorBoxShapeComponent",
+                    "Id": 459447293499378318,
+                    "BoxShape": {
+                        "Configuration": {
+                            "Dimensions": [
+                                10.0,
+                                10.0,
+                                5.0
+                            ]
+                        }
+                    }
+                },
+                "Component_[8428788072393495291]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 8428788072393495291,
+                    "m_template": {
+                        "$type": "MultiplayerSample::NetworkRandomTranslateComponent",
+                        "MovementDuration": 2.0
+                    }
+                },
+                "Component_[9209406762830822090]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9209406762830822090
+                }
+            }
+        }
+    }
+}

--- a/Levels/SpawningPerfTest/SpawningPerfTest.prefab
+++ b/Levels/SpawningPerfTest/SpawningPerfTest.prefab
@@ -33,6 +33,11 @@
                 "$type": "EditorDisabledCompositionComponent",
                 "Id": 16239496886950819870
             },
+            "Component_[5521462106189916225]": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 5521462106189916225,
+                "LocalBookmarkFileName": "SpawningPerfTest_6951221139.setreg"
+            },
             "Component_[5688118765544765547]": {
                 "$type": "EditorEntityIconComponent",
                 "Id": 5688118765544765547
@@ -317,6 +322,13 @@
                             0.0,
                             -0.5
                         ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        },
                         "MaterialSelection": {
                             "MaterialIds": [
                                 {}
@@ -506,7 +518,7 @@
         },
         "Entity_[448371574594]": {
             "Id": "Entity_[448371574594]",
-            "Name": "Player Spawn",
+            "Name": "Player Spawner",
             "Components": {
                 "Component_[10530615535325605593]": {
                     "$type": "EditorPendingCompositionComponent",

--- a/Prefabs/Test_Net_Object.prefab
+++ b/Prefabs/Test_Net_Object.prefab
@@ -70,37 +70,11 @@
                     "$type": "EditorVisibilityComponent",
                     "Id": 13213110774758686394
                 },
-                "Component_[14022225546352237038]": {
-                    "$type": "EditorRigidBodyComponent",
-                    "Id": 14022225546352237038,
-                    "Configuration": {
-                        "entityId": "",
-                        "Mass": 999.9999389648438,
-                        "Centre of mass offset": [
-                            0.0,
-                            0.0,
-                            0.5
-                        ],
-                        "Inertia tensor": {
-                            "roll": 0.0,
-                            "pitch": 0.0,
-                            "yaw": 0.0,
-                            "scale": 0.0059999991208314896
-                        }
-                    }
-                },
                 "Component_[15076020362360634866]": {
                     "$type": "GenericComponentWrapper",
                     "Id": 15076020362360634866,
                     "m_template": {
                         "$type": "Multiplayer::NetworkTransformComponent"
-                    }
-                },
-                "Component_[15397597781278882914]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15397597781278882914,
-                    "m_template": {
-                        "$type": "Multiplayer::NetworkRigidBodyComponent"
                     }
                 },
                 "Component_[15646219890037406725]": {
@@ -140,14 +114,13 @@
                         }
                     ]
                 },
-                "Component_[2176242692874007681]": {
+                "Component_[2160433012867593070]": {
                     "$type": "GenericComponentWrapper",
-                    "Id": 2176242692874007681,
+                    "Id": 2160433012867593070,
                     "m_template": {
-                        "$type": "MultiplayerSample::NetworkRandomImpulseComponent",
-                        "EnableHopping": true,
-                        "HopPeriod": 4.0,
-                        "HopForce": 10000.0
+                        "$type": "MultiplayerSample::NetworkRandomTranslateComponent",
+                        "MovementDuration": 5.0,
+                        "MaxMoveDistance": 5.0
                     }
                 },
                 "Component_[2286851697353605533]": {
@@ -159,25 +132,6 @@
                     "Id": 2310691145575538810,
                     "m_template": {
                         "$type": "NetBindComponent"
-                    }
-                },
-                "Component_[2512731683353439569]": {
-                    "$type": "EditorColliderComponent",
-                    "Id": 2512731683353439569,
-                    "ColliderConfiguration": {
-                        "Position": [
-                            0.0,
-                            0.0,
-                            0.5
-                        ],
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
-                        }
-                    },
-                    "ShapeConfiguration": {
-                        "ShapeType": 1
                     }
                 },
                 "Component_[307488191766036503]": {


### PR DESCRIPTION
Fixing SpawningPerfTest by adding the new player spawner component to the SpawningPerfTest. 
Also applying random movements to the test boxes instead of using PhysX because PhysX had a performance bug.

Tested by opening SpawningPerfTest in Editor and pressing CTRL+G and now noticing that the boxes spawn and move around

![2022-06-27_19-02-40](https://user-images.githubusercontent.com/32776221/176074006-e64d2822-9564-40f9-a6ea-556e7322987a.gif)

Fixes GHI #157 
Signed-off-by: Gene Walters <genewalt@amazon.com>