### PR TITLE
MPSample Project Preview Icon

### DIFF
--- a/preview.png
+++ b/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:1cf8339fb51f82a68d2ab475c0476960e75a79d96d239c5b7cd272fbe4990ffe
-size 2770
+oid sha256:d0836b55d450f25f4ca7ff1bc81d266378f65a887c65b7dea4a3c8c65f68d4d9
+size 77570

--- a/preview.png
+++ b/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:d0836b55d450f25f4ca7ff1bc81d266378f65a887c65b7dea4a3c8c65f68d4d9
-size 77570
+oid sha256:682ecefceef4c154e386cd2dcdca2db7a3357c078777018968b181fd94abe7c8
+size 75685


### PR DESCRIPTION
Change MPSample project image so it's not the default
Tested by opening o3de.exe (Project Manager) and seeing the new icon
Fixes #160

BEFORE
![image](https://user-images.githubusercontent.com/32776221/176508159-2419a6e0-1408-410d-87e5-9dc05e565e98.png)

AFTER
![image](https://user-images.githubusercontent.com/32776221/176520967-a68da5ad-2401-434c-87b4-049750b44aac.png)

Signed-off-by: Gene Walters <genewalt@amazon.com>