### PR TITLE
Integrated PopcornFX

### DIFF
--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -52,4 +52,5 @@ set(ENABLED_GEMS
     PrefabBuilder
     MaterialEditor
     UiBasics
+    PopcornFX
 )

--- a/Levels/SampleBase/SampleBase.prefab
+++ b/Levels/SampleBase/SampleBase.prefab
@@ -75,7 +75,8 @@
                     "Entity_[6070312681563]",
                     "Entity_[527570584484]",
                     "Entity_[58245980399131]",
-                    "Entity_[37677838535797]"
+                    "Entity_[37677838535797]",
+                    "Entity_[23205364177803]"
                 ]
             }
         }
@@ -892,6 +893,159 @@
                 "Component_[939429558173407653]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 939429558173407653
+                }
+            }
+        },
+        "Entity_[23205364177803]": {
+            "Id": "Entity_[23205364177803]",
+            "Name": "Particle Ball",
+            "Components": {
+                "Component_[11735870288175062181]": {
+                    "$type": "SelectionComponent",
+                    "Id": 11735870288175062181
+                },
+                "Component_[13027672609292727721]": {
+                    "$type": "EditorSphereShapeComponent",
+                    "Id": 13027672609292727721,
+                    "SphereShape": {
+                        "Configuration": {
+                            "Radius": 0.550000011920929
+                        }
+                    }
+                },
+                "Component_[14720166059315733780]": {
+                    "$type": "EditorRigidBodyComponent",
+                    "Id": 14720166059315733780,
+                    "Configuration": {
+                        "entityId": "",
+                        "Linear damping": 5.0,
+                        "Mass": 523.5988159179688,
+                        "Inertia tensor": {
+                            "roll": 0.0,
+                            "pitch": 0.0,
+                            "yaw": 0.0,
+                            "scale": 52.35987854003906
+                        }
+                    }
+                },
+                "Component_[1480501426020384086]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1480501426020384086
+                },
+                "Component_[14875568387651782137]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14875568387651782137
+                },
+                "Component_[16377420513017824424]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 16377420513017824424
+                },
+                "Component_[1775496397764089233]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1775496397764089233
+                },
+                "Component_[18210194396034179368]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18210194396034179368,
+                    "Parent Entity": "Entity_[356758116574]",
+                    "Transform Data": {
+                        "Translate": [
+                            2.1090826988220215,
+                            -8.42399787902832,
+                            0.439389705657959
+                        ]
+                    }
+                },
+                "Component_[3919011340731659607]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 3919011340731659607,
+                    "m_template": {
+                        "$type": "NetBindComponent"
+                    }
+                },
+                "Component_[4912773530096322309]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4912773530096322309
+                },
+                "Component_[5057386170116920896]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5057386170116920896
+                },
+                "Component_[6029021062967785129]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 6029021062967785129,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkRigidBodyComponent"
+                    }
+                },
+                "Component_[7087077749069182345]": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 7087077749069182345,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{5BE45916-46BC-5522-A41A-C0A1ED8481FC}"
+                        },
+                        "assetHint": "popcornfx/particles/particleball.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Scale",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "zczMPgAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 0.4000000059604645
+                                    }
+                                ]
+                            },
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 0.4000000059604645
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "Component_[725984638850969331]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 725984638850969331,
+                    "m_template": {
+                        "$type": "Multiplayer::NetworkTransformComponent"
+                    }
+                },
+                "Component_[7757820644470971111]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 7757820644470971111,
+                    "ColliderConfiguration": {
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 0
+                    }
+                },
+                "Component_[9717622753391867483]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9717622753391867483
+                },
+                "Component_[981514129882235647]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 981514129882235647
                 }
             }
         },

--- a/PopcornFX/Editor/AnimationTracks/Circle.fbx
+++ b/PopcornFX/Editor/AnimationTracks/Circle.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05a30e7043f298078a9012908423c305146b4bbe5afac697550526b100c1e7d0
+size 247899

--- a/PopcornFX/Editor/AnimationTracks/Circle.pkcf
+++ b/PopcornFX/Editor/AnimationTracks/Circle.pkcf
@@ -1,0 +1,6 @@
+Version = 2.12.0.12699;
+COvenBakeConfig_Mesh	$82362157
+{
+	ImportGeometry = false;
+	ImportAnimation = true;
+}

--- a/PopcornFX/Editor/AnimationTracks/PingPong.fbx
+++ b/PopcornFX/Editor/AnimationTracks/PingPong.fbx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6a99458ca7ce98af5456cc8cd53d04eb9314be78d88ddd55d46eb70d09f688f8
+size 32576

--- a/PopcornFX/Editor/AnimationTracks/PingPong.pkcf
+++ b/PopcornFX/Editor/AnimationTracks/PingPong.pkcf
@@ -1,0 +1,6 @@
+Version = 2.12.0.12699;
+COvenBakeConfig_Mesh	$A6D04D13
+{
+	ImportGeometry = false;
+	ImportAnimation = true;
+}

--- a/PopcornFX/Editor/Presets/Effects/Basic.pkfx
+++ b/PopcornFX/Editor/Presets/Effects/Basic.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:447b30ac265f4ea9ded1b8c233fd76b5a6fe70f60534313415ad57bf6c8b2555
+size 28683

--- a/PopcornFX/Editor/Presets/Effects/FX_Simple.pkfx
+++ b/PopcornFX/Editor/Presets/Effects/FX_Simple.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4c884c6c9ba02c4285fa141e76615a30ba719e2893ebfaf27d4bbafeb6501c6f
+size 30006

--- a/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/Basic.pkfx.anim.png
+++ b/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/Basic.pkfx.anim.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:67fc229d13445bbedcd15abc9b4319b221061d63293a62c0ad513307d9e951a6
+size 1027350

--- a/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/Basic.pkfx.png
+++ b/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/Basic.pkfx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d7df620834d08136275e34476f744329f3f4cfc9ebfeb0a00d98269159068ac1
+size 94338

--- a/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/FX_Simple.pkfx.anim.png
+++ b/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/FX_Simple.pkfx.anim.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ddb52f7f9acfe1ab084d1a6d01208580913a876411aa7359cf65517e07e3088c
+size 901119

--- a/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/FX_Simple.pkfx.png
+++ b/PopcornFX/Editor/Thumbnails/Editor/Presets/Effects/FX_Simple.pkfx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d0b8125baa58d3efe75d4acfdf09907b5d2dd17ca5d8006b3001f726fbbecdd4
+size 64534

--- a/PopcornFX/Editor/Thumbnails/Particles/ParticleBall.pkfx.png
+++ b/PopcornFX/Editor/Thumbnails/Particles/ParticleBall.pkfx.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4deff5912da761122e68c08a93648e60185222aff92eb8b4b84d8ffbf8cfadd8
+size 71828

--- a/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Black.dds
+++ b/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Black.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b0ce4b944209a3232be0b9253f8e061c879064e03791e07fcb9c14ed4bd8e12e
+size 1492

--- a/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Default_AlphaMap.dds
+++ b/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Default_AlphaMap.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0e3dbb200c254e73cd35cefbd49a89fe487db98e0da5f5efe1cfc1aed142d8e8
+size 349652

--- a/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Diffuse.dds
+++ b/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Diffuse.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3640a24c7ba9907b2d1ecedf82b6c342e0e11f45f8b5004bdae5267207961bac
+size 21972

--- a/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Distort.dds
+++ b/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/Distort.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a41cf2939c335e182473c758c2c2c5442c8f511e6d011188e4512481755893e8
+size 16512

--- a/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/NMap_Flat.dds
+++ b/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/NMap_Flat.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b863a04cd62bf3b02edbcfdb8cd7fc7061f0bf531a93a0587b4c29e5d739d2d3
+size 1152

--- a/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/White.dds
+++ b/PopcornFX/Library/PopcornFXCore/Materials/DefaultTextures/White.dds
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:fcbf856b99ea2cd8e3bfd939f5e5471218f3fd86cd09dd9f36fe28cb88c91b97
+size 1492

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Billboard.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Billboard.pkma
@@ -1,0 +1,110 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D857A09F",
+		"$EA3837ED",
+		"$02499109",
+		"$EA331F29",
+		"$1DB717AE",
+		"$1098ED35",
+		"$CAD62F46",
+		"$4B933A29",
+		"$C5F9C9BF",
+		"$D851A09F",
+		"$35A36C4E",
+		"$EAC726E3",
+		"$7FB4AB5F",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$02499109
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LegacyLit";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "FlipUVs";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Billboard.frag";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Decal.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Decal.pkma
@@ -1,0 +1,50 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$4B933A29",
+		"$35A36C4E",
+		"$EAC726E3",
+		"$2DCA11C6",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryDecal";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CRHIMaterialShaders	$9154DFA0
+{
+	VertexShader = "Library/PopcornFXCore/Shaders/Default_Decal.vert";
+	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Decal.frag";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Decal";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$2DCA11C6
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Light.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Light.pkma
@@ -1,0 +1,51 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$409FF19E",
+		"$BFFD5E01",
+		"$27D7F2E5",
+		"$D857A09F",
+		"$2FB0C593",
+		"$5ACCE379",
+	};
+}
+CParticleRendererFeatureDesc	$409FF19E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryLight";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$BFFD5E01
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Light";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$27D7F2E5
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LightAttenuation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$2FB0C593
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LightTranslucent";
+}
+CParticleRendererFeatureDesc	$5ACCE379
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CastShadows";
+}
+CRHIMaterialShaders	$73ED6589
+{
+	VertexShader = "Library/PopcornFXCore/Shaders/Default_Light.vert";
+	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Light.frag";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Mesh.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Mesh.pkma
@@ -1,0 +1,92 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$A8FC2215",
+		"$18565271",
+		"$8F7B32AE",
+		"$9154DFA0",
+		"$35A36C4E",
+		"$8BF32864",
+		"$ECD07C82",
+		"$D857A09F",
+		"$4B933A29",
+		"$4B954A29",
+		"$EAC726E3",
+		"$3BE1856D",
+		"$1A35A1FF",
+	};
+}
+CParticleRendererFeatureDesc	$A8FC2215
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryMesh";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$18565271
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$8F7B32AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$8BF32864
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$ECD07C82
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LegacyLit";
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "MeshAtlas";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$4B954A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Mesh.frag";
+}
+CParticleRendererFeatureDesc	$3BE1856D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1A35A1FF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "UseVertexColors";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Ribbon.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Ribbon.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$FB5367C7",
+		"$83FDC6C2",
+		"$156D23DE",
+		"$D857A09F",
+		"$1A756CB9",
+		"$8AB9925C",
+		"$9237A057",
+		"$07AE0A48",
+		"$61837614",
+		"$1CA8897A",
+		"$D3C19C23",
+		"$E7CAD9E4",
+		"$3AC11902",
+		"$01F95E26",
+		"$4B933A29",
+		"$D157A09F",
+		"$35A36C4E",
+		"$9154DFA0",
+		"$84382E2F",
+	};
+}
+CParticleRendererFeatureDesc	$FB5367C7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$83FDC6C2
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$156D23DE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$1A756CB9
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$8AB9925C
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LegacyLit";
+}
+CParticleRendererFeatureDesc	$9237A057
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$07AE0A48
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CorrectDeformation";
+}
+CParticleRendererFeatureDesc	$61837614
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$1CA8897A
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TextureUVs";
+}
+CParticleRendererFeatureDesc	$D3C19C23
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$E7CAD9E4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$3AC11902
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$01F95E26
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$D157A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Ribbon.frag";
+}
+CParticleRendererFeatureDesc	$84382E2F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Sound.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Sound.pkma
@@ -1,0 +1,42 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$F361BD3A",
+		"$DCB8444C",
+		"$D857A09F",
+		"$53C68443",
+		"$589BAB05",
+	};
+}
+CParticleRendererFeatureDesc	$F361BD3A
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometrySound";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DCB8444C
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Sound";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$53C68443
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "SoundAttenuation";
+}
+CParticleRendererFeatureDesc	$589BAB05
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Doppler";
+}
+CRHIMaterialShaders	$00269EC3
+{
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Default_Triangle.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Default_Triangle.pkma
@@ -1,0 +1,63 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$3D324B43",
+		"$9154DFA0",
+		"$7605928F",
+		"$4B933A29",
+		"$EAC726E3",
+		"$4ADE8DE2",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalBend";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$4ADE8DE2
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CParticleRendererFeatureDesc	$7605928F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Default_Triangle.frag";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Billboard.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Billboard.pkma
@@ -1,0 +1,91 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$E8631443",
+		"$D0BFBDD9",
+		"$D857A09F",
+		"$DDEAB83F",
+		"$EEE60312",
+		"$B650CB43",
+		"$05ED5D39",
+		"$D956C336",
+		"$4E07A528",
+		"$618E9B88",
+		"$7513657A",
+		"$07F6ADCE",
+		"$4E5BBEB1",
+	};
+}
+CParticleRendererFeatureDesc	$E8631443
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D0BFBDD9
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Distortion";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DDEAB83F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$EEE60312
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "FlipUVs";
+}
+CParticleRendererFeatureDesc	$05ED5D39
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$D956C336
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$4E07A528
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$618E9B88
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$7513657A
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$07F6ADCE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$B650CB43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CParticleRendererFeatureDesc	$4E5BBEB1
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Tint";
+}
+CRHIMaterialShaders	$89AA45AB
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Particle_Master.frag";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Ribbon.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Distortion_Ribbon.pkma
@@ -1,0 +1,109 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$35A36C4E",
+		"$D0BFBDD9",
+		"$D857A09F",
+		"$DDEAB83F",
+		"$4B933A29",
+		"$D279714D",
+		"$EAC726E3",
+		"$D6EB29BC",
+		"$4ADE8DE2",
+		"$05ED5D39",
+		"$AE117C84",
+		"$B6BCAA6F",
+		"$451CCD2F",
+		"$BD4D7F29",
+		"$B3A8235C",
+		"$7B20F85D",
+	};
+}
+CParticleRendererFeatureDesc	$D0BFBDD9
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Distortion";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DDEAB83F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$05ED5D39
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CorrectDeformation";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TextureUVs";
+}
+CParticleRendererFeatureDesc	$4ADE8DE2
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$D279714D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CRHIMaterialShaders	$27E10855
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$B6BCAA6F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$451CCD2F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$BD4D7F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$B3A8235C
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$7B20F85D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$AE117C84
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$D6EB29BC
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Diffuse.pkma
@@ -1,0 +1,116 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Distortion.pkma
@@ -1,0 +1,116 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Emissive.pkma
@@ -1,0 +1,116 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Opaque.pkma
@@ -1,0 +1,102 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$0EBD49BE",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+	};
+	NodeGraph = "$09FB01D9";
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0EBD49BE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleNodeGraph	$09FB01D9
+{
+	CustomName = "Adapter";
+	WorkspaceZoom = -4;
+}
+CParticleNodePinOut	$33311BAE
+{
+	SelfName = "Value";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Billboard/Billboard_Tinted.pkma
@@ -1,0 +1,116 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+	Mandatory = true;
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Diffuse.pkma
@@ -1,0 +1,81 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$0F57EEAC",
+		"$3D324B43",
+		"$D851A09F",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$5A9EEFD8",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryDecal";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	VertexShader = "Library/PopcornFXCore/Shaders/Experimental/Decal_Default.vert";
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0F57EEAC
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Decal";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5A9EEFD8
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Decal/Decal_Emissive.pkma
@@ -1,0 +1,75 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$0F57EEAC",
+		"$3D324B43",
+		"$D851A09F",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryDecal";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	VertexShader = "Library/PopcornFXCore/Shaders/Experimental/Decal_Default.vert";
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0F57EEAC
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Decal";
+	Mandatory = true;
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Light/Light_Default.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Light/Light_Default.pkma
@@ -1,0 +1,45 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$409FF19E",
+		"$BFFD5E01",
+		"$27D7F2E5",
+		"$D857A09F",
+		"$2FB0C593",
+	};
+}
+CParticleRendererFeatureDesc	$409FF19E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryLight";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$BFFD5E01
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Light";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$27D7F2E5
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "LightAttenuation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$2FB0C593
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "LightTranslucent";
+}
+CRHIMaterialShaders	$73ED6589
+{
+	VertexShader = "Library/PopcornFXCore/Shaders/Experimental/Light_Default.vert";
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Light_Default.frag";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Emissive.pkma
@@ -1,0 +1,80 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$93540081",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$1BCA2B7D",
+		"$B040E9CD",
+		"$862F644E",
+		"$98B9ED49",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryMesh";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$1BCA2B7D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$B040E9CD
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "MeshAtlas";
+}
+CParticleRendererFeatureDesc	$862F644E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "UseVertexColors";
+}
+CParticleRendererFeatureDesc	$93540081
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$98B9ED49
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Opaque.pkma
@@ -1,0 +1,98 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$A357A567",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$1BCA2B7D",
+		"$B040E9CD",
+		"$862F644E",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryMesh";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$A357A567
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$1BCA2B7D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$B040E9CD
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "MeshAtlas";
+}
+CParticleRendererFeatureDesc	$862F644E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "UseVertexColors";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Mesh/Mesh_Tinted.pkma
@@ -1,0 +1,92 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$93540081",
+		"$B9161D10",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$1BCA2B7D",
+		"$B040E9CD",
+		"$862F644E",
+		"$98B9ED49",
+		"$F36FE1CF",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryMesh";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$1BCA2B7D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$B040E9CD
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "MeshAtlas";
+}
+CParticleRendererFeatureDesc	$862F644E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "UseVertexColors";
+}
+CParticleRendererFeatureDesc	$93540081
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$98B9ED49
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$F36FE1CF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$B9161D10
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Diffuse.pkma
@@ -1,0 +1,129 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$DCD8A7E7",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$DCD8B8C4",
+		"$8F800045",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$DCD8A7E7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CorrectDeformation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Distortion.pkma
@@ -1,0 +1,129 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$DCD8A7E7",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$DCD8B8C4",
+		"$8F800045",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$DCD8A7E7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CorrectDeformation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Emissive.pkma
@@ -1,0 +1,129 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$DCD8A7E7",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$DCD8B8C4",
+		"$8F800045",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$DCD8A7E7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CorrectDeformation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Opaque.pkma
@@ -1,0 +1,116 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191A1915",
+		"$D857A09F",
+		"$0EBD49BE",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$1DB717AE",
+		"$D2F84E07",
+		"$DCD8B8C4",
+		"$DCD8A7E7",
+		"$860D8229",
+		"$D5F9BFE4",
+	};
+}
+CParticleRendererFeatureDesc	$191A1915
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0EBD49BE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$DCD8A7E7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CorrectDeformation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D2F84E07
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$D5F9BFE4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Dithering";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_CorrectDeformation_Tinted.pkma
@@ -1,0 +1,129 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$DCD8A7E7",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$DCD8B8C4",
+		"$8F800045",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$DCD8A7E7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CorrectDeformation";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Diffuse.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$DCD8B8C4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Distortion.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$DCD8B8C4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Emissive.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$DCD8B8C4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Opaque.pkma
@@ -1,0 +1,110 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191A1915",
+		"$D857A09F",
+		"$0EBD49BE",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$DCD8B8C4",
+		"$860D8229",
+		"$166128F6",
+	};
+}
+CParticleRendererFeatureDesc	$191A1915
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0EBD49BE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$166128F6
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Dithering";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Ribbon/Ribbon_Tinted.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1492",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$CAD62F46",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$DCD8B8C4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1492
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DCD8B8C4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Sound/Sound_Default.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Sound/Sound_Default.pkma
@@ -1,0 +1,42 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$F361BD3A",
+		"$DCB8444C",
+		"$D857A09F",
+		"$53C68443",
+		"$589BAB05",
+	};
+}
+CParticleRendererFeatureDesc	$F361BD3A
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometrySound";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$DCB8444C
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Sound";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$53C68443
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoundAttenuation";
+}
+CParticleRendererFeatureDesc	$589BAB05
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Doppler";
+}
+CRHIMaterialShaders	$00269EC3
+{
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Diffuse.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Diffuse.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$FD189ED3",
+		"$DA06D7A4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$FD189ED3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$DA06D7A4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Distortion.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Distortion.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$FD189ED3",
+		"$DA06D7A4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$FD189ED3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$DA06D7A4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Emissive.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Emissive.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$FD189ED3",
+		"$DA06D7A4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+}
+CParticleRendererFeatureDesc	$FD189ED3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$DA06D7A4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Opaque.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Opaque.pkma
@@ -1,0 +1,116 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$A357A567",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$FD189ED3",
+		"$DA06D7A4",
+		"$860D8229",
+		"$A2478C51",
+	};
+	NodeGraph = "$9EC1D3AA";
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$FD189ED3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$DA06D7A4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CParticleRendererFeatureDesc	$A357A567
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleNodeGraph	$9EC1D3AA
+{
+	CustomName = "Adapter";
+	WorkspaceZoom = -4;
+}
+CParticleRendererFeatureDesc	$A2478C51
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Dithering";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Tinted.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Experimental/Triangle/Triangle_Tinted.pkma
@@ -1,0 +1,128 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$5F3F8D5F",
+		"$3D324B43",
+		"$D851A09F",
+		"$EA3837ED",
+		"$C5F9C9BF",
+		"$4B933A29",
+		"$35A36C4E",
+		"$7FB4AB5F",
+		"$1098ED35",
+		"$EA331F29",
+		"$1DB717AE",
+		"$EAC726E3",
+		"$0FEA2C5F",
+		"$8F800045",
+		"$FD189ED3",
+		"$DA06D7A4",
+		"$860D8229",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$5F3F8D5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Diffuse";
+}
+CParticleRendererFeatureDesc	$D851A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$7FB4AB5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$EA331F29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "BasicTransformUVs";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag";
+}
+CParticleRendererFeatureDesc	$0FEA2C5F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Distortion";
+}
+CParticleRendererFeatureDesc	$8F800045
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "Tint";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$FD189ED3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$DA06D7A4
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CParticleRendererFeatureDesc	$860D8229
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Experimental.pkri";
+	RendererFeatureName = "TextureRepeat";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Interface/Editor.pkri
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Interface/Editor.pkri
@@ -1,0 +1,4948 @@
+Version = 2.12.0.12699;
+CEngineRendererInterface	$6B70D015
+{
+	InterfaceName = "Editor features";
+	RendererFeatures = {
+		"$D6EEA348",
+		"$81861AB7",
+		"$B660FBF9",
+		"$42E16C02",
+		"$D734A95F",
+		"$8F7A985A",
+		"$B53F5A68",
+		"$1E5C8DCF",
+		"$0798FEE6",
+		"$E749E042",
+		"$1838F4AE",
+		"$E191BFCB",
+		"$F415EE0A",
+		"$41EED1A4",
+		"$62BCE275",
+		"$0CD860BD",
+		"$DADBF2F1",
+		"$A9934228",
+		"$A2277B6B",
+		"$D834E0C1",
+		"$EABBAE94",
+		"$0E3ACA6C",
+		"$61D82A82",
+		"$D481D29F",
+		"$4B99796F",
+		"$4B44F286",
+		"$E7A7BE8E",
+		"$D4EA65F0",
+		"$052CEED2",
+		"$F20FBF14",
+		"$4AF71D41",
+		"$A2ABAB94",
+		"$123456AC",
+		"$DDECD857",
+		"$D857A09F",
+		"$047497F3",
+		"$9154DFA0",
+		"$52697627",
+		"$D6BEA348",
+		"$55289D1E",
+		"$23F9C093",
+		"$F50D7FD2",
+		"$8A93EEE1",
+		"$1BDFA32C",
+		"$5CBB6243",
+		"$71D528E3",
+	};
+}
+CParticleRendererFeature	$81861AB7
+{
+	FeatureName = "GeometryBillboard";
+	Properties = {
+		"$48E2E8B7",
+		"$41E5AFE7",
+		"$3B3DDE67",
+		"$BEEF8936",
+		"$F02495CD",
+		"$CE8CC02E",
+		"$6AD0A593",
+		"$125C39DB",
+	};
+}
+CParticleNodeTemplateExport	$48E2E8B7
+{
+	Description = {
+		"@eng:Billboard center in world coordinates",
+	};
+	InputPins = {
+		"$48E2E8BF",
+	};
+	OutputPins = {
+		"$1A05FF77",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$48E2E8BF
+{
+	SelfName = "DefaultValue";
+	Owner = "$48E2E8B7";
+}
+CParticleNodeTemplateExport	$3B3DDE67
+{
+	Description = {
+		"@eng:Radius of the billboard in world units",
+	};
+	InputPins = {
+		"$3B3DDE6F",
+	};
+	OutputPins = {
+		"$0C954798",
+	};
+	ExportedName = "General.Size";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(5.0000001e-02, 4.9999997e-02, 4.9999997e-02, 4.9999997e-02);
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.EnableSize2D";
+	RuleFunction = NotEqual;
+}
+CParticleNodePinIn	$3B3DDE6F
+{
+	SelfName = "DefaultValue";
+	Owner = "$3B3DDE67";
+}
+CParticleNodeTemplateExport	$F02495CD
+{
+	Description = {
+		"@eng:Billboard rotation angle in degrees",
+	};
+	InputPins = {
+		"$F02495CF",
+	};
+	OutputPins = {
+		"$7837C3E5",
+	};
+	ExportedName = "General.Rotation";
+	ExportedType = float;
+	Semantic = Angle;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MinValueF4 = float4(-1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1_AND_Rule2;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = Greater;
+	RuleValue = "1";
+	DependentProperty2 = "General.BillboardingMode";
+	RuleFunction2 = Lower;
+	RuleValue2 = "5";
+}
+CParticleNodePinIn	$F02495CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$F02495CD";
+}
+CParticleNodeTemplateExport	$CE8CC02E
+{
+	Description = {
+		"@eng:Principal axis of the billboard when <c>BillboardingMode</c> is set to <c>AxisAligned*</c>\\nSide axis of the billboard when <c>BillboardingMode</c> is set to <c>PlaneAligned</c>",
+	};
+	InputPins = {
+		"$CE8CC02F",
+	};
+	OutputPins = {
+		"$2FB70E0C",
+	};
+	ExportedName = "General.Axis";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = Lower;
+	RuleValue = "2";
+}
+CParticleNodePinIn	$CE8CC02F
+{
+	SelfName = "DefaultValue";
+	Owner = "$CE8CC02E";
+}
+CParticleNodeTemplateExport	$6AD0A593
+{
+	Description = {
+		"@eng:Normal of the billboard when <c>BillboardingMode</c> is set to <c>PlaneAligned</c>",
+	};
+	InputPins = {
+		"$6AD0A59F",
+	};
+	OutputPins = {
+		"$36207FBF",
+	};
+	ExportedName = "General.NormalAxis";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = NotEqual;
+	RuleValue = "5";
+}
+CParticleNodePinIn	$6AD0A59F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6AD0A593";
+}
+CParticleNodeTemplateExport	$125C39DB
+{
+	Description = {
+		"@eng:Specifies how the billboard geometry should be build & aligned.\\nUnless mentioned otherwise, the generated geometry will be a quad: 2 triangles, 4 vertices.\\n<ul>\\n<li><b>ScreenAligned</b>: Oriented to always face the camera screen plane</li>\\n<li><b>ViewposAligned</b>: Oriented to always face the camera position</li>\\n<li><b>AxisAligned</b>: Constrained along the <c>Axis</c> vector, tries facing the screen by rotating around the axis</li>\\n<li><b>AxisAlignedSpheroid</b>: Same as <c>AxisAligned</c>, but vertices will always enclose a spheroid, preventing the billboard from looking like a thin slice when looking along the direction of <c>Axis</c></li>\\n<li><b>AxisAlignedCapsule</b>: Similar to <c>AxisAlignedSpheroid</c>, but the geometry has 4 triangles and 6 vertices, resembling a stretched cylinder instead of a spheroid</li>\\n<li><b>PlaneAligned</b>: Constrained on two axes, does not depend on the camera, will appear as a 3D plane</li>\\n</ul>",
+	};
+	InputPins = {
+		"$125C39DF",
+	};
+	OutputPins = {
+		"$E54029EE",
+	};
+	ExportedName = "General.BillboardingMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:General",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"ScreenAligned",
+		"ViewposAligned",
+		"AxisAligned",
+		"AxisAlignedSpheroid",
+		"AxisAlignedCapsule",
+		"PlaneAligned",
+	};
+}
+CParticleNodePinIn	$125C39DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$125C39DB";
+}
+CParticleRendererFeature	$B660FBF9
+{
+	FeatureName = "GeometryRibbon";
+	Properties = {
+		"$ECEE2C92",
+		"$C71A50C8",
+		"$4703F6C7",
+		"$6B1D589C",
+	};
+}
+CParticleNodeTemplateExport	$ECEE2C92
+{
+	InputPins = {
+		"$ECEE2C9F",
+	};
+	OutputPins = {
+		"$5209F849",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$ECEE2C9F
+{
+	SelfName = "DefaultValue";
+	Owner = "$ECEE2C92";
+}
+CParticleNodeTemplateExport	$C71A50C8
+{
+	InputPins = {
+		"$C71A50CF",
+	};
+	OutputPins = {
+		"$A913E2D6",
+	};
+	ExportedName = "General.Size";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(4.9999997e-02, 4.9999997e-02, 4.9999997e-02, 4.9999997e-02);
+}
+CParticleNodePinIn	$C71A50CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$C71A50C8";
+}
+CParticleNodeTemplateExport	$4703F6C7
+{
+	InputPins = {
+		"$4703F6CF",
+	};
+	OutputPins = {
+		"$17E22F51",
+	};
+	ExportedName = "General.Axis";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = Lower;
+	RuleValue = "1";
+}
+CParticleNodePinIn	$4703F6CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$4703F6C7";
+}
+CParticleNodeTemplateExport	$6B1D589C
+{
+	InputPins = {
+		"$6B1D589F",
+	};
+	OutputPins = {
+		"$8EAEE7E8",
+	};
+	ExportedName = "General.BillboardingMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:General",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"ViewposAligned",
+		"NormalAxisAligned",
+		"SideAxisAligned",
+	};
+}
+CParticleNodePinIn	$6B1D589F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6B1D589C";
+}
+CParticleRendererFeature	$42E16C02
+{
+	FeatureName = "GeometryMesh";
+	Properties = {
+		"$B6F5CC16",
+		"$49145BE4",
+		"$D4309EA4",
+		"$8B66367E",
+	};
+}
+CParticleNodeTemplateExport	$B6F5CC16
+{
+	Description = {
+		"@eng:Mesh position in world coordinates",
+	};
+	InputPins = {
+		"$B6F5CC1F",
+	};
+	OutputPins = {
+		"$125230CB",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$B6F5CC1F
+{
+	SelfName = "DefaultValue";
+	Owner = "$B6F5CC16";
+}
+CParticleNodeTemplateExport	$49145BE4
+{
+	Description = {
+		"@eng:Mesh scale",
+	};
+	InputPins = {
+		"$49145BEF",
+	};
+	OutputPins = {
+		"$F527E9EA",
+	};
+	ExportedName = "General.Scale";
+	ExportedType = float3;
+	Semantic = 3D_Scale;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$49145BEF
+{
+	SelfName = "DefaultValue";
+	Owner = "$49145BE4";
+}
+CParticleNodeTemplateExport	$D4309EA4
+{
+	Description = {
+		"@eng:Mesh orientation",
+	};
+	InputPins = {
+		"$D4309EAF",
+	};
+	OutputPins = {
+		"$E7F879F5",
+	};
+	ExportedName = "General.Orientation";
+	ExportedType = orientation;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(0.0000000e+00, 0.0000000e+00, 0.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$D4309EAF
+{
+	SelfName = "DefaultValue";
+	Owner = "$D4309EA4";
+}
+CParticleNodeTemplateExport	$8B66367E
+{
+	Description = {
+		"@eng:Mesh resource",
+	};
+	InputPins = {
+		"$8B66367F",
+	};
+	OutputPins = {
+		"$C45BF55C",
+	};
+	ExportedName = "General.Mesh";
+	ExportedType = dataGeometry;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$8B66367F
+{
+	SelfName = "DefaultValue";
+	Owner = "$8B66367E";
+}
+CParticleRendererFeature	$D734A95F
+{
+	FeatureName = "GeometryLight";
+	Properties = {
+		"$E2583104",
+	};
+}
+CParticleNodeTemplateExport	$E2583104
+{
+	Description = {
+		"@eng:Light position in world coordinates",
+	};
+	InputPins = {
+		"$E258310F",
+	};
+	OutputPins = {
+		"$22B8D14F",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$E258310F
+{
+	SelfName = "DefaultValue";
+	Owner = "$E2583104";
+}
+CParticleRendererFeature	$8F7A985A
+{
+	FeatureName = "GeometrySound";
+	Properties = {
+		"$203CAA66",
+	};
+}
+CParticleNodeTemplateExport	$203CAA66
+{
+	Description = {
+		"@eng:Sound source position in world coordinates",
+	};
+	InputPins = {
+		"$203CAA6F",
+	};
+	OutputPins = {
+		"$AAFF12BE",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$203CAA6F
+{
+	SelfName = "DefaultValue";
+	Owner = "$203CAA66";
+}
+CParticleRendererFeature	$0798FEE6
+{
+	FeatureName = "Transparent";
+	Feature = "$BE4E302C";
+	Properties = {
+		"$C78B225F",
+		"$353B08E3",
+		"$9AA9404E",
+		"$E6F904E6",
+		"$20D13232",
+	};
+}
+CParticleNodeTemplateExport	$BE4E302C
+{
+	InputPins = {
+		"$BE4E302F",
+	};
+	OutputPins = {
+		"$1A488438",
+	};
+	ExportedName = "Transparent";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$BE4E302F
+{
+	SelfName = "DefaultValue";
+	Owner = "$BE4E302C";
+}
+CParticleNodeTemplateExport	$C78B225F
+{
+	Description = {
+		"@eng:Transparent blending mode",
+	};
+	InputPins = {
+		"$C78B225A",
+	};
+	OutputPins = {
+		"$42F2DB5B",
+	};
+	ExportedName = "Transparent.Type";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Additive",
+		"AdditiveNoAlpha",
+		"AlphaBlend",
+		"PremultipliedAlpha",
+	};
+}
+CParticleNodePinIn	$C78B225A
+{
+	SelfName = "DefaultValue";
+	Owner = "$C78B225F";
+}
+CParticleNodeTemplateExport	$353B08E3
+{
+	Description = {
+		"@eng:Allows to specify a custom sorting key. By default sorts based on the distance to the camera.",
+	};
+	InputPins = {
+		"$353B08EF",
+	};
+	OutputPins = {
+		"$55F99FBA",
+	};
+	ExportedName = "Transparent.SortMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"CameraDistance",
+		"ByCustomValue",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.Type";
+	RuleFunction = Lower;
+	RuleValue = "2";
+}
+CParticleNodePinIn	$353B08EF
+{
+	SelfName = "DefaultValue";
+	Owner = "$353B08E3";
+}
+CParticleNodeTemplateExport	$9AA9404E
+{
+	Description = {
+		"@eng:Value to be used for sorting when <c>SortMode</c> is set to <c>ByCustomValue</c>",
+	};
+	InputPins = {
+		"$9AA9404F",
+	};
+	OutputPins = {
+		"$C73E7C05",
+	};
+	ExportedName = "Transparent.SortKey";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	PinRules = Rule1_OR_Rule2;
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.SortMode";
+	DependentProperty2 = "Transparent.Type";
+	RuleFunction2 = Lower;
+	RuleValue2 = "2";
+}
+CParticleNodePinIn	$9AA9404F
+{
+	SelfName = "DefaultValue";
+	Owner = "$9AA9404E";
+}
+CParticleRendererFeature	$E749E042
+{
+	FeatureName = "Opaque";
+	Feature = "$0755FA7C";
+	Properties = {
+		"$6887733F",
+		"$41B5AFE7",
+	};
+}
+CParticleNodeTemplateExport	$0755FA7C
+{
+	InputPins = {
+		"$0755FA7F",
+	};
+	OutputPins = {
+		"$ED0A18AC",
+	};
+	ExportedName = "Opaque";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$0755FA7F
+{
+	SelfName = "DefaultValue";
+	Owner = "$0755FA7C";
+}
+CParticleNodeTemplateExport	$6887733F
+{
+	Description = {
+		"@eng:Opaque mode\\n<ul>\\n<li><b>Solid</b>: Fully opaque, ignores the texture & color alpha channel</li>\\n<li><b>Masked</b>: When the final pixel\'s alpha value is lower than <c>MaskThreshold</c>, the pixel is not drawn</li>\\n</ul>",
+	};
+	InputPins = {
+		"$6887733A",
+	};
+	OutputPins = {
+		"$CF350EDF",
+	};
+	ExportedName = "Opaque.Type";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Solid",
+		"Masked",
+	};
+}
+CParticleNodePinIn	$6887733A
+{
+	SelfName = "DefaultValue";
+	Owner = "$6887733F";
+}
+CParticleRendererFeature	$1838F4AE
+{
+	FeatureName = "Diffuse";
+	Feature = "$3FB45D67";
+	Properties = {
+		"$E32FF502",
+		"$89BB54AC",
+	};
+}
+CParticleNodeTemplateExport	$3FB45D67
+{
+	InputPins = {
+		"$3FB45D6F",
+	};
+	OutputPins = {
+		"$1BDBE0E0",
+	};
+	ExportedName = "Diffuse";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$3FB45D6F
+{
+	SelfName = "DefaultValue";
+	Owner = "$3FB45D67";
+}
+CParticleNodeTemplateExport	$E32FF502
+{
+	Description = {
+		"@eng:Texture map used for the diffuse lighting component",
+	};
+	InputPins = {
+		"$E32FF50F",
+	};
+	OutputPins = {
+		"$84ADA123",
+	};
+	ExportedName = "Diffuse.DiffuseMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Diffuse",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodePinIn	$E32FF50F
+{
+	SelfName = "DefaultValue";
+	Owner = "$E32FF502";
+}
+CParticleNodeTemplateExport	$89BB54AC
+{
+	Description = {
+		"@eng:Diffuse color, multiplied with the diffuse map color",
+	};
+	InputPins = {
+		"$89BB54AF",
+	};
+	OutputPins = {
+		"$946D7522",
+	};
+	ExportedName = "Diffuse.Color";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Diffuse",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$89BB54AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$89BB54AC";
+}
+CParticleRendererFeature	$E191BFCB
+{
+	FeatureName = "SoftParticles";
+	Feature = "$82F1B3B1";
+	Properties = {
+		"$3F05660E",
+	};
+}
+CParticleNodeTemplateExport	$82F1B3B1
+{
+	InputPins = {
+		"$82F1B3BF",
+	};
+	OutputPins = {
+		"$C072C98D",
+	};
+	ExportedName = "SoftParticles";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$82F1B3BF
+{
+	SelfName = "DefaultValue";
+	Owner = "$82F1B3B1";
+}
+CParticleNodeTemplateExport	$3F05660E
+{
+	Description = {
+		"@eng:Fade distance of particles in world units",
+	};
+	InputPins = {
+		"$3F05660F",
+	};
+	OutputPins = {
+		"$F8EE30D4",
+	};
+	ExportedName = "SoftParticles.SoftnessDistance";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SoftParticles",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$3F05660F
+{
+	SelfName = "DefaultValue";
+	Owner = "$3F05660E";
+}
+CParticleRendererFeature	$F415EE0A
+{
+	FeatureName = "CastShadows";
+	Feature = "$E0B498C5";
+}
+CParticleNodeTemplateExport	$E0B498C5
+{
+	InputPins = {
+		"$E0B498CF",
+	};
+	OutputPins = {
+		"$033D718A",
+	};
+	ExportedName = "CastShadows";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E0B498CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$E0B498C5";
+}
+CParticleRendererFeature	$41EED1A4
+{
+	FeatureName = "Distortion";
+	Feature = "$9E526218";
+	Properties = {
+		"$0E4E8810",
+		"$BDABEA0C",
+	};
+}
+CParticleNodeTemplateExport	$9E526218
+{
+	InputPins = {
+		"$9E52621F",
+	};
+	OutputPins = {
+		"$4092CA15",
+	};
+	ExportedName = "Distortion";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$9E52621F
+{
+	SelfName = "DefaultValue";
+	Owner = "$9E526218";
+}
+CParticleNodeTemplateExport	$0E4E8810
+{
+	Description = {
+		"@eng:Distortion texture map:\\n<ul>\\n<li><b>RG</b>: 2D screenspace distortion vector for the side & up screen axes. The zero vector is <c>{0.5, 0.5}</c>, like a normalmap</li>\\n<li><b>B</b>: Blur factor (not all integrations support this)</li>\\n<li><b>A</b>: Unused</li>\\n</ul>\\n",
+	};
+	InputPins = {
+		"$0E4E881F",
+	};
+	OutputPins = {
+		"$727E77FC",
+	};
+	ExportedName = "Distortion.DistortionMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Distortion",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Distort.dds";
+}
+CParticleNodePinIn	$0E4E881F
+{
+	SelfName = "DefaultValue";
+	Owner = "$0E4E8810";
+}
+CParticleNodeTemplateExport	$BDABEA0C
+{
+	Description = {
+		"@eng:Distortion coefficient. It gets multiplied with the distortion texture to get the final distortion vectors.",
+	};
+	InputPins = {
+		"$BDABEA0F",
+	};
+	OutputPins = {
+		"$2496386F",
+	};
+	ExportedName = "Distortion.Color";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	CategoryName = {
+		"@eng:Distortion",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$BDABEA0F
+{
+	SelfName = "DefaultValue";
+	Owner = "$BDABEA0C";
+}
+CParticleRendererFeature	$62BCE275
+{
+	FeatureName = "CorrectDeformation";
+	Feature = "$7CB97F8A";
+}
+CParticleNodeTemplateExport	$7CB97F8A
+{
+	InputPins = {
+		"$7CB97F8F",
+	};
+	OutputPins = {
+		"$F686F85E",
+	};
+	ExportedName = "CorrectDeformation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$7CB97F8F
+{
+	SelfName = "DefaultValue";
+	Owner = "$7CB97F8A";
+}
+CParticleRendererFeature	$0CD860BD
+{
+	FeatureName = "AlphaRemap";
+	Feature = "$FF1A9FA2";
+	Properties = {
+		"$371F2116",
+		"$C861FC98",
+	};
+}
+CParticleNodeTemplateExport	$FF1A9FA2
+{
+	InputPins = {
+		"$FF1A9FAF",
+	};
+	OutputPins = {
+		"$0208AF79",
+	};
+	ExportedName = "AlphaRemap";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$FF1A9FAF
+{
+	SelfName = "DefaultValue";
+	Owner = "$FF1A9FA2";
+}
+CParticleNodeTemplateExport	$371F2116
+{
+	Description = {
+		"@eng:Texture map used as the alpha remap lookup.\\nThe <c>X</c> lookup coordinate is the diffuse texture alpha.\\nThe <c>Y</c> lookup coordinate is the <c>Cursor</c> value.",
+	};
+	InputPins = {
+		"$371F211F",
+	};
+	OutputPins = {
+		"$9AA1D730",
+	};
+	ExportedName = "AlphaRemap.AlphaMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:AlphaRemap",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Default_AlphaMap.dds";
+}
+CParticleNodePinIn	$371F211F
+{
+	SelfName = "DefaultValue";
+	Owner = "$371F2116";
+}
+CParticleNodeTemplateExport	$C861FC98
+{
+	Description = {
+		"@eng:<c>Y</c> coordinate used to sample the <c>AlphaMap</c> texture.",
+	};
+	InputPins = {
+		"$C861FC9F",
+	};
+	OutputPins = {
+		"$6964ADB3",
+	};
+	ExportedName = "AlphaRemap.Cursor";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:AlphaRemap",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$C861FC9F
+{
+	SelfName = "DefaultValue";
+	Owner = "$C861FC98";
+}
+CParticleRendererFeature	$DADBF2F1
+{
+	FeatureName = "Atlas";
+	Feature = "$E22E94DB";
+	Properties = {
+		"$2D8A7741",
+		"$2E215ABC",
+		"$F580CA43",
+		"$63EBE82E",
+		"$BEDF8936",
+		"$D6DEA348",
+		"$2D0B2651",
+	};
+}
+CParticleNodeTemplateExport	$E22E94DB
+{
+	InputPins = {
+		"$E22E94DF",
+	};
+	OutputPins = {
+		"$100434F2",
+	};
+	ExportedName = "Atlas";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E22E94DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$E22E94DB";
+}
+CParticleNodeTemplateExport	$2D8A7741
+{
+	Description = {
+		"@eng:Atlas source type\\n<ul>\\n<li><b>External</b>: Use a .pkat file to specify the corners of each atlas sub-rectangle in UV space</li>\\n<li><b>Procedural</b>: Specify the number of tiles along the U and V axes</li>\\n</ul>\\n",
+	};
+	InputPins = {
+		"$2D8A774F",
+	};
+	OutputPins = {
+		"$41FD9D9D",
+	};
+	ExportedName = "Atlas.Source";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"External",
+		"Procedural",
+	};
+	DefaultValueI4 = int4(1, 0, 0, 0);
+}
+CParticleNodePinIn	$2D8A774F
+{
+	SelfName = "DefaultValue";
+	Owner = "$2D8A7741";
+}
+CParticleNodeTemplateExport	$2E215ABC
+{
+	Description = {
+		"@eng:Atlas definition (.pkat)",
+	};
+	InputPins = {
+		"$2E215ABF",
+	};
+	OutputPins = {
+		"$45F88E24",
+	};
+	ExportedName = "Atlas.Definition";
+	ExportedType = dataImageAtlas;
+	Type = Input;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "Atlas.Source";
+	RuleFunction = NotEqual;
+}
+CParticleNodePinIn	$2E215ABF
+{
+	SelfName = "DefaultValue";
+	Owner = "$2E215ABC";
+}
+CParticleNodeTemplateExport	$F580CA43
+{
+	Description = {
+		"@eng:Subdivision count",
+	};
+	InputPins = {
+		"$F580CA4F",
+	};
+	OutputPins = {
+		"$81F975B7",
+	};
+	ExportedName = "Atlas.SubDiv";
+	ExportedType = int2;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DefaultValueI4 = int4(1, 1, 1, 1);
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "Atlas.Source";
+	RuleFunction = NotEqual;
+	RuleValue = "1";
+}
+CParticleNodePinIn	$F580CA4F
+{
+	SelfName = "DefaultValue";
+	Owner = "$F580CA43";
+}
+CParticleNodeTemplateExport	$63EBE82E
+{
+	Description = {
+		"@eng:Frame blending type\\n<ul>\\n<li><b>None</b>: No interpolation between frames</li>\\n<li><b>Linear</b>: Linear blending</li>\\n<li><b>MotionVectors</b>: Use the <c>MotionVectorsMap</c> texture as the interpolation vectors to blend between frames</li>\\n</ul>",
+	};
+	InputPins = {
+		"$63EBE82F",
+	};
+	OutputPins = {
+		"$3E88DB46",
+	};
+	ExportedName = "Atlas.Blending";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"None",
+		"Linear",
+		"Motion vectors (optical flow)",
+	};
+}
+CParticleNodePinIn	$63EBE82F
+{
+	SelfName = "DefaultValue";
+	Owner = "$63EBE82E";
+}
+CParticleNodeTemplateExport	$2D0B2651
+{
+	Description = {
+		"@eng:Index of the sub-rect to use inside the atlas",
+	};
+	InputPins = {
+		"$2D0B265F",
+	};
+	OutputPins = {
+		"$113E6425",
+	};
+	ExportedName = "Atlas.TextureID";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+}
+CParticleNodePinIn	$2D0B265F
+{
+	SelfName = "DefaultValue";
+	Owner = "$2D0B2651";
+}
+CParticleRendererFeature	$A9934228
+{
+	FeatureName = "Light";
+	Feature = "$D10978FE";
+	Properties = {
+		"$1795DE47",
+	};
+}
+CParticleNodeTemplateExport	$D10978FE
+{
+	InputPins = {
+		"$D10978FF",
+	};
+	OutputPins = {
+		"$C736134C",
+	};
+	ExportedName = "Light";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D10978FF
+{
+	SelfName = "DefaultValue";
+	Owner = "$D10978FE";
+}
+CParticleNodeTemplateExport	$1795DE47
+{
+	Description = {
+		"@eng:Light color",
+	};
+	InputPins = {
+		"$1795DE4F",
+	};
+	OutputPins = {
+		"$189D4DFF",
+	};
+	ExportedName = "Light.Color";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Light",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$1795DE4F
+{
+	SelfName = "DefaultValue";
+	Owner = "$1795DE47";
+}
+CParticleRendererFeature	$A2277B6B
+{
+	FeatureName = "LightAttenuation";
+	Feature = "$C62A1F73";
+	Properties = {
+		"$1EADE0D1",
+		"$761783D3",
+	};
+}
+CParticleNodeTemplateExport	$C62A1F73
+{
+	InputPins = {
+		"$C62A1F7F",
+	};
+	OutputPins = {
+		"$8139F52E",
+	};
+	ExportedName = "LightAttenuation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$C62A1F7F
+{
+	SelfName = "DefaultValue";
+	Owner = "$C62A1F73";
+}
+CParticleNodeTemplateExport	$1EADE0D1
+{
+	Description = {
+		"@eng:Controls how fast the light intensity falls off from the center of the light",
+	};
+	InputPins = {
+		"$1EADE0DF",
+	};
+	OutputPins = {
+		"$0F960489",
+	};
+	ExportedName = "LightAttenuation.AttenuationSteepness";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LightAttenuation",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 5.0000000e-01, 5.0000000e-01, 5.0000000e-01);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$1EADE0DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$1EADE0D1";
+}
+CParticleNodeTemplateExport	$761783D3
+{
+	Description = {
+		"@eng:Radius of the light sphere, in world units. Light intensity falls down to zero on the sphere edge, <c>Radius</c> units away from the light <c>Position</c>",
+	};
+	InputPins = {
+		"$761783DF",
+	};
+	OutputPins = {
+		"$17B04980",
+	};
+	ExportedName = "LightAttenuation.Range";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:LightAttenuation",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$761783DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$761783D3";
+}
+CParticleRendererFeature	$EABBAE94
+{
+	FeatureName = "Sound";
+	Feature = "$7CFB103C";
+	Properties = {
+		"$6818E968",
+		"$725E6552",
+	};
+}
+CParticleNodeTemplateExport	$7CFB103C
+{
+	InputPins = {
+		"$7CFB103F",
+	};
+	OutputPins = {
+		"$C0CC90C2",
+	};
+	ExportedName = "Sound";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$7CFB103F
+{
+	SelfName = "DefaultValue";
+	Owner = "$7CFB103C";
+}
+CParticleNodeTemplateExport	$6818E968
+{
+	Description = {
+		"@eng:Path to the sound to be played",
+	};
+	InputPins = {
+		"$6818E96F",
+	};
+	OutputPins = {
+		"$8D8C3DAD",
+	};
+	ExportedName = "Sound.SoundData";
+	ExportedType = dataAudio;
+	Type = Input;
+	Order = 9;
+	CategoryName = {
+		"@eng:Sound",
+	};
+}
+CParticleNodePinIn	$6818E96F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6818E968";
+}
+CParticleNodeTemplateExport	$725E6552
+{
+	Description = {
+		"@eng:Sound playback volume coefficient",
+	};
+	InputPins = {
+		"$725E655F",
+	};
+	OutputPins = {
+		"$BC2CA774",
+	};
+	ExportedName = "Sound.Volume";
+	ExportedType = float;
+	Type = Input;
+	Order = 10;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Sound",
+	};
+	DefaultValueF4 = float4(5.0000000e-01, 5.0000000e-01, 5.0000000e-01, 5.0000000e-01);
+}
+CParticleNodePinIn	$725E655F
+{
+	SelfName = "DefaultValue";
+	Owner = "$725E6552";
+}
+CParticleRendererFeature	$0E3ACA6C
+{
+	FeatureName = "SoundAttenuation";
+	Feature = "$86A6D721";
+	Properties = {
+		"$C0425F45",
+		"$F158603E",
+	};
+}
+CParticleNodeTemplateExport	$86A6D721
+{
+	InputPins = {
+		"$86A6D72F",
+	};
+	OutputPins = {
+		"$A4D7E147",
+	};
+	ExportedName = "SoundAttenuation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$86A6D72F
+{
+	SelfName = "DefaultValue";
+	Owner = "$86A6D721";
+}
+CParticleNodeTemplateExport	$C0425F45
+{
+	Description = {
+		"@eng:Controls how fast the sound intensity falls off from the source",
+	};
+	InputPins = {
+		"$C0425F4F",
+	};
+	OutputPins = {
+		"$089AE616",
+	};
+	ExportedName = "SoundAttenuation.AttenuationModel";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SoundAttenuation",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Linear",
+		"InverseLinear",
+	};
+}
+CParticleNodePinIn	$C0425F4F
+{
+	SelfName = "DefaultValue";
+	Owner = "$C0425F45";
+}
+CParticleNodeTemplateExport	$F158603E
+{
+	Description = {
+		"@eng:Radius of the sound sphere, in world units. Sound volume falls down to zero on the sphere edge, <c>Radius</c> units away from the sound <c>Position</c>",
+	};
+	InputPins = {
+		"$F158603F",
+	};
+	OutputPins = {
+		"$C4E7D391",
+	};
+	ExportedName = "SoundAttenuation.Range";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:SoundAttenuation",
+	};
+	DefaultValueF4 = float4(1.0000000e+03, 1.0000000e+03, 1.0000000e+03, 1.0000000e+03);
+}
+CParticleNodePinIn	$F158603F
+{
+	SelfName = "DefaultValue";
+	Owner = "$F158603E";
+}
+CParticleRendererFeature	$61D82A82
+{
+	FeatureName = "Doppler";
+	Feature = "$D1AFAA07";
+	Properties = {
+		"$DE4AF925",
+		"$8F92C16F",
+	};
+}
+CParticleNodeTemplateExport	$D1AFAA07
+{
+	InputPins = {
+		"$D1AFAA0F",
+	};
+	OutputPins = {
+		"$EED74128",
+	};
+	ExportedName = "Doppler";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D1AFAA0F
+{
+	SelfName = "DefaultValue";
+	Owner = "$D1AFAA07";
+}
+CParticleNodeTemplateExport	$DE4AF925
+{
+	Description = {
+		"@eng:Controls the strength of the doppler effect",
+	};
+	InputPins = {
+		"$DE4AF92F",
+	};
+	OutputPins = {
+		"$EF48E30B",
+	};
+	ExportedName = "Doppler.DopplerFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Doppler",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$DE4AF92F
+{
+	SelfName = "DefaultValue";
+	Owner = "$DE4AF925";
+}
+CParticleNodeTemplateExport	$8F92C16F
+{
+	Description = {
+		"@eng:Sound source velocity vector in worldspace",
+	};
+	InputPins = {
+		"$8F92C16A",
+	};
+	OutputPins = {
+		"$126F692A",
+	};
+	ExportedName = "Doppler.Velocity";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Doppler",
+	};
+}
+CParticleNodePinIn	$8F92C16A
+{
+	SelfName = "DefaultValue";
+	Owner = "$8F92C16F";
+}
+CParticleRendererFeature	$D481D29F
+{
+	FeatureName = "CustomTextureU";
+	Feature = "$AF3DCC22";
+	Properties = {
+		"$704F64D6",
+	};
+}
+CParticleNodeTemplateExport	$AF3DCC22
+{
+	InputPins = {
+		"$AF3DCC2F",
+	};
+	OutputPins = {
+		"$994A4A35",
+	};
+	ExportedName = "CustomTextureU";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$AF3DCC2F
+{
+	SelfName = "DefaultValue";
+	Owner = "$AF3DCC22";
+}
+CParticleNodeTemplateExport	$704F64D6
+{
+	Description = {
+		"@eng:<c>U</c> texture coordinate of the ribbon particle.\\n\\nUsually set to <c>self.lifeRatio</c>\\n",
+	};
+	InputPins = {
+		"$704F64DF",
+	};
+	OutputPins = {
+		"$576DEA9C",
+	};
+	ExportedName = "CustomTextureU.TextureU";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:CustomTextureU",
+	};
+}
+CParticleNodePinIn	$704F64DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$704F64D6";
+}
+CParticleRendererFeature	$4B99796F
+{
+	FeatureName = "TextureUVs";
+	Feature = "$37DC024B";
+	Properties = {
+		"$C43F52A5",
+		"$0FB78BF6",
+		"$88F8E019",
+	};
+}
+CParticleNodeTemplateExport	$37DC024B
+{
+	InputPins = {
+		"$37DC024F",
+	};
+	OutputPins = {
+		"$3DCB4F8F",
+	};
+	ExportedName = "TextureUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$37DC024F
+{
+	SelfName = "DefaultValue";
+	Owner = "$37DC024B";
+}
+CParticleNodeTemplateExport	$C43F52A5
+{
+	Description = {
+		"@eng:Flips the texture UVs horizontally",
+	};
+	InputPins = {
+		"$C43F52AF",
+	};
+	OutputPins = {
+		"$EB684DFE",
+	};
+	ExportedName = "TextureUVs.FlipU";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:TextureUVs",
+	};
+}
+CParticleNodePinIn	$C43F52AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$C43F52A5";
+}
+CParticleNodeTemplateExport	$0FB78BF6
+{
+	Description = {
+		"@eng:Flips the texture UVs vertically",
+	};
+	InputPins = {
+		"$0FB78BFF",
+	};
+	OutputPins = {
+		"$1653E599",
+	};
+	ExportedName = "TextureUVs.FlipV";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:TextureUVs",
+	};
+}
+CParticleNodePinIn	$0FB78BFF
+{
+	SelfName = "DefaultValue";
+	Owner = "$0FB78BF6";
+}
+CParticleNodeTemplateExport	$88F8E019
+{
+	Description = {
+		"@eng:Rotates texcoords 90 degrees clockwise (TextureU, FlipU, and FlipV are rotated too)",
+	};
+	InputPins = {
+		"$88F8E01F",
+	};
+	OutputPins = {
+		"$923437D0",
+	};
+	ExportedName = "TextureUVs.RotateTexture";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:TextureUVs",
+	};
+}
+CParticleNodePinIn	$88F8E01F
+{
+	SelfName = "DefaultValue";
+	Owner = "$88F8E019";
+}
+CParticleRendererFeature	$4B44F286
+{
+	FeatureName = "FlipUVs";
+	Feature = "$FE7E5C02";
+}
+CParticleNodeTemplateExport	$FE7E5C02
+{
+	InputPins = {
+		"$FE7E5C0F",
+	};
+	OutputPins = {
+		"$FD604AD3",
+	};
+	ExportedName = "FlipUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$FE7E5C0F
+{
+	SelfName = "DefaultValue";
+	Owner = "$FE7E5C02";
+}
+CParticleRendererFeature	$E7A7BE8E
+{
+	FeatureName = "TextureRepeat";
+	Feature = "$FC4DE60A";
+}
+CParticleNodeTemplateExport	$FC4DE60A
+{
+	InputPins = {
+		"$FC4DE60F",
+	};
+	OutputPins = {
+		"$EA4B8892",
+	};
+	ExportedName = "TextureRepeat";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$FC4DE60F
+{
+	SelfName = "DefaultValue";
+	Owner = "$FC4DE60A";
+}
+CParticleRendererFeature	$D4EA65F0
+{
+	FeatureName = "ShaderInput0";
+	Feature = "$4FBCF4A3";
+	Properties = {
+		"$6DA71F10",
+	};
+}
+CParticleNodeTemplateExport	$4FBCF4A3
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter0 in UE4",
+	};
+	InputPins = {
+		"$4FBCF4AF",
+	};
+	OutputPins = {
+		"$BA87A9BD",
+	};
+	ExportedName = "ShaderInput0";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4FBCF4AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$4FBCF4A3";
+}
+CParticleNodeTemplateExport	$6DA71F10
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter0 in UE4",
+	};
+	InputPins = {
+		"$6DA71F1F",
+	};
+	OutputPins = {
+		"$22A77CC4",
+	};
+	ExportedName = "ShaderInput0.Input0";
+	ExportedType = float4;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:ShaderInput0",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$6DA71F1F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6DA71F10";
+}
+CParticleRendererFeature	$052CEED2
+{
+	FeatureName = "ShaderInput1";
+	Feature = "$79D6D712";
+	Properties = {
+		"$C1777DC9",
+	};
+}
+CParticleNodeTemplateExport	$79D6D712
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter1 in UE4",
+	};
+	InputPins = {
+		"$79D6D71F",
+	};
+	OutputPins = {
+		"$51E5B8D7",
+	};
+	ExportedName = "ShaderInput1";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$79D6D71F
+{
+	SelfName = "DefaultValue";
+	Owner = "$79D6D712";
+}
+CParticleNodeTemplateExport	$C1777DC9
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter1 in UE4",
+	};
+	InputPins = {
+		"$C1777DCF",
+	};
+	OutputPins = {
+		"$839ACCE6",
+	};
+	ExportedName = "ShaderInput1.Input1";
+	ExportedType = float4;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:ShaderInput1",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$C1777DCF
+{
+	SelfName = "DefaultValue";
+	Owner = "$C1777DC9";
+}
+CParticleRendererFeature	$F20FBF14
+{
+	FeatureName = "ShaderInput2";
+	Feature = "$6C420902";
+	Properties = {
+		"$15A65D09",
+	};
+}
+CParticleNodeTemplateExport	$6C420902
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter2 in UE4",
+	};
+	InputPins = {
+		"$6C42090F",
+	};
+	OutputPins = {
+		"$12EF5AA1",
+	};
+	ExportedName = "ShaderInput2";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$6C42090F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6C420902";
+}
+CParticleNodeTemplateExport	$15A65D09
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter2 in UE4",
+	};
+	InputPins = {
+		"$15A65D0F",
+	};
+	OutputPins = {
+		"$A5F2CD78",
+	};
+	ExportedName = "ShaderInput2.Input2";
+	ExportedType = float4;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:ShaderInput2",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$15A65D0F
+{
+	SelfName = "DefaultValue";
+	Owner = "$15A65D09";
+}
+CParticleRendererFeature	$4AF71D41
+{
+	FeatureName = "ShaderInput3";
+	Feature = "$55D031E8";
+	Properties = {
+		"$25F3E2DD",
+	};
+}
+CParticleNodeTemplateExport	$55D031E8
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter3 in UE4",
+	};
+	InputPins = {
+		"$55D031EF",
+	};
+	OutputPins = {
+		"$3F9A3D9B",
+	};
+	ExportedName = "ShaderInput3";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$55D031EF
+{
+	SelfName = "DefaultValue";
+	Owner = "$55D031E8";
+}
+CParticleNodeTemplateExport	$25F3E2DD
+{
+	Description = {
+		"@eng:Data sent to the shader, remaps to DynamicParameter3 in UE4",
+	};
+	InputPins = {
+		"$25F3E2DF",
+	};
+	OutputPins = {
+		"$2F678EFA",
+	};
+	ExportedName = "ShaderInput3.Input3";
+	ExportedType = float4;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:ShaderInput3",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$25F3E2DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$25F3E2DD";
+}
+CParticleRendererFeature	$DDECD857
+{
+	FeatureName = "LegacyLit";
+	Feature = "$FE14B3C9";
+	Properties = {
+		"$6CCCA72A",
+		"$C5163AA2",
+		"$5A5BD1DE",
+		"$B014C0B6",
+		"$FAC5D9D8",
+		"$94DB7335",
+		"$43290D5A",
+	};
+}
+CParticleNodeTemplateExport	$FE14B3C9
+{
+	InputPins = {
+		"$FE14B3CF",
+	};
+	OutputPins = {
+		"$6C5BA959",
+	};
+	ExportedName = "LegacyLit";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$FE14B3CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$FE14B3C9";
+}
+CParticleNodeTemplateExport	$43290D5A
+{
+	Description = {
+		"@eng:Source map used in specular lighting computation",
+	};
+	InputPins = {
+		"$43290D5F",
+	};
+	OutputPins = {
+		"$DD2B8661",
+	};
+	ExportedName = "LegacyLit.SpecularMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Black.dds";
+}
+CParticleNodePinIn	$43290D5F
+{
+	SelfName = "DefaultValue";
+	Owner = "$43290D5A";
+}
+CParticleNodeTemplateExport	$5A5BD1DE
+{
+	Description = {
+		"@eng:Exponentiation of the lighting term",
+	};
+	InputPins = {
+		"$5A5BD1DF",
+	};
+	OutputPins = {
+		"$9C42C17D",
+	};
+	ExportedName = "LegacyLit.LightExponent";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+	MinValueF4 = float4(9.9999998e-03, 9.9999998e-03, 9.9999998e-03, 9.9999998e-03);
+	MaxValueF4 = float4(8.0000000e+00, 8.0000000e+00, 8.0000000e+00, 8.0000000e+00);
+}
+CParticleNodePinIn	$5A5BD1DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$5A5BD1DE";
+}
+CParticleNodeTemplateExport	$B014C0B6
+{
+	Description = {
+		"@eng:Multiplier applied to the incoming light",
+	};
+	InputPins = {
+		"$B014C0BF",
+	};
+	OutputPins = {
+		"$AFB08F84",
+	};
+	ExportedName = "LegacyLit.LightScale";
+	ExportedType = float3;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$B014C0BF
+{
+	SelfName = "DefaultValue";
+	Owner = "$B014C0B6";
+}
+CParticleNodeTemplateExport	$FAC5D9D8
+{
+	Description = {
+		"@eng:Additional uniform light",
+	};
+	InputPins = {
+		"$FAC5D9DF",
+	};
+	OutputPins = {
+		"$E406E297",
+	};
+	ExportedName = "LegacyLit.AmbientLight";
+	ExportedType = float3;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+}
+CParticleNodePinIn	$FAC5D9DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$FAC5D9D8";
+}
+CParticleNodeTemplateExport	$6CCCA72A
+{
+	Description = {
+		"@eng:Texture map representing tangent-space normals to be used for lighting",
+	};
+	InputPins = {
+		"$6CCCA72F",
+	};
+	OutputPins = {
+		"$09F16690",
+	};
+	ExportedName = "LegacyLit.NormalMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/NMap_Flat.dds";
+}
+CParticleNodePinIn	$6CCCA72F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6CCCA72A";
+}
+CParticleNodeTemplateExport	$C5163AA2
+{
+	Description = {
+		"@eng:Remap the <c>n dot l</c> of the lighting equation from <c>[-1,1]<c> to <c>[-1+factor,1]</c>",
+	};
+	InputPins = {
+		"$C5163AAF",
+	};
+	OutputPins = {
+		"$5A435152",
+	};
+	ExportedName = "LegacyLit.NormalWrapFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e-01, 1.0000000e-01, 1.0000000e-01, 1.0000000e-01);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$C5163AAF
+{
+	SelfName = "DefaultValue";
+	Owner = "$C5163AA2";
+}
+CParticleNodeTemplateExport	$94DB7335
+{
+	Description = {
+		"@eng:Can cast shadows (not implemented in editor)",
+	};
+	InputPins = {
+		"$94DB733F",
+	};
+	OutputPins = {
+		"$A11A59A6",
+	};
+	ExportedName = "LegacyLit.CastShadows";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LegacyLit",
+	};
+}
+CParticleNodePinIn	$94DB733F
+{
+	SelfName = "DefaultValue";
+	Owner = "$94DB7335";
+}
+CParticleRendererFeature	$123456AC
+{
+	FeatureName = "Lit";
+	Feature = "$FAFAFAB0";
+	Properties = {
+		"$6CCCA72B",
+		"$94DB7334",
+		"$C7760457",
+		"$C7760456",
+		"$43290D5D",
+		"$5928161E",
+		"$E31D7A62",
+	};
+}
+CParticleNodeTemplateExport	$FAFAFAB0
+{
+	InputPins = {
+		"$862FBE70",
+	};
+	OutputPins = {
+		"$53613D1F",
+	};
+	ExportedName = "Lit";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$862FBE70
+{
+	SelfName = "DefaultValue";
+	Owner = "$FAFAFAB0";
+}
+CParticleNodeTemplateExport	$6CCCA72B
+{
+	Description = {
+		"@eng:Texture map representing tangent-space normals to be used for lighting",
+	};
+	InputPins = {
+		"$6CCCA72E",
+	};
+	OutputPins = {
+		"$54E702CE",
+	};
+	ExportedName = "Lit.NormalMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/NMap_Flat.dds";
+}
+CParticleNodePinIn	$6CCCA72E
+{
+	SelfName = "DefaultValue";
+	Owner = "$6CCCA72B";
+}
+CParticleNodeTemplateExport	$94DB7334
+{
+	Description = {
+		"@eng:Can cast shadows",
+	};
+	InputPins = {
+		"$94DB733E",
+	};
+	OutputPins = {
+		"$C71AA220",
+	};
+	ExportedName = "Lit.CastShadows";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+}
+CParticleNodePinIn	$94DB733E
+{
+	SelfName = "DefaultValue";
+	Owner = "$94DB7334";
+}
+CParticleNodeTemplateExport	$C7760456
+{
+	Description = {
+		"@eng:Material metalness (PBR). A metalness of <c>0.0</c> represents a pure nonmetal, a metalness of <c>1.0</c> represents a pure metal.\\n\\nAffects the color of the reflections.",
+	};
+	InputPins = {
+		"$FF012345",
+	};
+	OutputPins = {
+		"$EFC61C62",
+	};
+	ExportedName = "Lit.Metalness";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$FF012345
+{
+	SelfName = "DefaultValue";
+	Owner = "$C7760456";
+}
+CParticleNodeTemplateExport	$C7760457
+{
+	Description = {
+		"@eng:Material roughness (PBR). A roughness of <c>0.0</c> represents a mirror, a roughness of <c>1.0</c> represents a purely diffuse surface.",
+	};
+	InputPins = {
+		"$FF012346",
+	};
+	OutputPins = {
+		"$ADC6DB63",
+	};
+	ExportedName = "Lit.Roughness";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e+00, 5.0000000e-01, 5.0000000e-01, 5.0000000e-01);
+	MinValueF4 = float4(0.0000000e+00, 4.9999997e-02, 4.9999997e-02, 4.9999997e-02);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$FF012346
+{
+	SelfName = "DefaultValue";
+	Owner = "$C7760457";
+}
+CParticleNodeTemplateExport	$43290D5D
+{
+	Description = {
+		"@eng:Roughness (R) and Metalness (G) packed in an RGBA texture",
+	};
+	InputPins = {
+		"$43290FFF",
+	};
+	OutputPins = {
+		"$9B18E1CD",
+	};
+	ExportedName = "Lit.RoughMetalMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodePinIn	$43290FFF
+{
+	SelfName = "DefaultValue";
+	Owner = "$43290D5D";
+}
+CParticleRendererFeature	$D834E0C1
+{
+	FeatureName = "LightTranslucent";
+	Feature = "$D4A7787E";
+}
+CParticleNodeTemplateExport	$D4A7787E
+{
+	InputPins = {
+		"$D4A7787F",
+	};
+	OutputPins = {
+		"$D98FE643",
+	};
+	ExportedName = "LightTranslucent";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D4A7787F
+{
+	SelfName = "DefaultValue";
+	Owner = "$D4A7787E";
+}
+CParticleRendererFeature	$A2ABAB94
+{
+	FeatureName = "SphereLight";
+	Feature = "$C62A9438";
+	Properties = {
+		"$1EBCBC73",
+	};
+}
+CParticleNodeTemplateExport	$1EBCBC73
+{
+	Description = {
+		"@eng:Controls the radius of the light sphere",
+	};
+	InputPins = {
+		"$BFABFA46",
+	};
+	OutputPins = {
+		"$D922FDEC",
+	};
+	ExportedName = "AreaLight.SphereRadius";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:AreaLight",
+	};
+	HasMin = true;
+}
+CParticleNodePinIn	$BFABFA46
+{
+	SelfName = "DefaultValue";
+	Owner = "$1EBCBC73";
+}
+CParticleNodeTemplateExport	$C62A9438
+{
+	InputPins = {
+		"$CFAFBC75",
+	};
+	OutputPins = {
+		"$EB7F7C45",
+	};
+	ExportedName = "SphereLight";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$CFAFBC75
+{
+	SelfName = "DefaultValue";
+	Owner = "$C62A9438";
+}
+CParticleRendererFeature	$D857A09F
+{
+	FeatureName = "NormalWrap";
+	Feature = "$35A36C4E";
+	Properties = {
+		"$EAC726E3",
+	};
+}
+CParticleNodeTemplateExport	$35A36C4E
+{
+	InputPins = {
+		"$4B933A29",
+	};
+	OutputPins = {
+		"$32460E14",
+	};
+	ExportedName = "NormalWrap";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4B933A29
+{
+	SelfName = "DefaultValue";
+	Owner = "$35A36C4E";
+}
+CParticleNodeTemplateExport	$EAC726E3
+{
+	Description = {
+		"@eng:Fake sub-surface scattering on the particles by remapping the <c>N.L</c> in the lighting equation",
+	};
+	InputPins = {
+		"$14C3FC67",
+	};
+	OutputPins = {
+		"$633D8FB6",
+	};
+	ExportedName = "NormalWrap.WrapFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:NormalWrap",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CRHIRenderingSettings	$6DF50834
+{
+	RenderingFeatures = {
+		"$EA67A6E3",
+		"$3B49B5AD",
+		"$3E516D6B",
+		"$5DB3D227",
+		"$18A9F8AD",
+		"$85A347AD",
+		"$43951B1E",
+		"$8BECA4C6",
+		"$C9C644C8",
+		"$7FCFBFA6",
+		"$0B924B6C",
+		"$255BA3AA",
+		"$255BA3AB",
+		"$255BA3AC",
+		"$255BA3AD",
+		"$00269EC3",
+		"$69D57342",
+		"$F57D922D",
+		"$AA1655F4",
+		"$AB93F1C7",
+		"$CF880096",
+		"$C9F5C011",
+		"$B34D67A8",
+		"$28CECB8B",
+		"$347F3BAA",
+		"$0A554EB5",
+		"$029B091C",
+		"$1057900F",
+		"$F551587E",
+		"$0B148219",
+		"$41FACE50",
+		"$93476353",
+		"$F2BC4B12",
+		"$200E5E3D",
+		"$49220B44",
+		"$22142957",
+		"$1DB9C766",
+		"$FDD3ABF7",
+		"$1749C465",
+		"$05539FDC",
+		"$AF299513",
+		"$FB490026",
+		"$81E53C85",
+		"$16512360",
+		"$DD26542E",
+		"$A2DFDBD4",
+	};
+}
+CRHIRenderingFeature	$EA67A6E3
+{
+	FeatureName = "Lit";
+	UseUV = true;
+	UseNormal = true;
+	UseTangent = true;
+	UseSceneLightingInfo = true;
+	PropertiesAsShaderConstants = {
+		"RoughMetalMap",
+		"NormalMap",
+		"LitMaskMap",
+		"Metalness",
+		"Roughness",
+		"Type",
+	};
+	TexturesUsedAsLookUp = {
+		"RoughMetalMap",
+		"NormalMap",
+	};
+}
+CRHIRenderingFeature	$3B49B5AD
+{
+	FeatureName = "NormalWrap";
+	PropertiesAsShaderConstants = {
+		"WrapFactor",
+	};
+}
+CRHIRenderingFeature	$3E516D6B
+{
+	FeatureName = "LegacyLit";
+	UseUV = true;
+	UseNormal = true;
+	UseTangent = true;
+	UseSceneLightingInfo = true;
+	PropertiesAsShaderConstants = {
+		"SpecularMap",
+		"NormalMap",
+		"NormalWrapFactor",
+		"LightExponent",
+		"LightScale",
+		"AmbientLight",
+	};
+	TexturesUsedAsLookUp = {
+		"SpecularMap",
+		"NormalMap",
+	};
+}
+CRHIRenderingFeature	$5DB3D227
+{
+	FeatureName = "Opaque";
+	UseUV = true;
+	UseNormal = true;
+	UseTangent = true;
+	PropertiesAsShaderConstants = {
+		"Type",
+		"MaskThreshold",
+	};
+}
+CRHIRenderingFeature	$18A9F8AD
+{
+	FeatureName = "Diffuse";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"Color",
+		"DiffuseMap",
+	};
+}
+CRHIRenderingFeature	$85A347AD
+{
+	FeatureName = "Atlas";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"Blending",
+		"MotionVectorsMap",
+		"DistortionStrength",
+		"SubDiv",
+	};
+}
+CRHIRenderingFeature	$43951B1E
+{
+	FeatureName = "SoftParticles";
+	SampleDepth = true;
+	PropertiesAsShaderConstants = {
+		"SoftnessDistance",
+	};
+}
+CRHIRenderingFeature	$8BECA4C6
+{
+	FeatureName = "Distortion";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"DistortionMap",
+	};
+	TexturesUsedAsLookUp = {
+		"DistortionMap",
+	};
+}
+CRHIRenderingFeature	$C9C644C8
+{
+	FeatureName = "AlphaRemap";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"AlphaMap",
+	};
+	TexturesUsedAsLookUp = {
+		"AlphaMap",
+	};
+}
+CRHIRenderingFeature	$7FCFBFA6
+{
+	FeatureName = "TextureUVs";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"RotateTexture",
+	};
+}
+CRHIRenderingFeature	$0B924B6C
+{
+	FeatureName = "Light";
+	SampleDepth = true;
+	SampleNormalRoughMetal = true;
+	SampleDiffuse = true;
+}
+CRHIRenderingFeature	$255BA3AA
+{
+	FeatureName = "LightAttenuation";
+	PropertiesAsShaderConstants = {
+		"AttenuationSteepness",
+	};
+}
+CRHIRenderingFeature	$EBBBBB52
+{
+	FeatureName = "SphereLight";
+	PropertiesAsShaderConstants = {
+		"SphereRadius",
+	};
+}
+CRHIRenderingFeature	$255BA3AB
+{
+	FeatureName = "DiffuseRamp";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"RampMap",
+	};
+}
+CRHIRenderingFeature	$255BA3AC
+{
+	FeatureName = "Emissive";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"Color",
+		"EmissiveMap",
+	};
+}
+CRHIRenderingFeature	$255BA3AD
+{
+	FeatureName = "EmissiveRamp";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"RampMap",
+	};
+}
+CParticleRendererFeature	$9154DFA0
+{
+	FeatureName = "MeshAtlas";
+	Feature = "$4ADE8DE2";
+	Properties = {
+		"$2909A531",
+	};
+}
+CParticleNodeTemplateExport	$4ADE8DE2
+{
+	InputPins = {
+		"$D279714D",
+	};
+	OutputPins = {
+		"$5F621394",
+	};
+	ExportedName = "MeshAtlas";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D279714D
+{
+	SelfName = "DefaultValue";
+	Owner = "$4ADE8DE2";
+}
+CParticleNodePinOut	$5F621394
+{
+	SelfName = "Value";
+	Owner = "$4ADE8DE2";
+}
+CParticleNodeTemplateExport	$2909A531
+{
+	Description = {
+		"@eng:Index of the sub-mesh to draw when the mesh resource contains multiple sub-meshes.",
+	};
+	InputPins = {
+		"$AAA4EDB1",
+	};
+	OutputPins = {
+		"$0E0F55C8",
+	};
+	ExportedName = "General.MeshID";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+	HasMin = true;
+}
+CParticleNodeTemplateExport	$41B5AFE7
+{
+	Description = {
+		"@eng:Opacity mask threshold value.\\nIf the alpha value is below this value, the pixel is discarded.",
+	};
+	InputPins = {
+		"$773A578E",
+	};
+	OutputPins = {
+		"$4272E669",
+	};
+	ExportedName = "Opaque.MaskThreshold";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(6.9999999e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Opaque.Type";
+	RuleValue = "1";
+}
+CParticleNodeTemplateExport	$41E5AFE7
+{
+	Description = {
+		"@eng:When enabled, the billboard size is specified as a <c>float2</c> value, through the <c>Size2</c> property, instead of the <c>Size</c> property.",
+	};
+	InputPins = {
+		"$78A74806",
+	};
+	OutputPins = {
+		"$AF09E441",
+	};
+	ExportedName = "General.EnableSize2D";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodeTemplateExport	$BEEF8936
+{
+	Description = {
+		"@eng:2D side/up radius of the billboard in world units.\\nOnly available when <c>EnableSize2D</c> is enabled.",
+	};
+	InputPins = {
+		"$B4F3323B",
+	};
+	OutputPins = {
+		"$1EA3501A",
+	};
+	ExportedName = "General.Size2";
+	ExportedType = float2;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(5.0000001e-02, 5.0000001e-02, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "General.EnableSize2D";
+	RuleFunction = NotEqual;
+}
+CParticleNodePinOut	$F1356840
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$D0980C03
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$ED80C982
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$0384856D
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$96A2AA34
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$D970BB07
+{
+	SelfName = "Value";
+}
+CParticleRendererFeature	$52697627
+{
+	FeatureName = "DiffuseRamp";
+	Feature = "$256FAC76";
+	Properties = {
+		"$CB2631EB",
+	};
+}
+CParticleNodeTemplateExport	$256FAC76
+{
+	InputPins = {
+		"$173EE971",
+	};
+	OutputPins = {
+		"$122F1C88",
+	};
+	ExportedName = "DiffuseRamp";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$173EE971
+{
+	SelfName = "DefaultValue";
+	Owner = "$256FAC76";
+}
+CParticleNodePinOut	$122F1C88
+{
+	SelfName = "Value";
+	Owner = "$256FAC76";
+}
+CParticleNodeTemplateExport	$CB2631EB
+{
+	Description = {
+		"@eng:1D texture map used tor for diffuse color remap.\\nSampled with the <c>Red<c> channel of the <c>DiffuseMap</c> texture.",
+	};
+	InputPins = {
+		"$7042442B",
+	};
+	OutputPins = {
+		"$AEE5D0CA",
+	};
+	ExportedName = "DiffuseRamp.RampMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:DiffuseRamp",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleRendererFeature	$D6BEA348
+{
+	FeatureName = "Emissive";
+	Feature = "$5F44DAAB";
+	Properties = {
+		"$C01E68BC",
+		"$9D2B1A2F",
+	};
+}
+CParticleRendererFeature	$D6EEA348
+{
+	FeatureName = "EnableRendering";
+	Feature = "$5F44DFAB";
+	Properties = {
+		"$C01E62BC",
+	};
+}
+CParticleNodeTemplateExport	$5F44DAAB
+{
+	InputPins = {
+		"$D809D24A",
+	};
+	OutputPins = {
+		"$D03459D5",
+	};
+	ExportedName = "Emissive";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D809D24A
+{
+	SelfName = "DefaultValue";
+	Owner = "$5F44DAAB";
+}
+CParticleNodePinOut	$D03459D5
+{
+	SelfName = "Value";
+	Owner = "$5F44DAAB";
+}
+CParticleNodeTemplateExport	$5F44DFAB
+{
+	InputPins = {
+		"$D806D24A",
+	};
+	OutputPins = {
+		"$D03359D5",
+	};
+	ExportedName = "EnableRendering";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D806D24A
+{
+	SelfName = "DefaultValue";
+	Owner = "$5F44DFAB";
+}
+CParticleNodePinOut	$D03359D5
+{
+	SelfName = "Value";
+	Owner = "$5F44DFAB";
+}
+CParticleNodeTemplateExport	$C01E68BC
+{
+	Description = {
+		"@eng:Texture map used for the emissive lighting component",
+	};
+	InputPins = {
+		"$DD66FA55",
+	};
+	OutputPins = {
+		"$9C124D3C",
+	};
+	ExportedName = "Emissive.EmissiveMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Emissive",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodeTemplateExport	$9D2B1A2F
+{
+	Description = {
+		"@eng:Emissive color, multiplied with the emissive texture",
+	};
+	InputPins = {
+		"$D56016AF",
+	};
+	OutputPins = {
+		"$F94B139E",
+	};
+	ExportedName = "Emissive.EmissiveColor";
+	ExportedType = float3;
+	Semantic = Color;
+	Type = Input;
+	CategoryName = {
+		"@eng:Emissive",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleRendererFeature	$55289D1E
+{
+	FeatureName = "EmissiveRamp";
+	Feature = "$EC84D339";
+	Properties = {
+		"$89E0DDB2",
+	};
+}
+CParticleNodeTemplateExport	$EC84D339
+{
+	InputPins = {
+		"$2BBAE5F0",
+	};
+	OutputPins = {
+		"$14978373",
+	};
+	ExportedName = "EmissiveRamp";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$2BBAE5F0
+{
+	SelfName = "DefaultValue";
+	Owner = "$EC84D339";
+}
+CParticleNodePinOut	$14978373
+{
+	SelfName = "Value";
+	Owner = "$EC84D339";
+}
+CParticleNodeTemplateExport	$89E0DDB2
+{
+	Description = {
+		"@eng:1D texture map used tor for emissive color remap.\\nSampled with the <c>Red<c> channel of the <c>EmissiveMap</c> texture.",
+	};
+	InputPins = {
+		"$7E054BB9",
+	};
+	OutputPins = {
+		"$81108870",
+	};
+	ExportedName = "EmissiveRamp.RampMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:EmissiveRamp",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodeTemplateExport	$C01E62BC
+{
+	Description = {
+		"@eng:Controls if the renderer is enabled or disabled.\\nIf <c>true</c>, the particle will be drawn, if <c>false</c>, it won\'t.",
+	};
+	InputPins = {
+		"$AF0F155D",
+	};
+	OutputPins = {
+		"$DBE780E4",
+	};
+	ExportedName = "General.Enabled";
+	ExportedType = bool;
+	Semantic = Visibility;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueB4 = bool4(true, false, false, false);
+}
+CRHIRenderingFeature	$00269EC3
+{
+	FeatureName = "GeometryBillboard";
+}
+CRHIRenderingFeature	$69D57342
+{
+	FeatureName = "GeometryRibbon";
+}
+CRHIRenderingFeature	$F57D922D
+{
+	FeatureName = "GeometryMesh";
+}
+CRHIRenderingFeature	$AA1655F4
+{
+	FeatureName = "GeometryLight";
+}
+CRHIRenderingFeature	$AB93F1C7
+{
+	FeatureName = "GeometrySound";
+}
+CRHIRenderingFeature	$CF880096
+{
+	FeatureName = "Transparent";
+	PropertiesAsShaderConstants = {
+		"Type",
+	};
+}
+CRHIRenderingFeature	$C9F5C011
+{
+	FeatureName = "CastShadows";
+}
+CRHIRenderingFeature	$B34D67A8
+{
+	FeatureName = "CorrectDeformation";
+}
+CRHIRenderingFeature	$28CECB8B
+{
+	FeatureName = "Sound";
+}
+CRHIRenderingFeature	$347F3BAA
+{
+	FeatureName = "SoundAttenuation";
+}
+CRHIRenderingFeature	$0A554EB5
+{
+	FeatureName = "Doppler";
+}
+CRHIRenderingFeature	$029B091C
+{
+	FeatureName = "CustomTextureU";
+}
+CRHIRenderingFeature	$1057900F
+{
+	FeatureName = "FlipUVs";
+}
+CRHIRenderingFeature	$F551587E
+{
+	FeatureName = "TextureRepeat";
+}
+CRHIRenderingFeature	$0B148219
+{
+	FeatureName = "ShaderInput0";
+}
+CRHIRenderingFeature	$41FACE50
+{
+	FeatureName = "ShaderInput1";
+}
+CRHIRenderingFeature	$93476353
+{
+	FeatureName = "ShaderInput2";
+}
+CRHIRenderingFeature	$F2BC4B12
+{
+	FeatureName = "ShaderInput3";
+}
+CRHIRenderingFeature	$200E5E3D
+{
+	FeatureName = "LightTranslucent";
+}
+CRHIRenderingFeature	$49220B44
+{
+	FeatureName = "SphereLight";
+}
+CRHIRenderingFeature	$22142957
+{
+	FeatureName = "MeshAtlas";
+}
+CRHIRenderingFeature	$1DB9C766
+{
+	FeatureName = "EnableRendering";
+}
+CParticleNodeTemplateExport	$BEDF8936
+{
+	Description = {
+		"@eng:Motion vectors texture, used to blend between frames when <c>Blending</c> is set to <c>MotionVectors</c>",
+	};
+	InputPins = {
+		"$8D355881",
+	};
+	OutputPins = {
+		"$CEEFB0D8",
+	};
+	ExportedName = "Atlas.MotionVectorsMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Distort.dds";
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Atlas.Blending";
+	RuleValue = "2";
+}
+CParticleNodeTemplateExport	$D6DEA348
+{
+	Description = {
+		"@eng:Multiplier over the uv distortion\\nDistortion strength to apply for Houdini exported maps is: <c>-(1.0 / FPS / ColRow)</c>.",
+	};
+	InputPins = {
+		"$77FD347B",
+	};
+	OutputPins = {
+		"$56D85F5A",
+	};
+	ExportedName = "Atlas.DistortionStrength";
+	ExportedType = float2;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Atlas.Blending";
+	RuleValue = "2";
+}
+CParticleNodePinIn	$AF0F155D
+{
+	SelfName = "DefaultValue";
+	Owner = "$C01E62BC";
+}
+CParticleNodePinOut	$DBE780E4
+{
+	SelfName = "Value";
+	Owner = "$C01E62BC";
+}
+CParticleNodePinOut	$1A05FF77
+{
+	SelfName = "Value";
+	Owner = "$48E2E8B7";
+}
+CParticleNodePinIn	$78A74806
+{
+	SelfName = "DefaultValue";
+	Owner = "$41E5AFE7";
+}
+CParticleNodePinOut	$AF09E441
+{
+	SelfName = "Value";
+	Owner = "$41E5AFE7";
+}
+CParticleNodePinOut	$0C954798
+{
+	SelfName = "Value";
+	Owner = "$3B3DDE67";
+}
+CParticleNodePinIn	$B4F3323B
+{
+	SelfName = "DefaultValue";
+	Owner = "$BEEF8936";
+}
+CParticleNodePinOut	$1EA3501A
+{
+	SelfName = "Value";
+	Owner = "$BEEF8936";
+}
+CParticleNodePinOut	$7837C3E5
+{
+	SelfName = "Value";
+	Owner = "$F02495CD";
+}
+CParticleNodePinOut	$2FB70E0C
+{
+	SelfName = "Value";
+	Owner = "$CE8CC02E";
+}
+CParticleNodePinOut	$36207FBF
+{
+	SelfName = "Value";
+	Owner = "$6AD0A593";
+}
+CParticleNodePinOut	$E54029EE
+{
+	SelfName = "Value";
+	Owner = "$125C39DB";
+}
+CParticleNodePinOut	$5209F849
+{
+	SelfName = "Value";
+	Owner = "$ECEE2C92";
+}
+CParticleNodePinOut	$A913E2D6
+{
+	SelfName = "Value";
+	Owner = "$C71A50C8";
+}
+CParticleNodePinOut	$17E22F51
+{
+	SelfName = "Value";
+	Owner = "$4703F6C7";
+}
+CParticleNodePinOut	$8EAEE7E8
+{
+	SelfName = "Value";
+	Owner = "$6B1D589C";
+}
+CParticleNodePinOut	$125230CB
+{
+	SelfName = "Value";
+	Owner = "$B6F5CC16";
+}
+CParticleNodePinOut	$F527E9EA
+{
+	SelfName = "Value";
+	Owner = "$49145BE4";
+}
+CParticleNodePinOut	$E7F879F5
+{
+	SelfName = "Value";
+	Owner = "$D4309EA4";
+}
+CParticleNodePinOut	$C45BF55C
+{
+	SelfName = "Value";
+	Owner = "$8B66367E";
+}
+CParticleNodePinOut	$22B8D14F
+{
+	SelfName = "Value";
+	Owner = "$E2583104";
+}
+CParticleNodePinOut	$AAFF12BE
+{
+	SelfName = "Value";
+	Owner = "$203CAA66";
+}
+CParticleNodePinOut	$6C5BA959
+{
+	SelfName = "Value";
+	Owner = "$FE14B3C9";
+}
+CParticleNodePinOut	$09F16690
+{
+	SelfName = "Value";
+	Owner = "$6CCCA72A";
+}
+CParticleNodePinOut	$5A435152
+{
+	SelfName = "Value";
+	Owner = "$C5163AA2";
+}
+CParticleNodePinOut	$9C42C17D
+{
+	SelfName = "Value";
+	Owner = "$5A5BD1DE";
+}
+CParticleNodePinOut	$AFB08F84
+{
+	SelfName = "Value";
+	Owner = "$B014C0B6";
+}
+CParticleNodePinOut	$E406E297
+{
+	SelfName = "Value";
+	Owner = "$FAC5D9D8";
+}
+CParticleNodePinOut	$A11A59A6
+{
+	SelfName = "Value";
+	Owner = "$94DB7335";
+}
+CParticleNodePinOut	$DD2B8661
+{
+	SelfName = "Value";
+	Owner = "$43290D5A";
+}
+CParticleNodePinOut	$1A488438
+{
+	SelfName = "Value";
+	Owner = "$BE4E302C";
+}
+CParticleNodePinOut	$42F2DB5B
+{
+	SelfName = "Value";
+	Owner = "$C78B225F";
+}
+CParticleNodePinOut	$55F99FBA
+{
+	SelfName = "Value";
+	Owner = "$353B08E3";
+}
+CParticleNodePinOut	$C73E7C05
+{
+	SelfName = "Value";
+	Owner = "$9AA9404E";
+}
+CParticleNodePinOut	$ED0A18AC
+{
+	SelfName = "Value";
+	Owner = "$0755FA7C";
+}
+CParticleNodePinOut	$CF350EDF
+{
+	SelfName = "Value";
+	Owner = "$6887733F";
+}
+CParticleNodePinIn	$773A578E
+{
+	SelfName = "DefaultValue";
+	Owner = "$41B5AFE7";
+}
+CParticleNodePinOut	$4272E669
+{
+	SelfName = "Value";
+	Owner = "$41B5AFE7";
+}
+CParticleNodePinOut	$1BDBE0E0
+{
+	SelfName = "Value";
+	Owner = "$3FB45D67";
+}
+CParticleNodePinOut	$84ADA123
+{
+	SelfName = "Value";
+	Owner = "$E32FF502";
+}
+CParticleNodePinOut	$946D7522
+{
+	SelfName = "Value";
+	Owner = "$89BB54AC";
+}
+CParticleNodePinOut	$C072C98D
+{
+	SelfName = "Value";
+	Owner = "$82F1B3B1";
+}
+CParticleNodePinOut	$F8EE30D4
+{
+	SelfName = "Value";
+	Owner = "$3F05660E";
+}
+CParticleNodePinOut	$033D718A
+{
+	SelfName = "Value";
+	Owner = "$E0B498C5";
+}
+CParticleNodePinOut	$4092CA15
+{
+	SelfName = "Value";
+	Owner = "$9E526218";
+}
+CParticleNodePinOut	$727E77FC
+{
+	SelfName = "Value";
+	Owner = "$0E4E8810";
+}
+CParticleNodePinOut	$2496386F
+{
+	SelfName = "Value";
+	Owner = "$BDABEA0C";
+}
+CParticleNodePinOut	$F686F85E
+{
+	SelfName = "Value";
+	Owner = "$7CB97F8A";
+}
+CParticleNodePinOut	$0208AF79
+{
+	SelfName = "Value";
+	Owner = "$FF1A9FA2";
+}
+CParticleNodePinOut	$9AA1D730
+{
+	SelfName = "Value";
+	Owner = "$371F2116";
+}
+CParticleNodePinOut	$6964ADB3
+{
+	SelfName = "Value";
+	Owner = "$C861FC98";
+}
+CParticleNodePinOut	$100434F2
+{
+	SelfName = "Value";
+	Owner = "$E22E94DB";
+}
+CParticleNodePinOut	$41FD9D9D
+{
+	SelfName = "Value";
+	Owner = "$2D8A7741";
+}
+CParticleNodePinOut	$45F88E24
+{
+	SelfName = "Value";
+	Owner = "$2E215ABC";
+}
+CParticleNodePinOut	$81F975B7
+{
+	SelfName = "Value";
+	Owner = "$F580CA43";
+}
+CParticleNodePinOut	$3E88DB46
+{
+	SelfName = "Value";
+	Owner = "$63EBE82E";
+}
+CParticleNodePinIn	$8D355881
+{
+	SelfName = "DefaultValue";
+	Owner = "$BEDF8936";
+}
+CParticleNodePinOut	$CEEFB0D8
+{
+	SelfName = "Value";
+	Owner = "$BEDF8936";
+}
+CParticleNodePinIn	$77FD347B
+{
+	SelfName = "DefaultValue";
+	Owner = "$D6DEA348";
+}
+CParticleNodePinOut	$56D85F5A
+{
+	SelfName = "Value";
+	Owner = "$D6DEA348";
+}
+CParticleNodePinOut	$113E6425
+{
+	SelfName = "Value";
+	Owner = "$2D0B2651";
+}
+CParticleNodePinOut	$C736134C
+{
+	SelfName = "Value";
+	Owner = "$D10978FE";
+}
+CParticleNodePinOut	$189D4DFF
+{
+	SelfName = "Value";
+	Owner = "$1795DE47";
+}
+CParticleNodePinOut	$8139F52E
+{
+	SelfName = "Value";
+	Owner = "$C62A1F73";
+}
+CParticleNodePinOut	$0F960489
+{
+	SelfName = "Value";
+	Owner = "$1EADE0D1";
+}
+CParticleNodePinOut	$17B04980
+{
+	SelfName = "Value";
+	Owner = "$761783D3";
+}
+CParticleNodePinOut	$D98FE643
+{
+	SelfName = "Value";
+	Owner = "$D4A7787E";
+}
+CParticleNodePinOut	$C0CC90C2
+{
+	SelfName = "Value";
+	Owner = "$7CFB103C";
+}
+CParticleNodePinOut	$8D8C3DAD
+{
+	SelfName = "Value";
+	Owner = "$6818E968";
+}
+CParticleNodePinOut	$BC2CA774
+{
+	SelfName = "Value";
+	Owner = "$725E6552";
+}
+CParticleNodePinOut	$A4D7E147
+{
+	SelfName = "Value";
+	Owner = "$86A6D721";
+}
+CParticleNodePinOut	$089AE616
+{
+	SelfName = "Value";
+	Owner = "$C0425F45";
+}
+CParticleNodePinOut	$C4E7D391
+{
+	SelfName = "Value";
+	Owner = "$F158603E";
+}
+CParticleNodePinOut	$EED74128
+{
+	SelfName = "Value";
+	Owner = "$D1AFAA07";
+}
+CParticleNodePinOut	$EF48E30B
+{
+	SelfName = "Value";
+	Owner = "$DE4AF925";
+}
+CParticleNodePinOut	$126F692A
+{
+	SelfName = "Value";
+	Owner = "$8F92C16F";
+}
+CParticleNodePinOut	$994A4A35
+{
+	SelfName = "Value";
+	Owner = "$AF3DCC22";
+}
+CParticleNodePinOut	$576DEA9C
+{
+	SelfName = "Value";
+	Owner = "$704F64D6";
+}
+CParticleNodePinOut	$3DCB4F8F
+{
+	SelfName = "Value";
+	Owner = "$37DC024B";
+}
+CParticleNodePinOut	$EB684DFE
+{
+	SelfName = "Value";
+	Owner = "$C43F52A5";
+}
+CParticleNodePinOut	$1653E599
+{
+	SelfName = "Value";
+	Owner = "$0FB78BF6";
+}
+CParticleNodePinOut	$923437D0
+{
+	SelfName = "Value";
+	Owner = "$88F8E019";
+}
+CParticleNodePinOut	$FD604AD3
+{
+	SelfName = "Value";
+	Owner = "$FE7E5C02";
+}
+CParticleNodePinOut	$EA4B8892
+{
+	SelfName = "Value";
+	Owner = "$FC4DE60A";
+}
+CParticleNodePinOut	$BA87A9BD
+{
+	SelfName = "Value";
+	Owner = "$4FBCF4A3";
+}
+CParticleNodePinOut	$22A77CC4
+{
+	SelfName = "Value";
+	Owner = "$6DA71F10";
+}
+CParticleNodePinOut	$51E5B8D7
+{
+	SelfName = "Value";
+	Owner = "$79D6D712";
+}
+CParticleNodePinOut	$839ACCE6
+{
+	SelfName = "Value";
+	Owner = "$C1777DC9";
+}
+CParticleNodePinOut	$12EF5AA1
+{
+	SelfName = "Value";
+	Owner = "$6C420902";
+}
+CParticleNodePinOut	$A5F2CD78
+{
+	SelfName = "Value";
+	Owner = "$15A65D09";
+}
+CParticleNodePinOut	$3F9A3D9B
+{
+	SelfName = "Value";
+	Owner = "$55D031E8";
+}
+CParticleNodePinOut	$2F678EFA
+{
+	SelfName = "Value";
+	Owner = "$25F3E2DD";
+}
+CParticleNodePinOut	$EB7F7C45
+{
+	SelfName = "Value";
+	Owner = "$C62A9438";
+}
+CParticleNodePinOut	$D922FDEC
+{
+	SelfName = "Value";
+	Owner = "$1EBCBC73";
+}
+CParticleNodePinOut	$53613D1F
+{
+	SelfName = "Value";
+	Owner = "$FAFAFAB0";
+}
+CParticleNodePinOut	$54E702CE
+{
+	SelfName = "Value";
+	Owner = "$6CCCA72B";
+}
+CParticleNodePinOut	$C71AA220
+{
+	SelfName = "Value";
+	Owner = "$94DB7334";
+}
+CParticleNodePinOut	$ADC6DB63
+{
+	SelfName = "Value";
+	Owner = "$C7760457";
+}
+CParticleNodePinOut	$EFC61C62
+{
+	SelfName = "Value";
+	Owner = "$C7760456";
+}
+CParticleNodePinOut	$9B18E1CD
+{
+	SelfName = "Value";
+	Owner = "$43290D5D";
+}
+CParticleNodePinOut	$32460E14
+{
+	SelfName = "Value";
+	Owner = "$35A36C4E";
+}
+CParticleNodePinIn	$14C3FC67
+{
+	SelfName = "DefaultValue";
+	Owner = "$EAC726E3";
+}
+CParticleNodePinOut	$633D8FB6
+{
+	SelfName = "Value";
+	Owner = "$EAC726E3";
+}
+CParticleNodePinIn	$AAA4EDB1
+{
+	SelfName = "DefaultValue";
+	Owner = "$2909A531";
+}
+CParticleNodePinOut	$0E0F55C8
+{
+	SelfName = "Value";
+	Owner = "$2909A531";
+}
+CParticleNodePinIn	$7042442B
+{
+	SelfName = "DefaultValue";
+	Owner = "$CB2631EB";
+}
+CParticleNodePinOut	$AEE5D0CA
+{
+	SelfName = "Value";
+	Owner = "$CB2631EB";
+}
+CParticleNodePinIn	$DD66FA55
+{
+	SelfName = "DefaultValue";
+	Owner = "$C01E68BC";
+}
+CParticleNodePinOut	$9C124D3C
+{
+	SelfName = "Value";
+	Owner = "$C01E68BC";
+}
+CParticleNodePinIn	$D56016AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$9D2B1A2F";
+}
+CParticleNodePinOut	$F94B139E
+{
+	SelfName = "Value";
+	Owner = "$9D2B1A2F";
+}
+CParticleNodePinIn	$7E054BB9
+{
+	SelfName = "DefaultValue";
+	Owner = "$89E0DDB2";
+}
+CParticleNodePinOut	$81108870
+{
+	SelfName = "Value";
+	Owner = "$89E0DDB2";
+}
+CParticleRendererFeature	$047497F3
+{
+	FeatureName = "NormalBend";
+	Feature = "$24414C32";
+	Properties = {
+		"$DEF82E86",
+	};
+}
+CParticleNodeTemplateExport	$24414C32
+{
+	InputPins = {
+		"$CC28E5DD",
+	};
+	OutputPins = {
+		"$E5A55B64",
+	};
+	ExportedName = "NormalBend";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$CC28E5DD
+{
+	SelfName = "DefaultValue";
+	Owner = "$24414C32";
+}
+CParticleNodePinOut	$E5A55B64
+{
+	SelfName = "Value";
+	Owner = "$24414C32";
+}
+CRHIRenderingFeature	$FDD3ABF7
+{
+	FeatureName = "NormalBend";
+}
+CParticleNodeTemplateExport	$DEF82E86
+{
+	Description = {
+		"@eng:Bending factor to apply to the billboard normals.\\n\\n<c>0.0</c> means no bending, the normals will be perpendicular to the billboard quad plane.\\n<c>1.0</c> means fully bent, the normals will be tangent to the billboard quad plane, pointing outwards.",
+	};
+	InputPins = {
+		"$AE218CC1",
+	};
+	OutputPins = {
+		"$76B9DA18",
+	};
+	ExportedName = "NormalBend.NormalBendingFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:NormalBend",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$AE218CC1
+{
+	SelfName = "DefaultValue";
+	Owner = "$DEF82E86";
+}
+CParticleNodePinOut	$76B9DA18
+{
+	SelfName = "Value";
+	Owner = "$DEF82E86";
+}
+CParticleRendererFeature	$23F9C093
+{
+	FeatureName = "TransformUVs";
+	Feature = "$183B52A9";
+	Properties = {
+		"$D9B8D88C",
+		"$9A821802",
+		"$272AD0C9",
+		"$3235C787",
+	};
+}
+CParticleNodeTemplateExport	$183B52A9
+{
+	InputPins = {
+		"$1151F6BB",
+	};
+	OutputPins = {
+		"$69CF2E9A",
+	};
+	ExportedName = "TransformUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$1151F6BB
+{
+	SelfName = "DefaultValue";
+	Owner = "$183B52A9";
+}
+CParticleNodePinOut	$69CF2E9A
+{
+	SelfName = "Value";
+	Owner = "$183B52A9";
+}
+CRHIRenderingFeature	$1749C465
+{
+	FeatureName = "TransformUVs";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"UVOffset",
+		"UVRotate",
+		"UVScale",
+		"RGBOnly",
+	};
+}
+CParticleNodeTemplateExport	$D9B8D88C
+{
+	Description = {
+		"@eng:UV offset",
+	};
+	InputPins = {
+		"$8C88DC3F",
+	};
+	OutputPins = {
+		"$FFE9806E",
+	};
+	ExportedName = "TransformUVs.UVOffset";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+}
+CParticleNodePinIn	$8C88DC3F
+{
+	SelfName = "DefaultValue";
+	Owner = "$D9B8D88C";
+}
+CParticleNodePinOut	$FFE9806E
+{
+	SelfName = "Value";
+	Owner = "$D9B8D88C";
+}
+CParticleNodeTemplateExport	$272AD0C9
+{
+	Description = {
+		"@eng:UV scale",
+	};
+	InputPins = {
+		"$E882EAC0",
+	};
+	OutputPins = {
+		"$EBDA8083",
+	};
+	ExportedName = "TransformUVs.UVScale";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$E882EAC0
+{
+	SelfName = "DefaultValue";
+	Owner = "$272AD0C9";
+}
+CParticleNodePinOut	$EBDA8083
+{
+	SelfName = "Value";
+	Owner = "$272AD0C9";
+}
+CParticleNodeTemplateExport	$9A821802
+{
+	Description = {
+		"@eng:UV rotation angle",
+	};
+	InputPins = {
+		"$C560B5ED",
+	};
+	OutputPins = {
+		"$C92264B4",
+	};
+	ExportedName = "TransformUVs.UVRotate";
+	ExportedType = float;
+	Semantic = Angle;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MinValueF4 = float4(-1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$C560B5ED
+{
+	SelfName = "DefaultValue";
+	Owner = "$9A821802";
+}
+CParticleNodePinOut	$C92264B4
+{
+	SelfName = "Value";
+	Owner = "$9A821802";
+}
+CParticleNodeTemplateExport	$3235C787
+{
+	Description = {
+		"@eng:When enabled, does not transform the UVs used to sample the alpha channel.",
+	};
+	InputPins = {
+		"$81FFA956",
+	};
+	OutputPins = {
+		"$3E3E37D1",
+	};
+	ExportedName = "TransformUVs.RGBOnly";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+}
+CParticleNodePinIn	$81FFA956
+{
+	SelfName = "DefaultValue";
+	Owner = "$3235C787";
+}
+CParticleNodePinOut	$3E3E37D1
+{
+	SelfName = "Value";
+	Owner = "$3235C787";
+}
+CParticleRendererFeature	$B53F5A68
+{
+	FeatureName = "GeometryTriangle";
+	Feature = "$CB9A554B";
+	Properties = {
+		"$8A52D5A3",
+		"$0AA9AB54",
+		"$E17BB1F1",
+	};
+}
+CParticleNodeTemplateExport	$CB9A554B
+{
+	InputPins = {
+		"$E0C8A86A",
+	};
+	OutputPins = {
+		"$2430DA75",
+	};
+	ExportedName = "GeometryTriangle";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E0C8A86A
+{
+	SelfName = "DefaultValue";
+	Owner = "$CB9A554B";
+}
+CParticleNodePinOut	$2430DA75
+{
+	SelfName = "Value";
+	Owner = "$CB9A554B";
+}
+CRHIRenderingFeature	$05539FDC
+{
+	FeatureName = "GeometryTriangle";
+}
+CParticleRendererFeature	$1E5C8DCF
+{
+	FeatureName = "GeometryDecal";
+	Feature = "$4BD7493E";
+	Properties = {
+		"$2C3FF00A",
+		"$17C8B4EF",
+		"$D246F9B0",
+	};
+}
+CParticleNodeTemplateExport	$4BD7493E
+{
+	InputPins = {
+		"$79E4E1D9",
+	};
+	OutputPins = {
+		"$D39EC910",
+	};
+	ExportedName = "GeometryDecal";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$79E4E1D9
+{
+	SelfName = "DefaultValue";
+	Owner = "$4BD7493E";
+}
+CParticleNodePinOut	$D39EC910
+{
+	SelfName = "Value";
+	Owner = "$4BD7493E";
+}
+CRHIRenderingFeature	$AF299513
+{
+	FeatureName = "GeometryDecal";
+	SampleDepth = true;
+}
+CParticleRendererFeature	$F50D7FD2
+{
+	FeatureName = "Decal";
+	Feature = "$E92951FD";
+	Properties = {
+		"$2FD0EE1D",
+		"$BF3541C6",
+		"$6D3178FB",
+	};
+}
+CParticleNodeTemplateExport	$E92951FD
+{
+	InputPins = {
+		"$4ADA2A04",
+	};
+	OutputPins = {
+		"$7BCB4F17",
+	};
+	ExportedName = "Decal";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4ADA2A04
+{
+	SelfName = "DefaultValue";
+	Owner = "$E92951FD";
+}
+CParticleNodePinOut	$7BCB4F17
+{
+	SelfName = "Value";
+	Owner = "$E92951FD";
+}
+CRHIRenderingFeature	$FB490026
+{
+	FeatureName = "Decal";
+	PropertiesAsShaderConstants = {
+		"FadeTop",
+		"FadeBottom",
+		"FadeAngle",
+	};
+}
+CParticleRendererFeature	$8A93EEE1
+{
+	FeatureName = "TriangleCustomNormals";
+	Feature = "$74ACD6B8";
+	Properties = {
+		"$8E7F5DCC",
+		"$9F085D09",
+		"$33E15F42",
+	};
+}
+CParticleNodeTemplateExport	$74ACD6B8
+{
+	InputPins = {
+		"$F0AC5FDB",
+	};
+	OutputPins = {
+		"$0C373E3A",
+	};
+	ExportedName = "TriangleCustomNormals";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$F0AC5FDB
+{
+	SelfName = "DefaultValue";
+	Owner = "$74ACD6B8";
+}
+CParticleNodePinOut	$0C373E3A
+{
+	SelfName = "Value";
+	Owner = "$74ACD6B8";
+}
+CRHIRenderingFeature	$81E53C85
+{
+	FeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeature	$1BDFA32C
+{
+	FeatureName = "TriangleCustomUVs";
+	Feature = "$9D1C2B5F";
+	Properties = {
+		"$31CA6DC7",
+		"$7D2733A8",
+		"$F2EC2AB5",
+	};
+}
+CParticleNodeTemplateExport	$9D1C2B5F
+{
+	InputPins = {
+		"$4BE96E0E",
+	};
+	OutputPins = {
+		"$732C7EE9",
+	};
+	ExportedName = "TriangleCustomUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4BE96E0E
+{
+	SelfName = "DefaultValue";
+	Owner = "$9D1C2B5F";
+}
+CParticleNodePinOut	$732C7EE9
+{
+	SelfName = "Value";
+	Owner = "$9D1C2B5F";
+}
+CRHIRenderingFeature	$16512360
+{
+	FeatureName = "TriangleCustomUVs";
+}
+CParticleNodeTemplateExport	$8A52D5A3
+{
+	Description = {
+		"@eng:Position of the first triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$362883A2",
+	};
+	OutputPins = {
+		"$94ABBA0D",
+	};
+	ExportedName = "General.Position1";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$362883A2
+{
+	SelfName = "DefaultValue";
+	Owner = "$8A52D5A3";
+}
+CParticleNodePinOut	$94ABBA0D
+{
+	SelfName = "Value";
+	Owner = "$8A52D5A3";
+}
+CParticleNodeTemplateExport	$0AA9AB54
+{
+	Description = {
+		"@eng:Position of the second triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$D93542A7",
+	};
+	OutputPins = {
+		"$ED8932F6",
+	};
+	ExportedName = "General.Position2";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$D93542A7
+{
+	SelfName = "DefaultValue";
+	Owner = "$0AA9AB54";
+}
+CParticleNodePinOut	$ED8932F6
+{
+	SelfName = "Value";
+	Owner = "$0AA9AB54";
+}
+CParticleNodeTemplateExport	$E17BB1F1
+{
+	Description = {
+		"@eng:Position of the third triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$85CF4F08",
+	};
+	OutputPins = {
+		"$0AD9166B",
+	};
+	ExportedName = "General.Position3";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$85CF4F08
+{
+	SelfName = "DefaultValue";
+	Owner = "$E17BB1F1";
+}
+CParticleNodePinOut	$0AD9166B
+{
+	SelfName = "Value";
+	Owner = "$E17BB1F1";
+}
+CParticleNodeTemplateExport	$2C3FF00A
+{
+	Description = {
+		"@eng:Decal projection box center in world coordinates",
+	};
+	InputPins = {
+		"$B0EFEA95",
+	};
+	OutputPins = {
+		"$F419E27C",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$B0EFEA95
+{
+	SelfName = "DefaultValue";
+	Owner = "$2C3FF00A";
+}
+CParticleNodePinOut	$F419E27C
+{
+	SelfName = "Value";
+	Owner = "$2C3FF00A";
+}
+CParticleNodeTemplateExport	$17C8B4EF
+{
+	Description = {
+		"@eng:Decal projection box size",
+	};
+	InputPins = {
+		"$CAB4EEDE",
+	};
+	OutputPins = {
+		"$B6BAA7F9",
+	};
+	ExportedName = "General.Scale";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$CAB4EEDE
+{
+	SelfName = "DefaultValue";
+	Owner = "$17C8B4EF";
+}
+CParticleNodePinOut	$B6BAA7F9
+{
+	SelfName = "Value";
+	Owner = "$17C8B4EF";
+}
+CParticleNodeTemplateExport	$D246F9B0
+{
+	Description = {
+		"@eng:Decal projection box orientation",
+	};
+	InputPins = {
+		"$3A074233",
+	};
+	OutputPins = {
+		"$8FD82372",
+	};
+	ExportedName = "General.Orientation";
+	ExportedType = orientation;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$3A074233
+{
+	SelfName = "DefaultValue";
+	Owner = "$D246F9B0";
+}
+CParticleNodePinOut	$8FD82372
+{
+	SelfName = "Value";
+	Owner = "$D246F9B0";
+}
+CParticleNodeTemplateExport	$2FD0EE1D
+{
+	Description = {
+		"@eng:Incorrectly named! Should be <c>FadeBottom</c> !\\n\\nStart of the fade on the bottom section of the decal box volume.\\n<ul>\\n<li><c>1.0</c> starts fading linearly at the box center, all the way to the bottom.</li>\\n<li><c>0.5</c> starts fading linearly halfway between the center and the bottom.</li>\\n<li><c>0.0</c> has no fade and the decal abruptly stops at the bottom of the box.</li>\\n</ul>",
+	};
+	InputPins = {
+		"$2A2DE8A4",
+	};
+	OutputPins = {
+		"$0DD4A237",
+	};
+	ExportedName = "Decal.FadeTop";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Decal",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$2A2DE8A4
+{
+	SelfName = "DefaultValue";
+	Owner = "$2FD0EE1D";
+}
+CParticleNodePinOut	$0DD4A237
+{
+	SelfName = "Value";
+	Owner = "$2FD0EE1D";
+}
+CParticleNodeTemplateExport	$BF3541C6
+{
+	Description = {
+		"@eng:Incorrectly named! Should be <c>FadeTop</c> !\\n\\nStart of the fade on the top section of the decal box volume.\\n<ul>\\n<li><c>1.0</c> starts fading linearly at the box center, all the way to the top.</li>\\n<li><c>0.5</c> starts fading linearly halfway between the center and the top.</li>\\n<li><c>0.0</c> has no fade and the decal abruptly stops at the top of the box.</li>\\n</ul>",
+	};
+	InputPins = {
+		"$C00E8101",
+	};
+	OutputPins = {
+		"$2F33C358",
+	};
+	ExportedName = "Decal.FadeBottom";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Decal",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$C00E8101
+{
+	SelfName = "DefaultValue";
+	Owner = "$BF3541C6";
+}
+CParticleNodePinOut	$2F33C358
+{
+	SelfName = "Value";
+	Owner = "$BF3541C6";
+}
+CParticleNodeTemplateExport	$6D3178FB
+{
+	Description = {
+		"@eng:Reserved, not yet implemented",
+	};
+	InputPins = {
+		"$98C7BDDA",
+	};
+	OutputPins = {
+		"$4499E4A5",
+	};
+	ExportedName = "Decal.FadeAngle";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Decal",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$98C7BDDA
+{
+	SelfName = "DefaultValue";
+	Owner = "$6D3178FB";
+}
+CParticleNodePinOut	$4499E4A5
+{
+	SelfName = "Value";
+	Owner = "$6D3178FB";
+}
+CParticleNodeTemplateExport	$8E7F5DCC
+{
+	Description = {
+		"@eng:Normal of the first triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$2A232A7F",
+	};
+	OutputPins = {
+		"$BE8ECBAE",
+	};
+	ExportedName = "TriangleCustomNormals.Normal1";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+}
+CParticleNodePinIn	$2A232A7F
+{
+	SelfName = "DefaultValue";
+	Owner = "$8E7F5DCC";
+}
+CParticleNodePinOut	$BE8ECBAE
+{
+	SelfName = "Value";
+	Owner = "$8E7F5DCC";
+}
+CParticleNodeTemplateExport	$9F085D09
+{
+	Description = {
+		"@eng:Normal of the second triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$C6ED4C00",
+	};
+	OutputPins = {
+		"$8BB7DAC3",
+	};
+	ExportedName = "TriangleCustomNormals.Normal2";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+}
+CParticleNodePinIn	$C6ED4C00
+{
+	SelfName = "DefaultValue";
+	Owner = "$9F085D09";
+}
+CParticleNodePinOut	$8BB7DAC3
+{
+	SelfName = "Value";
+	Owner = "$9F085D09";
+}
+CParticleNodeTemplateExport	$33E15F42
+{
+	Description = {
+		"@eng:Normal of the third triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$3D41EE2D",
+	};
+	OutputPins = {
+		"$9CC3E1F4",
+	};
+	ExportedName = "TriangleCustomNormals.Normal3";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+}
+CParticleNodePinIn	$3D41EE2D
+{
+	SelfName = "DefaultValue";
+	Owner = "$33E15F42";
+}
+CParticleNodePinOut	$9CC3E1F4
+{
+	SelfName = "Value";
+	Owner = "$33E15F42";
+}
+CParticleNodeTemplateExport	$31CA6DC7
+{
+	Description = {
+		"@eng:UV of the first triangle vertex",
+	};
+	InputPins = {
+		"$6A822C96",
+	};
+	OutputPins = {
+		"$E2255C11",
+	};
+	ExportedName = "TriangleCustomUVs.UV1";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomUVs",
+	};
+}
+CParticleNodePinIn	$6A822C96
+{
+	SelfName = "DefaultValue";
+	Owner = "$31CA6DC7";
+}
+CParticleNodePinOut	$E2255C11
+{
+	SelfName = "Value";
+	Owner = "$31CA6DC7";
+}
+CParticleNodeTemplateExport	$7D2733A8
+{
+	Description = {
+		"@eng:UV of the second triangle vertex",
+	};
+	InputPins = {
+		"$C386878B",
+	};
+	OutputPins = {
+		"$9173A7AA",
+	};
+	ExportedName = "TriangleCustomUVs.UV2";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomUVs",
+	};
+}
+CParticleNodePinIn	$C386878B
+{
+	SelfName = "DefaultValue";
+	Owner = "$7D2733A8";
+}
+CParticleNodePinOut	$9173A7AA
+{
+	SelfName = "Value";
+	Owner = "$7D2733A8";
+}
+CParticleNodeTemplateExport	$F2EC2AB5
+{
+	Description = {
+		"@eng:UV of the third triangle vertex",
+	};
+	InputPins = {
+		"$654D151C",
+	};
+	OutputPins = {
+		"$8CAC8C0F",
+	};
+	ExportedName = "TriangleCustomUVs.UV3";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomUVs",
+	};
+}
+CParticleNodePinIn	$654D151C
+{
+	SelfName = "DefaultValue";
+	Owner = "$F2EC2AB5";
+}
+CParticleNodePinOut	$8CAC8C0F
+{
+	SelfName = "Value";
+	Owner = "$F2EC2AB5";
+}
+CParticleRendererFeature	$5CBB6243
+{
+	FeatureName = "Tint";
+	Feature = "$1C055142";
+	Properties = {
+		"$1810889B",
+		"$835BB7A2",
+	};
+}
+CParticleNodeTemplateExport	$1C055142
+{
+	InputPins = {
+		"$3E911FBB",
+	};
+	OutputPins = {
+		"$9A13A2A4",
+	};
+	ExportedName = "Tint";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$3E911FBB
+{
+	SelfName = "DefaultValue";
+	Owner = "$1C055142";
+}
+CParticleNodePinOut	$9A13A2A4
+{
+	SelfName = "Value";
+	Owner = "$1C055142";
+}
+CRHIRenderingFeature	$DD26542E
+{
+	FeatureName = "Tint";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"Color",
+		"TintMap",
+	};
+}
+CParticleNodeTemplateExport	$5928161E
+{
+	InputPins = {
+		"$AAD9158D",
+	};
+	OutputPins = {
+		"$21472E15",
+	};
+	ExportedName = "Lit.Type";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Solid",
+		"Transparent",
+	};
+}
+CParticleNodePinIn	$AAD9158D
+{
+	SelfName = "DefaultValue";
+	Owner = "$5928161E";
+}
+CParticleNodePinOut	$21472E15
+{
+	SelfName = "Value";
+	Owner = "$5928161E";
+}
+CParticleNodeTemplateExport	$E31D7A62
+{
+	InputPins = {
+		"$23C05B6B",
+	};
+	OutputPins = {
+		"$B2F13921",
+	};
+	ExportedName = "Lit.LitMaskMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Lit.Type";
+	RuleValue = "1";
+}
+CParticleNodePinIn	$23C05B6B
+{
+	SelfName = "DefaultValue";
+	Owner = "$E31D7A62";
+}
+CParticleNodePinOut	$B2F13921
+{
+	SelfName = "Value";
+	Owner = "$E31D7A62";
+}
+CParticleNodeTemplateExport	$835BB7A2
+{
+	Description = {
+		"@eng:Tint color, multiplied with the tint texture",
+	};
+	InputPins = {
+		"$247C7B76",
+	};
+	OutputPins = {
+		"$A5761DE0",
+	};
+	ExportedName = "Tint.Color";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	CategoryName = {
+		"@eng:Tint",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$247C7B76
+{
+	SelfName = "DefaultValue";
+	Owner = "$835BB7A2";
+}
+CParticleNodePinOut	$A5761DE0
+{
+	SelfName = "Value";
+	Owner = "$835BB7A2";
+}
+CParticleNodeTemplateExport	$1810889B
+{
+	Description = {
+		"@eng:Texture map used for the tint",
+	};
+	InputPins = {
+		"$A8F184F2",
+	};
+	OutputPins = {
+		"$2C0DB175",
+	};
+	ExportedName = "Tint.TintMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Tint",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodePinIn	$A8F184F2
+{
+	SelfName = "DefaultValue";
+	Owner = "$1810889B";
+}
+CParticleNodePinOut	$2C0DB175
+{
+	SelfName = "Value";
+	Owner = "$1810889B";
+}
+CParticleNodeTemplateExport	$E6F904E6
+{
+	Description = {
+		"@eng:Global sort order of the draw calls.\\nDifferent values for 2 renderers will separate their draw call.\\nSmaller values are drawn first (visually behind higher values). The value can be negative.",
+	};
+	InputPins = {
+		"$6E73C722",
+	};
+	OutputPins = {
+		"$21567356",
+	};
+	ExportedName = "Transparent.GlobalSortOverride";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.Type";
+	RuleFunction = Lower;
+	RuleValue = "2";
+}
+CParticleNodePinIn	$6E73C722
+{
+	SelfName = "DefaultValue";
+	Owner = "$E6F904E6";
+}
+CParticleNodePinOut	$21567356
+{
+	SelfName = "Value";
+	Owner = "$E6F904E6";
+}
+CParticleNodeTemplateExport	$20D13232
+{
+	Description = {
+		"@eng:The depth bias allows to offset the draw call bbox along the camera axis (in world units).\\nDifferent values for 2 renderers will separate their drawcall.",
+	};
+	InputPins = {
+		"$EB41CFF7",
+	};
+	OutputPins = {
+		"$240C664B",
+	};
+	ExportedName = "Transparent.CameraSortOffset";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.SortMode";
+	RuleValue = "1";
+	DependentProperty2 = "Transparent.Type";
+	RuleFunction2 = Lower;
+	RuleValue2 = "2";
+}
+CParticleNodePinIn	$EB41CFF7
+{
+	SelfName = "DefaultValue";
+	Owner = "$20D13232";
+}
+CParticleNodePinOut	$240C664B
+{
+	SelfName = "Value";
+	Owner = "$20D13232";
+}
+CParticleRendererFeature	$71D528E3
+{
+	FeatureName = "UseVertexColors";
+	Feature = "$AD0617FC";
+}
+CParticleNodeTemplateExport	$AD0617FC
+{
+	InputPins = {
+		"$187D07DC",
+	};
+	OutputPins = {
+		"$0307D62D",
+	};
+	ExportedName = "UseVertexColors";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$187D07DC
+{
+	SelfName = "DefaultValue";
+	Owner = "$AD0617FC";
+}
+CParticleNodePinOut	$0307D62D
+{
+	SelfName = "Value";
+	Owner = "$AD0617FC";
+}
+CRHIRenderingFeature	$A2DFDBD4
+{
+	FeatureName = "UseVertexColors";
+	UseMeshVertexColor0 = true;
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Interface/Experimental.pkri
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Interface/Experimental.pkri
@@ -1,0 +1,4365 @@
+Version = 2.12.0.12699;
+CEngineRendererInterface	$6B70D015
+{
+	InterfaceName = "Experimental material features";
+	RendererFeatures = {
+		"$D6EEA348",
+		"$81861AB7",
+		"$B660FBF9",
+		"$42E16C02",
+		"$D734A95F",
+		"$8F7A985A",
+		"$B53F5A68",
+		"$1E5C8DCF",
+		"$0798FEE6",
+		"$E749E042",
+		"$41EED1A4",
+		"$5CBB6243",
+		"$1838F4AE",
+		"$52697627",
+		"$123456AC",
+		"$D857A09F",
+		"$047497F3",
+		"$D6BEA348",
+		"$55289D1E",
+		"$0CD860BD",
+		"$E191BFCB",
+		"$DADBF2F1",
+		"$D481D29F",
+		"$4B99796F",
+		"$23F9C093",
+		"$62BCE275",
+		"$E7A7BE8E",
+		"$9154DFA0",
+		"$71D528E3",
+		"$F50D7FD2",
+		"$8A93EEE1",
+		"$1BDFA32C",
+		"$A9934228",
+		"$A2277B6B",
+		"$D834E0C1",
+		"$EABBAE94",
+		"$0E3ACA6C",
+		"$61D82A82",
+	};
+}
+CParticleRendererFeature	$81861AB7
+{
+	FeatureName = "GeometryBillboard";
+	Properties = {
+		"$48E2E8B7",
+		"$41E5AFE7",
+		"$3B3DDE67",
+		"$BEEF8936",
+		"$F02495CD",
+		"$CE8CC02E",
+		"$6AD0A593",
+		"$125C39DB",
+	};
+}
+CParticleNodeTemplateExport	$48E2E8B7
+{
+	Description = {
+		"@eng:Billboard center in world coordinates",
+	};
+	InputPins = {
+		"$48E2E8BF",
+	};
+	OutputPins = {
+		"$1A05FF77",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$48E2E8BF
+{
+	SelfName = "DefaultValue";
+	Owner = "$48E2E8B7";
+}
+CParticleNodeTemplateExport	$3B3DDE67
+{
+	Description = {
+		"@eng:Radius of the billboard in world units",
+	};
+	InputPins = {
+		"$3B3DDE6F",
+	};
+	OutputPins = {
+		"$0C954798",
+	};
+	ExportedName = "General.Size";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(5.0000001e-02, 4.9999997e-02, 4.9999997e-02, 4.9999997e-02);
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.EnableSize2D";
+	RuleFunction = NotEqual;
+}
+CParticleNodePinIn	$3B3DDE6F
+{
+	SelfName = "DefaultValue";
+	Owner = "$3B3DDE67";
+}
+CParticleNodeTemplateExport	$F02495CD
+{
+	Description = {
+		"@eng:Billboard rotation angle in degrees",
+	};
+	InputPins = {
+		"$F02495CF",
+	};
+	OutputPins = {
+		"$7837C3E5",
+	};
+	ExportedName = "General.Rotation";
+	ExportedType = float;
+	Semantic = Angle;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MinValueF4 = float4(-1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1_AND_Rule2;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = Greater;
+	RuleValue = "1";
+	DependentProperty2 = "General.BillboardingMode";
+	RuleFunction2 = Lower;
+	RuleValue2 = "5";
+}
+CParticleNodePinIn	$F02495CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$F02495CD";
+}
+CParticleNodeTemplateExport	$CE8CC02E
+{
+	Description = {
+		"@eng:Principal axis of the billboard when <c>BillboardingMode</c> is set to <c>AxisAligned*</c>\\nSide axis of the billboard when <c>BillboardingMode</c> is set to <c>PlaneAligned</c>",
+	};
+	InputPins = {
+		"$CE8CC02F",
+	};
+	OutputPins = {
+		"$2FB70E0C",
+	};
+	ExportedName = "General.Axis";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = Lower;
+	RuleValue = "2";
+}
+CParticleNodePinIn	$CE8CC02F
+{
+	SelfName = "DefaultValue";
+	Owner = "$CE8CC02E";
+}
+CParticleNodeTemplateExport	$6AD0A593
+{
+	Description = {
+		"@eng:Normal of the billboard when <c>BillboardingMode</c> is set to <c>PlaneAligned</c>",
+	};
+	InputPins = {
+		"$6AD0A59F",
+	};
+	OutputPins = {
+		"$36207FBF",
+	};
+	ExportedName = "General.NormalAxis";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = NotEqual;
+	RuleValue = "5";
+}
+CParticleNodePinIn	$6AD0A59F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6AD0A593";
+}
+CParticleNodeTemplateExport	$125C39DB
+{
+	Description = {
+		"@eng:Specifies how the billboard geometry should be build & aligned.\\nUnless mentioned otherwise, the generated geometry will be a quad: 2 triangles, 4 vertices.\\n<ul>\\n<li><b>ScreenAligned</b>: Oriented to always face the camera screen plane</li>\\n<li><b>ViewposAligned</b>: Oriented to always face the camera position</li>\\n<li><b>AxisAligned</b>: Constrained along the <c>Axis</c> vector, tries facing the screen by rotating around the axis</li>\\n<li><b>AxisAlignedSpheroid</b>: Same as <c>AxisAligned</c>, but vertices will always enclose a spheroid, preventing the billboard from looking like a thin slice when looking along the direction of <c>Axis</c></li>\\n<li><b>AxisAlignedCapsule</b>: Similar to <c>AxisAlignedSpheroid</c>, but the geometry has 4 triangles and 6 vertices, resembling a stretched cylinder instead of a spheroid</li>\\n<li><b>PlaneAligned</b>: Constrained on two axes, does not depend on the camera, will appear as a 3D plane</li>\\n</ul>",
+	};
+	InputPins = {
+		"$125C39DF",
+	};
+	OutputPins = {
+		"$E54029EE",
+	};
+	ExportedName = "General.BillboardingMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:General",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"ScreenAligned",
+		"ViewposAligned",
+		"AxisAligned",
+		"AxisAlignedSpheroid",
+		"AxisAlignedCapsule",
+		"PlaneAligned",
+	};
+}
+CParticleNodePinIn	$125C39DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$125C39DB";
+}
+CParticleRendererFeature	$B660FBF9
+{
+	FeatureName = "GeometryRibbon";
+	Properties = {
+		"$ECEE2C92",
+		"$C71A50C8",
+		"$4703F6C7",
+		"$6B1D589C",
+	};
+}
+CParticleNodeTemplateExport	$ECEE2C92
+{
+	InputPins = {
+		"$ECEE2C9F",
+	};
+	OutputPins = {
+		"$5209F849",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$ECEE2C9F
+{
+	SelfName = "DefaultValue";
+	Owner = "$ECEE2C92";
+}
+CParticleNodeTemplateExport	$C71A50C8
+{
+	InputPins = {
+		"$C71A50CF",
+	};
+	OutputPins = {
+		"$A913E2D6",
+	};
+	ExportedName = "General.Size";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(4.9999997e-02, 4.9999997e-02, 4.9999997e-02, 4.9999997e-02);
+}
+CParticleNodePinIn	$C71A50CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$C71A50C8";
+}
+CParticleNodeTemplateExport	$4703F6C7
+{
+	InputPins = {
+		"$4703F6CF",
+	};
+	OutputPins = {
+		"$17E22F51",
+	};
+	ExportedName = "General.Axis";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "General.BillboardingMode";
+	RuleFunction = Lower;
+	RuleValue = "1";
+}
+CParticleNodePinIn	$4703F6CF
+{
+	SelfName = "DefaultValue";
+	Owner = "$4703F6C7";
+}
+CParticleNodeTemplateExport	$6B1D589C
+{
+	InputPins = {
+		"$6B1D589F",
+	};
+	OutputPins = {
+		"$8EAEE7E8",
+	};
+	ExportedName = "General.BillboardingMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:General",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"ViewposAligned",
+		"NormalAxisAligned",
+		"SideAxisAligned",
+	};
+}
+CParticleNodePinIn	$6B1D589F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6B1D589C";
+}
+CParticleRendererFeature	$42E16C02
+{
+	FeatureName = "GeometryMesh";
+	Properties = {
+		"$B6F5CC16",
+		"$49145BE4",
+		"$D4309EA4",
+		"$8B66367E",
+	};
+}
+CParticleNodeTemplateExport	$B6F5CC16
+{
+	Description = {
+		"@eng:Mesh position in world coordinates",
+	};
+	InputPins = {
+		"$B6F5CC1F",
+	};
+	OutputPins = {
+		"$125230CB",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$B6F5CC1F
+{
+	SelfName = "DefaultValue";
+	Owner = "$B6F5CC16";
+}
+CParticleNodeTemplateExport	$49145BE4
+{
+	Description = {
+		"@eng:Mesh scale",
+	};
+	InputPins = {
+		"$49145BEF",
+	};
+	OutputPins = {
+		"$F527E9EA",
+	};
+	ExportedName = "General.Scale";
+	ExportedType = float3;
+	Semantic = 3D_Scale;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Direction;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$49145BEF
+{
+	SelfName = "DefaultValue";
+	Owner = "$49145BE4";
+}
+CParticleNodeTemplateExport	$D4309EA4
+{
+	Description = {
+		"@eng:Mesh orientation",
+	};
+	InputPins = {
+		"$D4309EAF",
+	};
+	OutputPins = {
+		"$E7F879F5",
+	};
+	ExportedName = "General.Orientation";
+	ExportedType = orientation;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(0.0000000e+00, 0.0000000e+00, 0.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$D4309EAF
+{
+	SelfName = "DefaultValue";
+	Owner = "$D4309EA4";
+}
+CParticleNodeTemplateExport	$8B66367E
+{
+	Description = {
+		"@eng:Mesh resource",
+	};
+	InputPins = {
+		"$8B66367F",
+	};
+	OutputPins = {
+		"$C45BF55C",
+	};
+	ExportedName = "General.Mesh";
+	ExportedType = dataGeometry;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$8B66367F
+{
+	SelfName = "DefaultValue";
+	Owner = "$8B66367E";
+}
+CParticleRendererFeature	$D734A95F
+{
+	FeatureName = "GeometryLight";
+	Properties = {
+		"$E2583104",
+	};
+}
+CParticleNodeTemplateExport	$E2583104
+{
+	Description = {
+		"@eng:Light position in world coordinates",
+	};
+	InputPins = {
+		"$E258310F",
+	};
+	OutputPins = {
+		"$22B8D14F",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$E258310F
+{
+	SelfName = "DefaultValue";
+	Owner = "$E2583104";
+}
+CParticleRendererFeature	$8F7A985A
+{
+	FeatureName = "GeometrySound";
+	Properties = {
+		"$203CAA66",
+	};
+}
+CParticleNodeTemplateExport	$203CAA66
+{
+	Description = {
+		"@eng:Sound source position in world coordinates",
+	};
+	InputPins = {
+		"$203CAA6F",
+	};
+	OutputPins = {
+		"$AAFF12BE",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	TransformSpace = World;
+	TransformMode = Position;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$203CAA6F
+{
+	SelfName = "DefaultValue";
+	Owner = "$203CAA66";
+}
+CParticleRendererFeature	$0798FEE6
+{
+	FeatureName = "Transparent";
+	Feature = "$BE4E302C";
+	Properties = {
+		"$353B08E3",
+		"$9AA9404E",
+		"$E6F904E6",
+		"$20D13232",
+	};
+}
+CParticleNodeTemplateExport	$BE4E302C
+{
+	InputPins = {
+		"$BE4E302F",
+	};
+	OutputPins = {
+		"$1A488438",
+	};
+	ExportedName = "Transparent";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$BE4E302F
+{
+	SelfName = "DefaultValue";
+	Owner = "$BE4E302C";
+}
+CParticleNodeTemplateExport	$353B08E3
+{
+	Description = {
+		"@eng:Allows to specify a custom sorting key. By default sorts based on the distance to the camera.",
+	};
+	InputPins = {
+		"$353B08EF",
+	};
+	OutputPins = {
+		"$55F99FBA",
+	};
+	ExportedName = "Transparent.SortMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"CameraDistance",
+		"ByCustomValue",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.Type";
+	RuleFunction = Lower;
+	RuleValue = "2";
+}
+CParticleNodePinIn	$353B08EF
+{
+	SelfName = "DefaultValue";
+	Owner = "$353B08E3";
+}
+CParticleNodeTemplateExport	$9AA9404E
+{
+	Description = {
+		"@eng:Value to be used for sorting when <c>SortMode</c> is set to <c>ByCustomValue</c>",
+	};
+	InputPins = {
+		"$9AA9404F",
+	};
+	OutputPins = {
+		"$C73E7C05",
+	};
+	ExportedName = "Transparent.SortKey";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	PinRules = Rule1_OR_Rule2;
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.SortMode";
+	DependentProperty2 = "Transparent.Type";
+	RuleFunction2 = Lower;
+	RuleValue2 = "2";
+}
+CParticleNodePinIn	$9AA9404F
+{
+	SelfName = "DefaultValue";
+	Owner = "$9AA9404E";
+}
+CParticleRendererFeature	$E749E042
+{
+	FeatureName = "Opaque";
+	Feature = "$0755FA7C";
+	Properties = {
+		"$6887733F",
+		"$41B5AFE7",
+		"$CE2F5487",
+		"$6C08EBFF",
+		"$168DB3A8",
+	};
+}
+CParticleNodeTemplateExport	$0755FA7C
+{
+	InputPins = {
+		"$0755FA7F",
+	};
+	OutputPins = {
+		"$ED0A18AC",
+	};
+	ExportedName = "Opaque";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$0755FA7F
+{
+	SelfName = "DefaultValue";
+	Owner = "$0755FA7C";
+}
+CParticleNodeTemplateExport	$6887733F
+{
+	Description = {
+		"@eng:Opaque mode\\n<ul>\\n<li><b>Solid</b>: Fully opaque, ignores the texture & color alpha channel</li>\\n<li><b>Masked</b>: When the final pixel\'s alpha value is lower than <c>MaskThreshold</c>, the pixel is not drawn</li>\\n<li><b>Dithered</b>: Dithering pattern applied based on pixel\'s alpha value</li>\\n</ul>",
+	};
+	InputPins = {
+		"$6887733A",
+	};
+	OutputPins = {
+		"$CF350EDF",
+	};
+	ExportedName = "Opaque.Type";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Solid",
+		"Masked",
+		"Dithered",
+	};
+}
+CParticleNodePinIn	$6887733A
+{
+	SelfName = "DefaultValue";
+	Owner = "$6887733F";
+}
+CParticleRendererFeature	$1838F4AE
+{
+	FeatureName = "Diffuse";
+	Feature = "$3FB45D67";
+	Properties = {
+		"$E32FF502",
+		"$89BB54AC",
+	};
+}
+CParticleNodeTemplateExport	$3FB45D67
+{
+	InputPins = {
+		"$3FB45D6F",
+	};
+	OutputPins = {
+		"$1BDBE0E0",
+	};
+	ExportedName = "Diffuse";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$3FB45D6F
+{
+	SelfName = "DefaultValue";
+	Owner = "$3FB45D67";
+}
+CParticleNodeTemplateExport	$E32FF502
+{
+	Description = {
+		"@eng:Texture map used for the diffuse lighting component",
+	};
+	InputPins = {
+		"$E32FF50F",
+	};
+	OutputPins = {
+		"$84ADA123",
+	};
+	ExportedName = "Diffuse.DiffuseMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Diffuse",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodePinIn	$E32FF50F
+{
+	SelfName = "DefaultValue";
+	Owner = "$E32FF502";
+}
+CParticleNodeTemplateExport	$89BB54AC
+{
+	Description = {
+		"@eng:Diffuse color, multiplied with the diffuse texture",
+	};
+	InputPins = {
+		"$89BB54AF",
+	};
+	OutputPins = {
+		"$946D7522",
+	};
+	ExportedName = "Diffuse.DiffuseColor";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Diffuse",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$89BB54AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$89BB54AC";
+}
+CParticleRendererFeature	$E191BFCB
+{
+	FeatureName = "SoftParticles";
+	Feature = "$82F1B3B1";
+	Properties = {
+		"$3F05660E",
+	};
+}
+CParticleNodeTemplateExport	$82F1B3B1
+{
+	InputPins = {
+		"$82F1B3BF",
+	};
+	OutputPins = {
+		"$C072C98D",
+	};
+	ExportedName = "SoftParticles";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$82F1B3BF
+{
+	SelfName = "DefaultValue";
+	Owner = "$82F1B3B1";
+}
+CParticleNodeTemplateExport	$3F05660E
+{
+	Description = {
+		"@eng:Fade distance of particles in world units",
+	};
+	InputPins = {
+		"$3F05660F",
+	};
+	OutputPins = {
+		"$F8EE30D4",
+	};
+	ExportedName = "SoftParticles.SoftnessDistance";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SoftParticles",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$3F05660F
+{
+	SelfName = "DefaultValue";
+	Owner = "$3F05660E";
+}
+CParticleRendererFeature	$41EED1A4
+{
+	FeatureName = "Distortion";
+	Feature = "$9E526218";
+	Properties = {
+		"$0E4E8810",
+		"$BDABEA0C",
+	};
+}
+CParticleNodeTemplateExport	$9E526218
+{
+	InputPins = {
+		"$9E52621F",
+	};
+	OutputPins = {
+		"$4092CA15",
+	};
+	ExportedName = "Distortion";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$9E52621F
+{
+	SelfName = "DefaultValue";
+	Owner = "$9E526218";
+}
+CParticleNodeTemplateExport	$0E4E8810
+{
+	Description = {
+		"@eng:Distortion texture map:\\n<ul>\\n<li><b>RG</b>: 2D screenspace distortion vector for the side & up screen axes. The zero vector is <c>{0.5, 0.5}</c>, like a normalmap</li>\\n<li><b>B</b>: Blur factor (not all integrations support this)</li>\\n<li><b>A</b>: Unused</li>\\n</ul>\\n",
+	};
+	InputPins = {
+		"$0E4E881F",
+	};
+	OutputPins = {
+		"$727E77FC",
+	};
+	ExportedName = "Distortion.DistortionMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Distortion",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Distort.dds";
+}
+CParticleNodePinIn	$0E4E881F
+{
+	SelfName = "DefaultValue";
+	Owner = "$0E4E8810";
+}
+CParticleNodeTemplateExport	$BDABEA0C
+{
+	Description = {
+		"@eng:Distortion coefficient. It gets multiplied with the distortion texture to get the final distortion vectors.",
+	};
+	InputPins = {
+		"$BDABEA0F",
+	};
+	OutputPins = {
+		"$2496386F",
+	};
+	ExportedName = "Distortion.DistortionColor";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	CategoryName = {
+		"@eng:Distortion",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$BDABEA0F
+{
+	SelfName = "DefaultValue";
+	Owner = "$BDABEA0C";
+}
+CParticleRendererFeature	$62BCE275
+{
+	FeatureName = "CorrectDeformation";
+	Feature = "$7CB97F8A";
+}
+CParticleNodeTemplateExport	$7CB97F8A
+{
+	InputPins = {
+		"$7CB97F8F",
+	};
+	OutputPins = {
+		"$F686F85E",
+	};
+	ExportedName = "CorrectDeformation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$7CB97F8F
+{
+	SelfName = "DefaultValue";
+	Owner = "$7CB97F8A";
+}
+CParticleRendererFeature	$0CD860BD
+{
+	FeatureName = "AlphaRemap";
+	Feature = "$FF1A9FA2";
+	Properties = {
+		"$371F2116",
+		"$C861FC98",
+	};
+}
+CParticleNodeTemplateExport	$FF1A9FA2
+{
+	InputPins = {
+		"$FF1A9FAF",
+	};
+	OutputPins = {
+		"$0208AF79",
+	};
+	ExportedName = "AlphaRemap";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$FF1A9FAF
+{
+	SelfName = "DefaultValue";
+	Owner = "$FF1A9FA2";
+}
+CParticleNodeTemplateExport	$371F2116
+{
+	Description = {
+		"@eng:Texture map used as the alpha remap lookup.\\nThe <c>X</c> lookup coordinate is the diffuse texture alpha.\\nThe <c>Y</c> lookup coordinate is the <c>AlphaRemapCursor</c> value.",
+	};
+	InputPins = {
+		"$371F211F",
+	};
+	OutputPins = {
+		"$9AA1D730",
+	};
+	ExportedName = "AlphaRemap.AlphaMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:AlphaRemap",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Default_AlphaMap.dds";
+}
+CParticleNodePinIn	$371F211F
+{
+	SelfName = "DefaultValue";
+	Owner = "$371F2116";
+}
+CParticleNodeTemplateExport	$C861FC98
+{
+	Description = {
+		"@eng:<c>Y</c> coordinate used to sample the <c>AlphaMap</c> texture.",
+	};
+	InputPins = {
+		"$C861FC9F",
+	};
+	OutputPins = {
+		"$6964ADB3",
+	};
+	ExportedName = "AlphaRemap.AlphaRemapCursor";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:AlphaRemap",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$C861FC9F
+{
+	SelfName = "DefaultValue";
+	Owner = "$C861FC98";
+}
+CParticleRendererFeature	$DADBF2F1
+{
+	FeatureName = "Atlas";
+	Feature = "$E22E94DB";
+	Properties = {
+		"$2D8A7741",
+		"$2E215ABC",
+		"$F580CA43",
+		"$63EBE82E",
+		"$BEDF8936",
+		"$D6DEA348",
+		"$2D0B2651",
+	};
+}
+CParticleNodeTemplateExport	$E22E94DB
+{
+	InputPins = {
+		"$E22E94DF",
+	};
+	OutputPins = {
+		"$100434F2",
+	};
+	ExportedName = "Atlas";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E22E94DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$E22E94DB";
+}
+CParticleNodeTemplateExport	$2D8A7741
+{
+	Description = {
+		"@eng:Atlas source type\\n<ul>\\n<li><b>External</b>: Use a .pkat file to specify the corners of each atlas sub-rectangle in UV space</li>\\n<li><b>Procedural</b>: Specify the number of tiles along the U and V axes</li>\\n</ul>\\n",
+	};
+	InputPins = {
+		"$2D8A774F",
+	};
+	OutputPins = {
+		"$41FD9D9D",
+	};
+	ExportedName = "Atlas.Source";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"External",
+		"Procedural",
+	};
+	DefaultValueI4 = int4(1, 0, 0, 0);
+}
+CParticleNodePinIn	$2D8A774F
+{
+	SelfName = "DefaultValue";
+	Owner = "$2D8A7741";
+}
+CParticleNodeTemplateExport	$2E215ABC
+{
+	Description = {
+		"@eng:Atlas definition (.pkat)",
+	};
+	InputPins = {
+		"$2E215ABF",
+	};
+	OutputPins = {
+		"$45F88E24",
+	};
+	ExportedName = "Atlas.Definition";
+	ExportedType = dataImageAtlas;
+	Type = Input;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "Atlas.Source";
+	RuleFunction = NotEqual;
+}
+CParticleNodePinIn	$2E215ABF
+{
+	SelfName = "DefaultValue";
+	Owner = "$2E215ABC";
+}
+CParticleNodeTemplateExport	$F580CA43
+{
+	Description = {
+		"@eng:Subdivision count on the U and V axes",
+	};
+	InputPins = {
+		"$F580CA4F",
+	};
+	OutputPins = {
+		"$81F975B7",
+	};
+	ExportedName = "Atlas.SubDiv";
+	ExportedType = int2;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DefaultValueI4 = int4(1, 1, 1, 1);
+	PinRules = Rule1;
+	RuleResult = Hidden;
+	DependentProperty = "Atlas.Source";
+	RuleFunction = NotEqual;
+	RuleValue = "1";
+}
+CParticleNodePinIn	$F580CA4F
+{
+	SelfName = "DefaultValue";
+	Owner = "$F580CA43";
+}
+CParticleNodeTemplateExport	$63EBE82E
+{
+	Description = {
+		"@eng:Frame blending type\\n<ul>\\n<li><b>None</b>: No interpolation between frames</li>\\n<li><b>Linear</b>: Linear blending</li>\\n<li><b>MotionVectors</b>: Use the <c>MotionVectorsMap</c> texture as the interpolation vectors to blend between frames</li>\\n</ul>",
+	};
+	InputPins = {
+		"$63EBE82F",
+	};
+	OutputPins = {
+		"$3E88DB46",
+	};
+	ExportedName = "Atlas.Blending";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"None",
+		"Linear",
+		"Motion vectors (optical flow)",
+	};
+}
+CParticleNodePinIn	$63EBE82F
+{
+	SelfName = "DefaultValue";
+	Owner = "$63EBE82E";
+}
+CParticleNodeTemplateExport	$2D0B2651
+{
+	Description = {
+		"@eng:Index of the sub-rect to use inside the atlas",
+	};
+	InputPins = {
+		"$2D0B265F",
+	};
+	OutputPins = {
+		"$113E6425",
+	};
+	ExportedName = "Atlas.TextureID";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+}
+CParticleNodePinIn	$2D0B265F
+{
+	SelfName = "DefaultValue";
+	Owner = "$2D0B2651";
+}
+CParticleRendererFeature	$A9934228
+{
+	FeatureName = "Light";
+	Feature = "$D10978FE";
+	Properties = {
+		"$1795DE47",
+		"$D65CBB1F",
+	};
+}
+CParticleNodeTemplateExport	$D10978FE
+{
+	InputPins = {
+		"$D10978FF",
+	};
+	OutputPins = {
+		"$C736134C",
+	};
+	ExportedName = "Light";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D10978FF
+{
+	SelfName = "DefaultValue";
+	Owner = "$D10978FE";
+}
+CParticleNodeTemplateExport	$1795DE47
+{
+	Description = {
+		"@eng:Light color",
+	};
+	InputPins = {
+		"$1795DE4F",
+	};
+	OutputPins = {
+		"$189D4DFF",
+	};
+	ExportedName = "Light.Color";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Light",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$1795DE4F
+{
+	SelfName = "DefaultValue";
+	Owner = "$1795DE47";
+}
+CParticleRendererFeature	$A2277B6B
+{
+	FeatureName = "LightAttenuation";
+	Feature = "$C62A1F73";
+	Properties = {
+		"$1EADE0D1",
+		"$761783D3",
+	};
+}
+CParticleNodeTemplateExport	$C62A1F73
+{
+	InputPins = {
+		"$C62A1F7F",
+	};
+	OutputPins = {
+		"$8139F52E",
+	};
+	ExportedName = "LightAttenuation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$C62A1F7F
+{
+	SelfName = "DefaultValue";
+	Owner = "$C62A1F73";
+}
+CParticleNodeTemplateExport	$1EADE0D1
+{
+	Description = {
+		"@eng:Controls how fast the light intensity falls off from the center of the light",
+	};
+	InputPins = {
+		"$1EADE0DF",
+	};
+	OutputPins = {
+		"$0F960489",
+	};
+	ExportedName = "LightAttenuation.AttenuationSteepness";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:LightAttenuation",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 5.0000000e-01, 5.0000000e-01, 5.0000000e-01);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$1EADE0DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$1EADE0D1";
+}
+CParticleNodeTemplateExport	$761783D3
+{
+	Description = {
+		"@eng:Radius of the light sphere, in world units. Light intensity falls down to zero on the sphere edge, <c>Radius</c> units away from the light <c>Position</c>",
+	};
+	InputPins = {
+		"$761783DF",
+	};
+	OutputPins = {
+		"$17B04980",
+	};
+	ExportedName = "LightAttenuation.Range";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:LightAttenuation",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$761783DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$761783D3";
+}
+CParticleRendererFeature	$EABBAE94
+{
+	FeatureName = "Sound";
+	Feature = "$7CFB103C";
+	Properties = {
+		"$6818E968",
+		"$725E6552",
+	};
+}
+CParticleNodeTemplateExport	$7CFB103C
+{
+	InputPins = {
+		"$7CFB103F",
+	};
+	OutputPins = {
+		"$C0CC90C2",
+	};
+	ExportedName = "Sound";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$7CFB103F
+{
+	SelfName = "DefaultValue";
+	Owner = "$7CFB103C";
+}
+CParticleNodeTemplateExport	$6818E968
+{
+	Description = {
+		"@eng:Path to the sound to be played",
+	};
+	InputPins = {
+		"$6818E96F",
+	};
+	OutputPins = {
+		"$8D8C3DAD",
+	};
+	ExportedName = "Sound.SoundData";
+	ExportedType = dataAudio;
+	Type = Input;
+	Order = 9;
+	CategoryName = {
+		"@eng:Sound",
+	};
+}
+CParticleNodePinIn	$6818E96F
+{
+	SelfName = "DefaultValue";
+	Owner = "$6818E968";
+}
+CParticleNodeTemplateExport	$725E6552
+{
+	Description = {
+		"@eng:Sound playback volume coefficient",
+	};
+	InputPins = {
+		"$725E655F",
+	};
+	OutputPins = {
+		"$BC2CA774",
+	};
+	ExportedName = "Sound.Volume";
+	ExportedType = float;
+	Type = Input;
+	Order = 10;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Sound",
+	};
+	DefaultValueF4 = float4(5.0000000e-01, 5.0000000e-01, 5.0000000e-01, 5.0000000e-01);
+}
+CParticleNodePinIn	$725E655F
+{
+	SelfName = "DefaultValue";
+	Owner = "$725E6552";
+}
+CParticleRendererFeature	$0E3ACA6C
+{
+	FeatureName = "SoundAttenuation";
+	Feature = "$86A6D721";
+	Properties = {
+		"$C0425F45",
+		"$F158603E",
+	};
+}
+CParticleNodeTemplateExport	$86A6D721
+{
+	InputPins = {
+		"$86A6D72F",
+	};
+	OutputPins = {
+		"$A4D7E147",
+	};
+	ExportedName = "SoundAttenuation";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$86A6D72F
+{
+	SelfName = "DefaultValue";
+	Owner = "$86A6D721";
+}
+CParticleNodeTemplateExport	$C0425F45
+{
+	Description = {
+		"@eng:Controls how fast the sound intensity falls off from the source",
+	};
+	InputPins = {
+		"$C0425F4F",
+	};
+	OutputPins = {
+		"$089AE616",
+	};
+	ExportedName = "SoundAttenuation.AttenuationModel";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:SoundAttenuation",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Linear",
+		"InverseLinear",
+	};
+}
+CParticleNodePinIn	$C0425F4F
+{
+	SelfName = "DefaultValue";
+	Owner = "$C0425F45";
+}
+CParticleNodeTemplateExport	$F158603E
+{
+	Description = {
+		"@eng:Radius of the sound sphere, in world units. Sound volume falls down to zero on the sphere edge, <c>Radius</c> units away from the sound <c>Position</c>",
+	};
+	InputPins = {
+		"$F158603F",
+	};
+	OutputPins = {
+		"$C4E7D391",
+	};
+	ExportedName = "SoundAttenuation.Range";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:SoundAttenuation",
+	};
+	DefaultValueF4 = float4(1.0000000e+03, 1.0000000e+03, 1.0000000e+03, 1.0000000e+03);
+}
+CParticleNodePinIn	$F158603F
+{
+	SelfName = "DefaultValue";
+	Owner = "$F158603E";
+}
+CParticleRendererFeature	$61D82A82
+{
+	FeatureName = "Doppler";
+	Feature = "$D1AFAA07";
+	Properties = {
+		"$DE4AF925",
+		"$8F92C16F",
+	};
+}
+CParticleNodeTemplateExport	$D1AFAA07
+{
+	InputPins = {
+		"$D1AFAA0F",
+	};
+	OutputPins = {
+		"$EED74128",
+	};
+	ExportedName = "Doppler";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D1AFAA0F
+{
+	SelfName = "DefaultValue";
+	Owner = "$D1AFAA07";
+}
+CParticleNodeTemplateExport	$DE4AF925
+{
+	Description = {
+		"@eng:Controls the strength of the doppler effect",
+	};
+	InputPins = {
+		"$DE4AF92F",
+	};
+	OutputPins = {
+		"$EF48E30B",
+	};
+	ExportedName = "Doppler.DopplerFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Doppler",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$DE4AF92F
+{
+	SelfName = "DefaultValue";
+	Owner = "$DE4AF925";
+}
+CParticleNodeTemplateExport	$8F92C16F
+{
+	Description = {
+		"@eng:Sound source velocity vector in worldspace",
+	};
+	InputPins = {
+		"$8F92C16A",
+	};
+	OutputPins = {
+		"$126F692A",
+	};
+	ExportedName = "Doppler.Velocity";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:Doppler",
+	};
+}
+CParticleNodePinIn	$8F92C16A
+{
+	SelfName = "DefaultValue";
+	Owner = "$8F92C16F";
+}
+CParticleRendererFeature	$D481D29F
+{
+	FeatureName = "CustomTextureU";
+	Feature = "$AF3DCC22";
+	Properties = {
+		"$704F64D6",
+	};
+}
+CParticleNodeTemplateExport	$AF3DCC22
+{
+	InputPins = {
+		"$AF3DCC2F",
+	};
+	OutputPins = {
+		"$994A4A35",
+	};
+	ExportedName = "CustomTextureU";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$AF3DCC2F
+{
+	SelfName = "DefaultValue";
+	Owner = "$AF3DCC22";
+}
+CParticleNodeTemplateExport	$704F64D6
+{
+	Description = {
+		"@eng:<c>U</c> texture coordinate of the ribbon particle.\\n\\nUsually set to <c>self.lifeRatio</c>\\n",
+	};
+	InputPins = {
+		"$704F64DF",
+	};
+	OutputPins = {
+		"$576DEA9C",
+	};
+	ExportedName = "CustomTextureU.TextureU";
+	ExportedType = float;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:CustomTextureU",
+	};
+}
+CParticleNodePinIn	$704F64DF
+{
+	SelfName = "DefaultValue";
+	Owner = "$704F64D6";
+}
+CParticleRendererFeature	$4B99796F
+{
+	FeatureName = "BasicTransformUVs";
+	Feature = "$37DC024B";
+	Properties = {
+		"$88F8E019",
+		"$C43F52A5",
+		"$0FB78BF6",
+	};
+}
+CParticleNodeTemplateExport	$37DC024B
+{
+	InputPins = {
+		"$37DC024F",
+	};
+	OutputPins = {
+		"$3DCB4F8F",
+	};
+	ExportedName = "BasicTransformUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$37DC024F
+{
+	SelfName = "DefaultValue";
+	Owner = "$37DC024B";
+}
+CParticleNodeTemplateExport	$C43F52A5
+{
+	Description = {
+		"@eng:Flips the texture UVs horizontally",
+	};
+	InputPins = {
+		"$C43F52AF",
+	};
+	OutputPins = {
+		"$EB684DFE",
+	};
+	ExportedName = "BasicTransformUVs.FlipU";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:BasicTransformUVs",
+	};
+}
+CParticleNodePinIn	$C43F52AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$C43F52A5";
+}
+CParticleNodeTemplateExport	$0FB78BF6
+{
+	Description = {
+		"@eng:Flips the texture UVs vertically",
+	};
+	InputPins = {
+		"$0FB78BFF",
+	};
+	OutputPins = {
+		"$1653E599",
+	};
+	ExportedName = "BasicTransformUVs.FlipV";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:BasicTransformUVs",
+	};
+}
+CParticleNodePinIn	$0FB78BFF
+{
+	SelfName = "DefaultValue";
+	Owner = "$0FB78BF6";
+}
+CParticleNodeTemplateExport	$88F8E019
+{
+	Description = {
+		"@eng:Rotates texcoords 90 degrees clockwise (<c>TextureU</c>, <c>FlipU</c>, and <c>FlipV</c> are rotated too)",
+	};
+	InputPins = {
+		"$88F8E01F",
+	};
+	OutputPins = {
+		"$923437D0",
+	};
+	ExportedName = "BasicTransformUVs.RotateUV";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:BasicTransformUVs",
+	};
+}
+CParticleNodePinIn	$88F8E01F
+{
+	SelfName = "DefaultValue";
+	Owner = "$88F8E019";
+}
+CParticleRendererFeature	$E7A7BE8E
+{
+	FeatureName = "TextureRepeat";
+	Feature = "$FC4DE60A";
+}
+CParticleNodeTemplateExport	$FC4DE60A
+{
+	InputPins = {
+		"$FC4DE60F",
+	};
+	OutputPins = {
+		"$EA4B8892",
+	};
+	ExportedName = "TextureRepeat";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$FC4DE60F
+{
+	SelfName = "DefaultValue";
+	Owner = "$FC4DE60A";
+}
+CParticleRendererFeature	$123456AC
+{
+	FeatureName = "Lit";
+	Feature = "$FAFAFAB0";
+	Properties = {
+		"$6CCCA72B",
+		"$C7760457",
+		"$C7760456",
+		"$43290D5D",
+		"$5928161E",
+		"$E31D7A62",
+	};
+}
+CParticleNodeTemplateExport	$FAFAFAB0
+{
+	InputPins = {
+		"$862FBE70",
+	};
+	OutputPins = {
+		"$53613D1F",
+	};
+	ExportedName = "Lit";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$862FBE70
+{
+	SelfName = "DefaultValue";
+	Owner = "$FAFAFAB0";
+}
+CParticleNodeTemplateExport	$6CCCA72B
+{
+	Description = {
+		"@eng:Texture map representing tangent-space normals to be used for lighting",
+	};
+	InputPins = {
+		"$6CCCA72E",
+	};
+	OutputPins = {
+		"$54E702CE",
+	};
+	ExportedName = "Lit.NormalMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/NMap_Flat.dds";
+}
+CParticleNodePinIn	$6CCCA72E
+{
+	SelfName = "DefaultValue";
+	Owner = "$6CCCA72B";
+}
+CParticleNodeTemplateExport	$C7760456
+{
+	Description = {
+		"@eng:Material metalness (PBR). A metalness of <c>0.0</c> represents a pure nonmetal, a metalness of <c>1.0</c> represents a pure metal.\\n\\nAffects the color of the reflections.",
+	};
+	InputPins = {
+		"$FF012345",
+	};
+	OutputPins = {
+		"$EFC61C62",
+	};
+	ExportedName = "Lit.Metalness";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$FF012345
+{
+	SelfName = "DefaultValue";
+	Owner = "$C7760456";
+}
+CParticleNodeTemplateExport	$C7760457
+{
+	Description = {
+		"@eng:Material roughness (PBR). A roughness of <c>0.0</c> represents a mirror, a roughness of <c>1.0</c> represents a purely diffuse surface.",
+	};
+	InputPins = {
+		"$FF012346",
+	};
+	OutputPins = {
+		"$ADC6DB63",
+	};
+	ExportedName = "Lit.Roughness";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e+00, 5.0000000e-01, 5.0000000e-01, 5.0000000e-01);
+	MinValueF4 = float4(0.0000000e+00, 4.9999997e-02, 4.9999997e-02, 4.9999997e-02);
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$FF012346
+{
+	SelfName = "DefaultValue";
+	Owner = "$C7760457";
+}
+CParticleNodeTemplateExport	$43290D5D
+{
+	Description = {
+		"@eng:Roughness (R) and Metalness (G) packed in an RGBA texture",
+	};
+	InputPins = {
+		"$43290FFF",
+	};
+	OutputPins = {
+		"$9B18E1CD",
+	};
+	ExportedName = "Lit.RoughMetalMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodePinIn	$43290FFF
+{
+	SelfName = "DefaultValue";
+	Owner = "$43290D5D";
+}
+CParticleRendererFeature	$D834E0C1
+{
+	FeatureName = "LightTranslucent";
+	Feature = "$D4A7787E";
+}
+CParticleNodeTemplateExport	$D4A7787E
+{
+	InputPins = {
+		"$D4A7787F",
+	};
+	OutputPins = {
+		"$D98FE643",
+	};
+	ExportedName = "LightTranslucent";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D4A7787F
+{
+	SelfName = "DefaultValue";
+	Owner = "$D4A7787E";
+}
+CParticleRendererFeature	$D857A09F
+{
+	FeatureName = "NormalWrap";
+	Feature = "$35A36C4E";
+	Properties = {
+		"$EAC726E3",
+	};
+}
+CParticleNodeTemplateExport	$35A36C4E
+{
+	InputPins = {
+		"$4B933A29",
+	};
+	OutputPins = {
+		"$32460E14",
+	};
+	ExportedName = "NormalWrap";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4B933A29
+{
+	SelfName = "DefaultValue";
+	Owner = "$35A36C4E";
+}
+CParticleNodeTemplateExport	$EAC726E3
+{
+	Description = {
+		"@eng:Fake sub-surface scattering on the particles by remapping the <c>N.L</c> in the lighting equation",
+	};
+	InputPins = {
+		"$14C3FC67",
+	};
+	OutputPins = {
+		"$633D8FB6",
+	};
+	ExportedName = "NormalWrap.WrapFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:NormalWrap",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(1.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CRHIRenderingSettings	$6DF50834
+{
+	RenderingFeatures = {
+		"$EA67A6E3",
+		"$3B49B5AD",
+		"$5DB3D227",
+		"$18A9F8AD",
+		"$85A347AD",
+		"$43951B1E",
+		"$8BECA4C6",
+		"$C9C644C8",
+		"$7FCFBFA6",
+		"$0B924B6C",
+		"$255BA3AA",
+		"$255BA3AB",
+		"$255BA3AC",
+		"$255BA3AD",
+		"$00269EC3",
+		"$69D57342",
+		"$F57D922D",
+		"$AA1655F4",
+		"$AB93F1C7",
+		"$CF880096",
+		"$B34D67A8",
+		"$28CECB8B",
+		"$347F3BAA",
+		"$0A554EB5",
+		"$029B091C",
+		"$F551587E",
+		"$200E5E3D",
+		"$22142957",
+		"$1DB9C766",
+		"$FDD3ABF7",
+		"$1749C465",
+		"$05539FDC",
+		"$AF299513",
+		"$FB490026",
+		"$81E53C85",
+		"$16512360",
+		"$DD26542E",
+		"$A2DFDBD4",
+	};
+}
+CRHIRenderingFeature	$EA67A6E3
+{
+	FeatureName = "Lit";
+	UseUV = true;
+	UseNormal = true;
+	UseTangent = true;
+	UseSceneLightingInfo = true;
+	PropertiesAsShaderConstants = {
+		"RoughMetalMap",
+		"NormalMap",
+		"LitMaskMap",
+		"Metalness",
+		"Roughness",
+		"Type",
+	};
+	TexturesUsedAsLookUp = {
+		"RoughMetalMap",
+		"NormalMap",
+	};
+}
+CRHIRenderingFeature	$3B49B5AD
+{
+	FeatureName = "NormalWrap";
+	PropertiesAsShaderConstants = {
+		"WrapFactor",
+	};
+}
+CRHIRenderingFeature	$5DB3D227
+{
+	FeatureName = "Opaque";
+	UseUV = true;
+	UseNormal = true;
+	UseTangent = true;
+	PropertiesAsShaderConstants = {
+		"Type",
+		"MaskThreshold",
+		"DitheringMode",
+	};
+}
+CRHIRenderingFeature	$18A9F8AD
+{
+	FeatureName = "Diffuse";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"DiffuseMap",
+	};
+}
+CRHIRenderingFeature	$85A347AD
+{
+	FeatureName = "Atlas";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"Blending",
+		"MotionVectorsMap",
+		"DistortionStrength",
+		"SubDiv",
+	};
+}
+CRHIRenderingFeature	$43951B1E
+{
+	FeatureName = "SoftParticles";
+	SampleDepth = true;
+	PropertiesAsShaderConstants = {
+		"SoftnessDistance",
+	};
+}
+CRHIRenderingFeature	$8BECA4C6
+{
+	FeatureName = "Distortion";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"DistortionMap",
+	};
+	TexturesUsedAsLookUp = {
+		"DistortionMap",
+	};
+}
+CRHIRenderingFeature	$C9C644C8
+{
+	FeatureName = "AlphaRemap";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"AlphaMap",
+	};
+	TexturesUsedAsLookUp = {
+		"AlphaMap",
+	};
+}
+CRHIRenderingFeature	$7FCFBFA6
+{
+	FeatureName = "BasicTransformUVs";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"RotateUV",
+	};
+}
+CRHIRenderingFeature	$0B924B6C
+{
+	FeatureName = "Light";
+	SampleDepth = true;
+	SampleNormalRoughMetal = true;
+	SampleDiffuse = true;
+}
+CRHIRenderingFeature	$255BA3AA
+{
+	FeatureName = "LightAttenuation";
+	PropertiesAsShaderConstants = {
+		"AttenuationSteepness",
+	};
+}
+CRHIRenderingFeature	$EBBBBB52
+{
+	FeatureName = "SphereLight";
+	PropertiesAsShaderConstants = {
+		"SphereRadius",
+	};
+}
+CRHIRenderingFeature	$255BA3AB
+{
+	FeatureName = "DiffuseRamp";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"RampMap",
+	};
+}
+CRHIRenderingFeature	$255BA3AC
+{
+	FeatureName = "Emissive";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"Color",
+		"EmissiveMap",
+	};
+}
+CRHIRenderingFeature	$255BA3AD
+{
+	FeatureName = "EmissiveRamp";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"RampMap",
+	};
+}
+CParticleRendererFeature	$9154DFA0
+{
+	FeatureName = "MeshAtlas";
+	Feature = "$4ADE8DE2";
+	Properties = {
+		"$2909A531",
+	};
+}
+CParticleNodeTemplateExport	$4ADE8DE2
+{
+	InputPins = {
+		"$D279714D",
+	};
+	OutputPins = {
+		"$5F621394",
+	};
+	ExportedName = "MeshAtlas";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D279714D
+{
+	SelfName = "DefaultValue";
+	Owner = "$4ADE8DE2";
+}
+CParticleNodePinOut	$5F621394
+{
+	SelfName = "Value";
+	Owner = "$4ADE8DE2";
+}
+CParticleNodeTemplateExport	$2909A531
+{
+	Description = {
+		"@eng:Index of the sub-mesh to draw when the mesh resource contains multiple sub-meshes.",
+	};
+	InputPins = {
+		"$AAA4EDB1",
+	};
+	OutputPins = {
+		"$0E0F55C8",
+	};
+	ExportedName = "General.MeshID";
+	ExportedType = float;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+	HasMin = true;
+}
+CParticleNodeTemplateExport	$41B5AFE7
+{
+	Description = {
+		"@eng:Opacity mask threshold value.\\nIf the alpha value is below this value, the pixel is discarded.",
+	};
+	InputPins = {
+		"$773A578E",
+	};
+	OutputPins = {
+		"$4272E669",
+	};
+	ExportedName = "Opaque.MaskThreshold";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(6.9999999e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Opaque.Type";
+	RuleValue = "1";
+}
+CParticleNodeTemplateExport	$41E5AFE7
+{
+	Description = {
+		"@eng:When enabled, the billboard size is specified as a <c>float2</c> value, through the <c>Size2</c> property, instead of the <c>Size</c> property.",
+	};
+	InputPins = {
+		"$78A74806",
+	};
+	OutputPins = {
+		"$AF09E441",
+	};
+	ExportedName = "General.EnableSize2D";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodeTemplateExport	$BEEF8936
+{
+	Description = {
+		"@eng:2D side/up radius of the billboard in world units.\\nOnly available when <c>EnableSize2D</c> is enabled.",
+	};
+	InputPins = {
+		"$B4F3323B",
+	};
+	OutputPins = {
+		"$1EA3501A",
+	};
+	ExportedName = "General.Size2";
+	ExportedType = float2;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(5.0000001e-02, 5.0000001e-02, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "General.EnableSize2D";
+	RuleFunction = NotEqual;
+}
+CParticleNodePinOut	$F1356840
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$D0980C03
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$ED80C982
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$0384856D
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$96A2AA34
+{
+	SelfName = "Value";
+}
+CParticleNodePinOut	$D970BB07
+{
+	SelfName = "Value";
+}
+CParticleRendererFeature	$52697627
+{
+	FeatureName = "DiffuseRamp";
+	Feature = "$256FAC76";
+	Properties = {
+		"$CB2631EB",
+	};
+}
+CParticleNodeTemplateExport	$256FAC76
+{
+	InputPins = {
+		"$173EE971",
+	};
+	OutputPins = {
+		"$122F1C88",
+	};
+	ExportedName = "DiffuseRamp";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$173EE971
+{
+	SelfName = "DefaultValue";
+	Owner = "$256FAC76";
+}
+CParticleNodePinOut	$122F1C88
+{
+	SelfName = "Value";
+	Owner = "$256FAC76";
+}
+CParticleNodeTemplateExport	$CB2631EB
+{
+	Description = {
+		"@eng:1D texture map used tor for diffuse color remap.\\nSampled with the <c>Red<c> channel of the <c>DiffuseMap</c> texture.",
+	};
+	InputPins = {
+		"$7042442B",
+	};
+	OutputPins = {
+		"$AEE5D0CA",
+	};
+	ExportedName = "DiffuseRamp.RampMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:DiffuseRamp",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleRendererFeature	$D6BEA348
+{
+	FeatureName = "Emissive";
+	Feature = "$5F44DAAB";
+	Properties = {
+		"$C01E68BC",
+		"$9D2B1A2F",
+	};
+}
+CParticleRendererFeature	$D6EEA348
+{
+	FeatureName = "EnableRendering";
+	Feature = "$5F44DFAB";
+	Properties = {
+		"$C01E62BC",
+	};
+}
+CParticleNodeTemplateExport	$5F44DAAB
+{
+	InputPins = {
+		"$D809D24A",
+	};
+	OutputPins = {
+		"$D03459D5",
+	};
+	ExportedName = "Emissive";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D809D24A
+{
+	SelfName = "DefaultValue";
+	Owner = "$5F44DAAB";
+}
+CParticleNodePinOut	$D03459D5
+{
+	SelfName = "Value";
+	Owner = "$5F44DAAB";
+}
+CParticleNodeTemplateExport	$5F44DFAB
+{
+	InputPins = {
+		"$D806D24A",
+	};
+	OutputPins = {
+		"$D03359D5",
+	};
+	ExportedName = "EnableRendering";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$D806D24A
+{
+	SelfName = "DefaultValue";
+	Owner = "$5F44DFAB";
+}
+CParticleNodePinOut	$D03359D5
+{
+	SelfName = "Value";
+	Owner = "$5F44DFAB";
+}
+CParticleNodeTemplateExport	$C01E68BC
+{
+	Description = {
+		"@eng:Texture map used for the emissive lighting component",
+	};
+	InputPins = {
+		"$DD66FA55",
+	};
+	OutputPins = {
+		"$9C124D3C",
+	};
+	ExportedName = "Emissive.EmissiveMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Emissive",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodeTemplateExport	$9D2B1A2F
+{
+	Description = {
+		"@eng:Emissive color, multiplied with the emissive texture",
+	};
+	InputPins = {
+		"$D56016AF",
+	};
+	OutputPins = {
+		"$F94B139E",
+	};
+	ExportedName = "Emissive.EmissiveColor";
+	ExportedType = float3;
+	Semantic = Color;
+	Type = Input;
+	CategoryName = {
+		"@eng:Emissive",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleRendererFeature	$55289D1E
+{
+	FeatureName = "EmissiveRamp";
+	Feature = "$EC84D339";
+	Properties = {
+		"$89E0DDB2",
+	};
+}
+CParticleNodeTemplateExport	$EC84D339
+{
+	InputPins = {
+		"$2BBAE5F0",
+	};
+	OutputPins = {
+		"$14978373",
+	};
+	ExportedName = "EmissiveRamp";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$2BBAE5F0
+{
+	SelfName = "DefaultValue";
+	Owner = "$EC84D339";
+}
+CParticleNodePinOut	$14978373
+{
+	SelfName = "Value";
+	Owner = "$EC84D339";
+}
+CParticleNodeTemplateExport	$89E0DDB2
+{
+	Description = {
+		"@eng:1D texture map used tor for emissive color remap.\\nSampled with the <c>Red<c> channel of the <c>EmissiveMap</c> texture.",
+	};
+	InputPins = {
+		"$7E054BB9",
+	};
+	OutputPins = {
+		"$81108870",
+	};
+	ExportedName = "EmissiveRamp.RampMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:EmissiveRamp",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodeTemplateExport	$C01E62BC
+{
+	Description = {
+		"@eng:Controls if the renderer is enabled or disabled.\\nIf <c>true</c>, the particle will be drawn, if <c>false</c>, it won\'t.",
+	};
+	InputPins = {
+		"$AF0F155D",
+	};
+	OutputPins = {
+		"$DBE780E4",
+	};
+	ExportedName = "General.Enabled";
+	ExportedType = bool;
+	Semantic = Visibility;
+	Type = Input;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueB4 = bool4(true, false, false, false);
+}
+CRHIRenderingFeature	$00269EC3
+{
+	FeatureName = "GeometryBillboard";
+}
+CRHIRenderingFeature	$69D57342
+{
+	FeatureName = "GeometryRibbon";
+}
+CRHIRenderingFeature	$F57D922D
+{
+	FeatureName = "GeometryMesh";
+}
+CRHIRenderingFeature	$AA1655F4
+{
+	FeatureName = "GeometryLight";
+}
+CRHIRenderingFeature	$AB93F1C7
+{
+	FeatureName = "GeometrySound";
+}
+CRHIRenderingFeature	$CF880096
+{
+	FeatureName = "Transparent";
+}
+CRHIRenderingFeature	$B34D67A8
+{
+	FeatureName = "CorrectDeformation";
+}
+CRHIRenderingFeature	$28CECB8B
+{
+	FeatureName = "Sound";
+}
+CRHIRenderingFeature	$347F3BAA
+{
+	FeatureName = "SoundAttenuation";
+}
+CRHIRenderingFeature	$0A554EB5
+{
+	FeatureName = "Doppler";
+}
+CRHIRenderingFeature	$029B091C
+{
+	FeatureName = "CustomTextureU";
+}
+CRHIRenderingFeature	$F551587E
+{
+	FeatureName = "TextureRepeat";
+}
+CRHIRenderingFeature	$200E5E3D
+{
+	FeatureName = "LightTranslucent";
+}
+CRHIRenderingFeature	$22142957
+{
+	FeatureName = "MeshAtlas";
+}
+CRHIRenderingFeature	$1DB9C766
+{
+	FeatureName = "EnableRendering";
+}
+CParticleNodeTemplateExport	$BEDF8936
+{
+	Description = {
+		"@eng:Motion vectors texture, used to blend between frames when <c>Blending</c> is set to <c>MotionVectors</c>",
+	};
+	InputPins = {
+		"$8D355881",
+	};
+	OutputPins = {
+		"$CEEFB0D8",
+	};
+	ExportedName = "Atlas.MotionVectorsMap";
+	ExportedType = dataImage;
+	Type = Input;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/Distort.dds";
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Atlas.Blending";
+	RuleValue = "2";
+}
+CParticleNodeTemplateExport	$D6DEA348
+{
+	Description = {
+		"@eng:Multiplier over the uv distortion\\nDistortion strength to apply for Houdini exported maps is: <c>-(1.0 / FPS / ColRow)</c>.",
+	};
+	InputPins = {
+		"$77FD347B",
+	};
+	OutputPins = {
+		"$56D85F5A",
+	};
+	ExportedName = "Atlas.DistortionStrength";
+	ExportedType = float2;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Atlas",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Atlas.Blending";
+	RuleValue = "2";
+}
+CParticleNodePinIn	$AF0F155D
+{
+	SelfName = "DefaultValue";
+	Owner = "$C01E62BC";
+}
+CParticleNodePinOut	$DBE780E4
+{
+	SelfName = "Value";
+	Owner = "$C01E62BC";
+}
+CParticleNodePinOut	$1A05FF77
+{
+	SelfName = "Value";
+	Owner = "$48E2E8B7";
+}
+CParticleNodePinIn	$78A74806
+{
+	SelfName = "DefaultValue";
+	Owner = "$41E5AFE7";
+}
+CParticleNodePinOut	$AF09E441
+{
+	SelfName = "Value";
+	Owner = "$41E5AFE7";
+}
+CParticleNodePinOut	$0C954798
+{
+	SelfName = "Value";
+	Owner = "$3B3DDE67";
+}
+CParticleNodePinIn	$B4F3323B
+{
+	SelfName = "DefaultValue";
+	Owner = "$BEEF8936";
+}
+CParticleNodePinOut	$1EA3501A
+{
+	SelfName = "Value";
+	Owner = "$BEEF8936";
+}
+CParticleNodePinOut	$7837C3E5
+{
+	SelfName = "Value";
+	Owner = "$F02495CD";
+}
+CParticleNodePinOut	$2FB70E0C
+{
+	SelfName = "Value";
+	Owner = "$CE8CC02E";
+}
+CParticleNodePinOut	$36207FBF
+{
+	SelfName = "Value";
+	Owner = "$6AD0A593";
+}
+CParticleNodePinOut	$E54029EE
+{
+	SelfName = "Value";
+	Owner = "$125C39DB";
+}
+CParticleNodePinOut	$5209F849
+{
+	SelfName = "Value";
+	Owner = "$ECEE2C92";
+}
+CParticleNodePinOut	$A913E2D6
+{
+	SelfName = "Value";
+	Owner = "$C71A50C8";
+}
+CParticleNodePinOut	$17E22F51
+{
+	SelfName = "Value";
+	Owner = "$4703F6C7";
+}
+CParticleNodePinOut	$8EAEE7E8
+{
+	SelfName = "Value";
+	Owner = "$6B1D589C";
+}
+CParticleNodePinOut	$125230CB
+{
+	SelfName = "Value";
+	Owner = "$B6F5CC16";
+}
+CParticleNodePinOut	$F527E9EA
+{
+	SelfName = "Value";
+	Owner = "$49145BE4";
+}
+CParticleNodePinOut	$E7F879F5
+{
+	SelfName = "Value";
+	Owner = "$D4309EA4";
+}
+CParticleNodePinOut	$C45BF55C
+{
+	SelfName = "Value";
+	Owner = "$8B66367E";
+}
+CParticleNodePinOut	$22B8D14F
+{
+	SelfName = "Value";
+	Owner = "$E2583104";
+}
+CParticleNodePinOut	$AAFF12BE
+{
+	SelfName = "Value";
+	Owner = "$203CAA66";
+}
+CParticleNodePinOut	$1A488438
+{
+	SelfName = "Value";
+	Owner = "$BE4E302C";
+}
+CParticleNodePinOut	$55F99FBA
+{
+	SelfName = "Value";
+	Owner = "$353B08E3";
+}
+CParticleNodePinOut	$C73E7C05
+{
+	SelfName = "Value";
+	Owner = "$9AA9404E";
+}
+CParticleNodePinOut	$ED0A18AC
+{
+	SelfName = "Value";
+	Owner = "$0755FA7C";
+}
+CParticleNodePinOut	$CF350EDF
+{
+	SelfName = "Value";
+	Owner = "$6887733F";
+}
+CParticleNodePinIn	$773A578E
+{
+	SelfName = "DefaultValue";
+	Owner = "$41B5AFE7";
+}
+CParticleNodePinOut	$4272E669
+{
+	SelfName = "Value";
+	Owner = "$41B5AFE7";
+}
+CParticleNodePinOut	$1BDBE0E0
+{
+	SelfName = "Value";
+	Owner = "$3FB45D67";
+}
+CParticleNodePinOut	$84ADA123
+{
+	SelfName = "Value";
+	Owner = "$E32FF502";
+}
+CParticleNodePinOut	$946D7522
+{
+	SelfName = "Value";
+	Owner = "$89BB54AC";
+}
+CParticleNodePinOut	$C072C98D
+{
+	SelfName = "Value";
+	Owner = "$82F1B3B1";
+}
+CParticleNodePinOut	$F8EE30D4
+{
+	SelfName = "Value";
+	Owner = "$3F05660E";
+}
+CParticleNodePinOut	$4092CA15
+{
+	SelfName = "Value";
+	Owner = "$9E526218";
+}
+CParticleNodePinOut	$727E77FC
+{
+	SelfName = "Value";
+	Owner = "$0E4E8810";
+}
+CParticleNodePinOut	$2496386F
+{
+	SelfName = "Value";
+	Owner = "$BDABEA0C";
+}
+CParticleNodePinOut	$F686F85E
+{
+	SelfName = "Value";
+	Owner = "$7CB97F8A";
+}
+CParticleNodePinOut	$0208AF79
+{
+	SelfName = "Value";
+	Owner = "$FF1A9FA2";
+}
+CParticleNodePinOut	$9AA1D730
+{
+	SelfName = "Value";
+	Owner = "$371F2116";
+}
+CParticleNodePinOut	$6964ADB3
+{
+	SelfName = "Value";
+	Owner = "$C861FC98";
+}
+CParticleNodePinOut	$100434F2
+{
+	SelfName = "Value";
+	Owner = "$E22E94DB";
+}
+CParticleNodePinOut	$41FD9D9D
+{
+	SelfName = "Value";
+	Owner = "$2D8A7741";
+}
+CParticleNodePinOut	$45F88E24
+{
+	SelfName = "Value";
+	Owner = "$2E215ABC";
+}
+CParticleNodePinOut	$81F975B7
+{
+	SelfName = "Value";
+	Owner = "$F580CA43";
+}
+CParticleNodePinOut	$3E88DB46
+{
+	SelfName = "Value";
+	Owner = "$63EBE82E";
+}
+CParticleNodePinIn	$8D355881
+{
+	SelfName = "DefaultValue";
+	Owner = "$BEDF8936";
+}
+CParticleNodePinOut	$CEEFB0D8
+{
+	SelfName = "Value";
+	Owner = "$BEDF8936";
+}
+CParticleNodePinIn	$77FD347B
+{
+	SelfName = "DefaultValue";
+	Owner = "$D6DEA348";
+}
+CParticleNodePinOut	$56D85F5A
+{
+	SelfName = "Value";
+	Owner = "$D6DEA348";
+}
+CParticleNodePinOut	$113E6425
+{
+	SelfName = "Value";
+	Owner = "$2D0B2651";
+}
+CParticleNodePinOut	$C736134C
+{
+	SelfName = "Value";
+	Owner = "$D10978FE";
+}
+CParticleNodePinOut	$189D4DFF
+{
+	SelfName = "Value";
+	Owner = "$1795DE47";
+}
+CParticleNodePinOut	$8139F52E
+{
+	SelfName = "Value";
+	Owner = "$C62A1F73";
+}
+CParticleNodePinOut	$0F960489
+{
+	SelfName = "Value";
+	Owner = "$1EADE0D1";
+}
+CParticleNodePinOut	$17B04980
+{
+	SelfName = "Value";
+	Owner = "$761783D3";
+}
+CParticleNodePinOut	$D98FE643
+{
+	SelfName = "Value";
+	Owner = "$D4A7787E";
+}
+CParticleNodePinOut	$C0CC90C2
+{
+	SelfName = "Value";
+	Owner = "$7CFB103C";
+}
+CParticleNodePinOut	$8D8C3DAD
+{
+	SelfName = "Value";
+	Owner = "$6818E968";
+}
+CParticleNodePinOut	$BC2CA774
+{
+	SelfName = "Value";
+	Owner = "$725E6552";
+}
+CParticleNodePinOut	$A4D7E147
+{
+	SelfName = "Value";
+	Owner = "$86A6D721";
+}
+CParticleNodePinOut	$089AE616
+{
+	SelfName = "Value";
+	Owner = "$C0425F45";
+}
+CParticleNodePinOut	$C4E7D391
+{
+	SelfName = "Value";
+	Owner = "$F158603E";
+}
+CParticleNodePinOut	$EED74128
+{
+	SelfName = "Value";
+	Owner = "$D1AFAA07";
+}
+CParticleNodePinOut	$EF48E30B
+{
+	SelfName = "Value";
+	Owner = "$DE4AF925";
+}
+CParticleNodePinOut	$126F692A
+{
+	SelfName = "Value";
+	Owner = "$8F92C16F";
+}
+CParticleNodePinOut	$994A4A35
+{
+	SelfName = "Value";
+	Owner = "$AF3DCC22";
+}
+CParticleNodePinOut	$576DEA9C
+{
+	SelfName = "Value";
+	Owner = "$704F64D6";
+}
+CParticleNodePinOut	$3DCB4F8F
+{
+	SelfName = "Value";
+	Owner = "$37DC024B";
+}
+CParticleNodePinOut	$EB684DFE
+{
+	SelfName = "Value";
+	Owner = "$C43F52A5";
+}
+CParticleNodePinOut	$1653E599
+{
+	SelfName = "Value";
+	Owner = "$0FB78BF6";
+}
+CParticleNodePinOut	$923437D0
+{
+	SelfName = "Value";
+	Owner = "$88F8E019";
+}
+CParticleNodePinOut	$EA4B8892
+{
+	SelfName = "Value";
+	Owner = "$FC4DE60A";
+}
+CParticleNodePinOut	$53613D1F
+{
+	SelfName = "Value";
+	Owner = "$FAFAFAB0";
+}
+CParticleNodePinOut	$54E702CE
+{
+	SelfName = "Value";
+	Owner = "$6CCCA72B";
+}
+CParticleNodePinOut	$ADC6DB63
+{
+	SelfName = "Value";
+	Owner = "$C7760457";
+}
+CParticleNodePinOut	$EFC61C62
+{
+	SelfName = "Value";
+	Owner = "$C7760456";
+}
+CParticleNodePinOut	$9B18E1CD
+{
+	SelfName = "Value";
+	Owner = "$43290D5D";
+}
+CParticleNodePinOut	$32460E14
+{
+	SelfName = "Value";
+	Owner = "$35A36C4E";
+}
+CParticleNodePinIn	$14C3FC67
+{
+	SelfName = "DefaultValue";
+	Owner = "$EAC726E3";
+}
+CParticleNodePinOut	$633D8FB6
+{
+	SelfName = "Value";
+	Owner = "$EAC726E3";
+}
+CParticleNodePinIn	$AAA4EDB1
+{
+	SelfName = "DefaultValue";
+	Owner = "$2909A531";
+}
+CParticleNodePinOut	$0E0F55C8
+{
+	SelfName = "Value";
+	Owner = "$2909A531";
+}
+CParticleNodePinIn	$7042442B
+{
+	SelfName = "DefaultValue";
+	Owner = "$CB2631EB";
+}
+CParticleNodePinOut	$AEE5D0CA
+{
+	SelfName = "Value";
+	Owner = "$CB2631EB";
+}
+CParticleNodePinIn	$DD66FA55
+{
+	SelfName = "DefaultValue";
+	Owner = "$C01E68BC";
+}
+CParticleNodePinOut	$9C124D3C
+{
+	SelfName = "Value";
+	Owner = "$C01E68BC";
+}
+CParticleNodePinIn	$D56016AF
+{
+	SelfName = "DefaultValue";
+	Owner = "$9D2B1A2F";
+}
+CParticleNodePinOut	$F94B139E
+{
+	SelfName = "Value";
+	Owner = "$9D2B1A2F";
+}
+CParticleNodePinIn	$7E054BB9
+{
+	SelfName = "DefaultValue";
+	Owner = "$89E0DDB2";
+}
+CParticleNodePinOut	$81108870
+{
+	SelfName = "Value";
+	Owner = "$89E0DDB2";
+}
+CParticleRendererFeature	$047497F3
+{
+	FeatureName = "NormalBend";
+	Feature = "$24414C32";
+	Properties = {
+		"$DEF82E86",
+	};
+}
+CParticleNodeTemplateExport	$24414C32
+{
+	InputPins = {
+		"$CC28E5DD",
+	};
+	OutputPins = {
+		"$E5A55B64",
+	};
+	ExportedName = "NormalBend";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$CC28E5DD
+{
+	SelfName = "DefaultValue";
+	Owner = "$24414C32";
+}
+CParticleNodePinOut	$E5A55B64
+{
+	SelfName = "Value";
+	Owner = "$24414C32";
+}
+CRHIRenderingFeature	$FDD3ABF7
+{
+	FeatureName = "NormalBend";
+}
+CParticleNodeTemplateExport	$DEF82E86
+{
+	Description = {
+		"@eng:Bending factor to apply to the billboard normals.\\n\\n<c>0.0</c> means no bending, the normals will be perpendicular to the billboard quad plane.\\n<c>1.0</c> means fully bent, the normals will be tangent to the billboard quad plane, pointing outwards.",
+	};
+	InputPins = {
+		"$AE218CC1",
+	};
+	OutputPins = {
+		"$76B9DA18",
+	};
+	ExportedName = "NormalBend.NormalBendingFactor";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:NormalBend",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$AE218CC1
+{
+	SelfName = "DefaultValue";
+	Owner = "$DEF82E86";
+}
+CParticleNodePinOut	$76B9DA18
+{
+	SelfName = "Value";
+	Owner = "$DEF82E86";
+}
+CParticleRendererFeature	$23F9C093
+{
+	FeatureName = "TransformUVs";
+	Feature = "$183B52A9";
+	Properties = {
+		"$D9B8D88C",
+		"$9A821802",
+		"$272AD0C9",
+		"$3235C787",
+	};
+}
+CParticleNodeTemplateExport	$183B52A9
+{
+	InputPins = {
+		"$1151F6BB",
+	};
+	OutputPins = {
+		"$69CF2E9A",
+	};
+	ExportedName = "TransformUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$1151F6BB
+{
+	SelfName = "DefaultValue";
+	Owner = "$183B52A9";
+}
+CParticleNodePinOut	$69CF2E9A
+{
+	SelfName = "Value";
+	Owner = "$183B52A9";
+}
+CRHIRenderingFeature	$1749C465
+{
+	FeatureName = "TransformUVs";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"UVOffset",
+		"UVRotate",
+		"UVScale",
+		"RGBOnly",
+	};
+}
+CParticleNodeTemplateExport	$D9B8D88C
+{
+	Description = {
+		"@eng:UV offset",
+	};
+	InputPins = {
+		"$8C88DC3F",
+	};
+	OutputPins = {
+		"$FFE9806E",
+	};
+	ExportedName = "TransformUVs.UVOffset";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+}
+CParticleNodePinIn	$8C88DC3F
+{
+	SelfName = "DefaultValue";
+	Owner = "$D9B8D88C";
+}
+CParticleNodePinOut	$FFE9806E
+{
+	SelfName = "Value";
+	Owner = "$D9B8D88C";
+}
+CParticleNodeTemplateExport	$272AD0C9
+{
+	Description = {
+		"@eng:UV scale",
+	};
+	InputPins = {
+		"$E882EAC0",
+	};
+	OutputPins = {
+		"$EBDA8083",
+	};
+	ExportedName = "TransformUVs.UVScale";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$E882EAC0
+{
+	SelfName = "DefaultValue";
+	Owner = "$272AD0C9";
+}
+CParticleNodePinOut	$EBDA8083
+{
+	SelfName = "Value";
+	Owner = "$272AD0C9";
+}
+CParticleNodeTemplateExport	$9A821802
+{
+	Description = {
+		"@eng:UV rotation angle",
+	};
+	InputPins = {
+		"$C560B5ED",
+	};
+	OutputPins = {
+		"$C92264B4",
+	};
+	ExportedName = "TransformUVs.UVRotate";
+	ExportedType = float;
+	Semantic = Angle;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MinValueF4 = float4(-1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.8000000e+02, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$C560B5ED
+{
+	SelfName = "DefaultValue";
+	Owner = "$9A821802";
+}
+CParticleNodePinOut	$C92264B4
+{
+	SelfName = "Value";
+	Owner = "$9A821802";
+}
+CParticleNodeTemplateExport	$3235C787
+{
+	Description = {
+		"@eng:When enabled, does not transform the UVs used to sample the alpha channel.",
+	};
+	InputPins = {
+		"$81FFA956",
+	};
+	OutputPins = {
+		"$3E3E37D1",
+	};
+	ExportedName = "TransformUVs.RGBOnly";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:TransformUVs",
+	};
+}
+CParticleNodePinIn	$81FFA956
+{
+	SelfName = "DefaultValue";
+	Owner = "$3235C787";
+}
+CParticleNodePinOut	$3E3E37D1
+{
+	SelfName = "Value";
+	Owner = "$3235C787";
+}
+CParticleRendererFeature	$B53F5A68
+{
+	FeatureName = "GeometryTriangle";
+	Feature = "$CB9A554B";
+	Properties = {
+		"$8A52D5A3",
+		"$0AA9AB54",
+		"$E17BB1F1",
+	};
+}
+CParticleNodeTemplateExport	$CB9A554B
+{
+	InputPins = {
+		"$E0C8A86A",
+	};
+	OutputPins = {
+		"$2430DA75",
+	};
+	ExportedName = "GeometryTriangle";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$E0C8A86A
+{
+	SelfName = "DefaultValue";
+	Owner = "$CB9A554B";
+}
+CParticleNodePinOut	$2430DA75
+{
+	SelfName = "Value";
+	Owner = "$CB9A554B";
+}
+CRHIRenderingFeature	$05539FDC
+{
+	FeatureName = "GeometryTriangle";
+}
+CParticleRendererFeature	$1E5C8DCF
+{
+	FeatureName = "GeometryDecal";
+	Feature = "$4BD7493E";
+	Properties = {
+		"$2C3FF00A",
+		"$17C8B4EF",
+		"$D246F9B0",
+	};
+}
+CParticleNodeTemplateExport	$4BD7493E
+{
+	InputPins = {
+		"$79E4E1D9",
+	};
+	OutputPins = {
+		"$D39EC910",
+	};
+	ExportedName = "GeometryDecal";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$79E4E1D9
+{
+	SelfName = "DefaultValue";
+	Owner = "$4BD7493E";
+}
+CParticleNodePinOut	$D39EC910
+{
+	SelfName = "Value";
+	Owner = "$4BD7493E";
+}
+CRHIRenderingFeature	$AF299513
+{
+	FeatureName = "GeometryDecal";
+	SampleDepth = true;
+}
+CParticleRendererFeature	$F50D7FD2
+{
+	FeatureName = "Decal";
+	Feature = "$E92951FD";
+	Properties = {
+		"$2FD0EE1D",
+		"$BF3541C6",
+		"$6D3178FB",
+	};
+}
+CParticleNodeTemplateExport	$E92951FD
+{
+	InputPins = {
+		"$4ADA2A04",
+	};
+	OutputPins = {
+		"$7BCB4F17",
+	};
+	ExportedName = "Decal";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4ADA2A04
+{
+	SelfName = "DefaultValue";
+	Owner = "$E92951FD";
+}
+CParticleNodePinOut	$7BCB4F17
+{
+	SelfName = "Value";
+	Owner = "$E92951FD";
+}
+CRHIRenderingFeature	$FB490026
+{
+	FeatureName = "Decal";
+	PropertiesAsShaderConstants = {
+		"FadeTop",
+		"FadeBottom",
+		"FadeAngle",
+	};
+}
+CParticleRendererFeature	$8A93EEE1
+{
+	FeatureName = "TriangleCustomNormals";
+	Feature = "$74ACD6B8";
+	Properties = {
+		"$8E7F5DCC",
+		"$9F085D09",
+		"$33E15F42",
+		"$423262DF",
+	};
+}
+CParticleNodeTemplateExport	$74ACD6B8
+{
+	InputPins = {
+		"$F0AC5FDB",
+	};
+	OutputPins = {
+		"$0C373E3A",
+	};
+	ExportedName = "TriangleCustomNormals";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$F0AC5FDB
+{
+	SelfName = "DefaultValue";
+	Owner = "$74ACD6B8";
+}
+CParticleNodePinOut	$0C373E3A
+{
+	SelfName = "Value";
+	Owner = "$74ACD6B8";
+}
+CRHIRenderingFeature	$81E53C85
+{
+	FeatureName = "TriangleCustomNormals";
+	PropertiesAsShaderConstants = {
+		"DoubleSided",
+	};
+}
+CParticleRendererFeature	$1BDFA32C
+{
+	FeatureName = "TriangleCustomUVs";
+	Feature = "$9D1C2B5F";
+	Properties = {
+		"$31CA6DC7",
+		"$7D2733A8",
+		"$F2EC2AB5",
+	};
+}
+CParticleNodeTemplateExport	$9D1C2B5F
+{
+	InputPins = {
+		"$4BE96E0E",
+	};
+	OutputPins = {
+		"$732C7EE9",
+	};
+	ExportedName = "TriangleCustomUVs";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$4BE96E0E
+{
+	SelfName = "DefaultValue";
+	Owner = "$9D1C2B5F";
+}
+CParticleNodePinOut	$732C7EE9
+{
+	SelfName = "Value";
+	Owner = "$9D1C2B5F";
+}
+CRHIRenderingFeature	$16512360
+{
+	FeatureName = "TriangleCustomUVs";
+}
+CParticleNodeTemplateExport	$8A52D5A3
+{
+	Description = {
+		"@eng:Position of the first triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$362883A2",
+	};
+	OutputPins = {
+		"$94ABBA0D",
+	};
+	ExportedName = "General.Position1";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$362883A2
+{
+	SelfName = "DefaultValue";
+	Owner = "$8A52D5A3";
+}
+CParticleNodePinOut	$94ABBA0D
+{
+	SelfName = "Value";
+	Owner = "$8A52D5A3";
+}
+CParticleNodeTemplateExport	$0AA9AB54
+{
+	Description = {
+		"@eng:Position of the second triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$D93542A7",
+	};
+	OutputPins = {
+		"$ED8932F6",
+	};
+	ExportedName = "General.Position2";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$D93542A7
+{
+	SelfName = "DefaultValue";
+	Owner = "$0AA9AB54";
+}
+CParticleNodePinOut	$ED8932F6
+{
+	SelfName = "Value";
+	Owner = "$0AA9AB54";
+}
+CParticleNodeTemplateExport	$E17BB1F1
+{
+	Description = {
+		"@eng:Position of the third triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$85CF4F08",
+	};
+	OutputPins = {
+		"$0AD9166B",
+	};
+	ExportedName = "General.Position3";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$85CF4F08
+{
+	SelfName = "DefaultValue";
+	Owner = "$E17BB1F1";
+}
+CParticleNodePinOut	$0AD9166B
+{
+	SelfName = "Value";
+	Owner = "$E17BB1F1";
+}
+CParticleNodeTemplateExport	$2C3FF00A
+{
+	Description = {
+		"@eng:Decal projection box center in world coordinates",
+	};
+	InputPins = {
+		"$B0EFEA95",
+	};
+	OutputPins = {
+		"$F419E27C",
+	};
+	ExportedName = "General.Position";
+	ExportedType = float3;
+	Semantic = 3D_Coordinate;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$B0EFEA95
+{
+	SelfName = "DefaultValue";
+	Owner = "$2C3FF00A";
+}
+CParticleNodePinOut	$F419E27C
+{
+	SelfName = "Value";
+	Owner = "$2C3FF00A";
+}
+CParticleNodeTemplateExport	$17C8B4EF
+{
+	Description = {
+		"@eng:Decal projection box size",
+	};
+	InputPins = {
+		"$CAB4EEDE",
+	};
+	OutputPins = {
+		"$B6BAA7F9",
+	};
+	ExportedName = "General.Scale";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+	DefaultValueF4 = float4(1.0000000e+00, 1.0000000e+00, 1.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$CAB4EEDE
+{
+	SelfName = "DefaultValue";
+	Owner = "$17C8B4EF";
+}
+CParticleNodePinOut	$B6BAA7F9
+{
+	SelfName = "Value";
+	Owner = "$17C8B4EF";
+}
+CParticleNodeTemplateExport	$D246F9B0
+{
+	Description = {
+		"@eng:Decal projection box orientation",
+	};
+	InputPins = {
+		"$3A074233",
+	};
+	OutputPins = {
+		"$8FD82372",
+	};
+	ExportedName = "General.Orientation";
+	ExportedType = orientation;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:General",
+	};
+}
+CParticleNodePinIn	$3A074233
+{
+	SelfName = "DefaultValue";
+	Owner = "$D246F9B0";
+}
+CParticleNodePinOut	$8FD82372
+{
+	SelfName = "Value";
+	Owner = "$D246F9B0";
+}
+CParticleNodeTemplateExport	$2FD0EE1D
+{
+	Description = {
+		"@eng:Start of the fade on the top section of the decal box volume.\\n<ul>\\n<li><c>1.0</c> starts fading linearly at the box center, all the way to the top.</li>\\n<li><c>0.5</c> starts fading linearly halfway between the center and the top.</li>\\n<li><c>0.0</c> has no fade and the decal abruptly stops at the top of the box.</li>\\n</ul>",
+	};
+	InputPins = {
+		"$2A2DE8A4",
+	};
+	OutputPins = {
+		"$0DD4A237",
+	};
+	ExportedName = "Decal.FadeTop";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Decal",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$2A2DE8A4
+{
+	SelfName = "DefaultValue";
+	Owner = "$2FD0EE1D";
+}
+CParticleNodePinOut	$0DD4A237
+{
+	SelfName = "Value";
+	Owner = "$2FD0EE1D";
+}
+CParticleNodeTemplateExport	$BF3541C6
+{
+	Description = {
+		"@eng:Start of the fade on the bottom section of the decal box volume.\\n<ul>\\n<li><c>1.0</c> starts fading linearly at the box center, all the way to the bottom.</li>\\n<li><c>0.5</c> starts fading linearly halfway between the center and the bottom.</li>\\n<li><c>0.0</c> has no fade and the decal abruptly stops at the bottom of the box.</li>\\n</ul>",
+	};
+	InputPins = {
+		"$C00E8101",
+	};
+	OutputPins = {
+		"$2F33C358",
+	};
+	ExportedName = "Decal.FadeBottom";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Decal",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	DefaultValueF4 = float4(5.0000000e-01, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$C00E8101
+{
+	SelfName = "DefaultValue";
+	Owner = "$BF3541C6";
+}
+CParticleNodePinOut	$2F33C358
+{
+	SelfName = "Value";
+	Owner = "$BF3541C6";
+}
+CParticleNodeTemplateExport	$6D3178FB
+{
+	Description = {
+		"@eng:Reserved, not yet implemented",
+	};
+	InputPins = {
+		"$98C7BDDA",
+	};
+	OutputPins = {
+		"$4499E4A5",
+	};
+	ExportedName = "Decal.FadeAngle";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Decal",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 0.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+}
+CParticleNodePinIn	$98C7BDDA
+{
+	SelfName = "DefaultValue";
+	Owner = "$6D3178FB";
+}
+CParticleNodePinOut	$4499E4A5
+{
+	SelfName = "Value";
+	Owner = "$6D3178FB";
+}
+CParticleNodeTemplateExport	$8E7F5DCC
+{
+	Description = {
+		"@eng:Normal of the first triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$2A232A7F",
+	};
+	OutputPins = {
+		"$BE8ECBAE",
+	};
+	ExportedName = "TriangleCustomNormals.Normal1";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+}
+CParticleNodePinIn	$2A232A7F
+{
+	SelfName = "DefaultValue";
+	Owner = "$8E7F5DCC";
+}
+CParticleNodePinOut	$BE8ECBAE
+{
+	SelfName = "Value";
+	Owner = "$8E7F5DCC";
+}
+CParticleNodeTemplateExport	$9F085D09
+{
+	Description = {
+		"@eng:Normal of the second triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$C6ED4C00",
+	};
+	OutputPins = {
+		"$8BB7DAC3",
+	};
+	ExportedName = "TriangleCustomNormals.Normal2";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+}
+CParticleNodePinIn	$C6ED4C00
+{
+	SelfName = "DefaultValue";
+	Owner = "$9F085D09";
+}
+CParticleNodePinOut	$8BB7DAC3
+{
+	SelfName = "Value";
+	Owner = "$9F085D09";
+}
+CParticleNodeTemplateExport	$33E15F42
+{
+	Description = {
+		"@eng:Normal of the third triangle vertex in world coordinates",
+	};
+	InputPins = {
+		"$3D41EE2D",
+	};
+	OutputPins = {
+		"$9CC3E1F4",
+	};
+	ExportedName = "TriangleCustomNormals.Normal3";
+	ExportedType = float3;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+}
+CParticleNodePinIn	$3D41EE2D
+{
+	SelfName = "DefaultValue";
+	Owner = "$33E15F42";
+}
+CParticleNodePinOut	$9CC3E1F4
+{
+	SelfName = "Value";
+	Owner = "$33E15F42";
+}
+CParticleNodeTemplateExport	$31CA6DC7
+{
+	Description = {
+		"@eng:UV of the first triangle vertex",
+	};
+	InputPins = {
+		"$6A822C96",
+	};
+	OutputPins = {
+		"$E2255C11",
+	};
+	ExportedName = "TriangleCustomUVs.UV1";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomUVs",
+	};
+}
+CParticleNodePinIn	$6A822C96
+{
+	SelfName = "DefaultValue";
+	Owner = "$31CA6DC7";
+}
+CParticleNodePinOut	$E2255C11
+{
+	SelfName = "Value";
+	Owner = "$31CA6DC7";
+}
+CParticleNodeTemplateExport	$7D2733A8
+{
+	Description = {
+		"@eng:UV of the second triangle vertex",
+	};
+	InputPins = {
+		"$C386878B",
+	};
+	OutputPins = {
+		"$9173A7AA",
+	};
+	ExportedName = "TriangleCustomUVs.UV2";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomUVs",
+	};
+}
+CParticleNodePinIn	$C386878B
+{
+	SelfName = "DefaultValue";
+	Owner = "$7D2733A8";
+}
+CParticleNodePinOut	$9173A7AA
+{
+	SelfName = "Value";
+	Owner = "$7D2733A8";
+}
+CParticleNodeTemplateExport	$F2EC2AB5
+{
+	Description = {
+		"@eng:UV of the third triangle vertex",
+	};
+	InputPins = {
+		"$654D151C",
+	};
+	OutputPins = {
+		"$8CAC8C0F",
+	};
+	ExportedName = "TriangleCustomUVs.UV3";
+	ExportedType = float2;
+	Type = Input;
+	VisibleByDefault = true;
+	CategoryName = {
+		"@eng:TriangleCustomUVs",
+	};
+}
+CParticleNodePinIn	$654D151C
+{
+	SelfName = "DefaultValue";
+	Owner = "$F2EC2AB5";
+}
+CParticleNodePinOut	$8CAC8C0F
+{
+	SelfName = "Value";
+	Owner = "$F2EC2AB5";
+}
+CParticleRendererFeature	$5CBB6243
+{
+	FeatureName = "Tint";
+	Feature = "$1C055142";
+	Properties = {
+		"$1810889B",
+		"$835BB7A2",
+	};
+}
+CParticleNodeTemplateExport	$1C055142
+{
+	InputPins = {
+		"$3E911FBB",
+	};
+	OutputPins = {
+		"$9A13A2A4",
+	};
+	ExportedName = "Tint";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$3E911FBB
+{
+	SelfName = "DefaultValue";
+	Owner = "$1C055142";
+}
+CParticleNodePinOut	$9A13A2A4
+{
+	SelfName = "Value";
+	Owner = "$1C055142";
+}
+CRHIRenderingFeature	$DD26542E
+{
+	FeatureName = "Tint";
+	UseUV = true;
+	PropertiesAsShaderConstants = {
+		"TintColor",
+		"TintMap",
+	};
+}
+CParticleNodeTemplateExport	$5928161E
+{
+	InputPins = {
+		"$AAD9158D",
+	};
+	OutputPins = {
+		"$21472E15",
+	};
+	ExportedName = "Lit.Type";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Solid",
+		"Transparent",
+	};
+}
+CParticleNodePinIn	$AAD9158D
+{
+	SelfName = "DefaultValue";
+	Owner = "$5928161E";
+}
+CParticleNodePinOut	$21472E15
+{
+	SelfName = "Value";
+	Owner = "$5928161E";
+}
+CParticleNodeTemplateExport	$E31D7A62
+{
+	InputPins = {
+		"$23C05B6B",
+	};
+	OutputPins = {
+		"$B2F13921",
+	};
+	ExportedName = "Lit.LitMaskMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Lit",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Lit.Type";
+	RuleValue = "1";
+}
+CParticleNodePinIn	$23C05B6B
+{
+	SelfName = "DefaultValue";
+	Owner = "$E31D7A62";
+}
+CParticleNodePinOut	$B2F13921
+{
+	SelfName = "Value";
+	Owner = "$E31D7A62";
+}
+CParticleNodeTemplateExport	$835BB7A2
+{
+	Description = {
+		"@eng:Tint color, multiplied with the tint texture",
+	};
+	InputPins = {
+		"$247C7B76",
+	};
+	OutputPins = {
+		"$A5761DE0",
+	};
+	ExportedName = "Tint.TintColor";
+	ExportedType = float4;
+	Semantic = Color;
+	Type = Input;
+	CategoryName = {
+		"@eng:Tint",
+	};
+	DefaultValueF4 = float4(2.1404114e-01, 1.0000000e+00, 1.0000000e+00, 1.0000000e+00);
+}
+CParticleNodePinIn	$247C7B76
+{
+	SelfName = "DefaultValue";
+	Owner = "$835BB7A2";
+}
+CParticleNodePinOut	$A5761DE0
+{
+	SelfName = "Value";
+	Owner = "$835BB7A2";
+}
+CParticleNodeTemplateExport	$1810889B
+{
+	Description = {
+		"@eng:Texture map used for the tint",
+	};
+	InputPins = {
+		"$A8F184F2",
+	};
+	OutputPins = {
+		"$2C0DB175",
+	};
+	ExportedName = "Tint.TintMap";
+	ExportedType = dataImage;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Tint",
+	};
+	DefaultValueData = "Library/PopcornFXCore/Materials/DefaultTextures/White.dds";
+}
+CParticleNodePinIn	$A8F184F2
+{
+	SelfName = "DefaultValue";
+	Owner = "$1810889B";
+}
+CParticleNodePinOut	$2C0DB175
+{
+	SelfName = "Value";
+	Owner = "$1810889B";
+}
+CParticleNodeTemplateExport	$E6F904E6
+{
+	Description = {
+		"@eng:Global sort order of the draw calls.\\nDifferent values for 2 renderers will separate their draw call.\\nSmaller values are drawn first (visually behind higher values). The value can be negative.",
+	};
+	InputPins = {
+		"$6E73C722",
+	};
+	OutputPins = {
+		"$21567356",
+	};
+	ExportedName = "Transparent.GlobalSortOverride";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.Type";
+	RuleFunction = Lower;
+	RuleValue = "2";
+}
+CParticleNodePinIn	$6E73C722
+{
+	SelfName = "DefaultValue";
+	Owner = "$E6F904E6";
+}
+CParticleNodePinOut	$21567356
+{
+	SelfName = "Value";
+	Owner = "$E6F904E6";
+}
+CParticleNodeTemplateExport	$20D13232
+{
+	Description = {
+		"@eng:The depth bias allows to offset the draw call bbox along the camera axis (in world units).\\nDifferent values for 2 renderers will separate their drawcall.",
+	};
+	InputPins = {
+		"$EB41CFF7",
+	};
+	OutputPins = {
+		"$240C664B",
+	};
+	ExportedName = "Transparent.CameraSortOffset";
+	ExportedType = float;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Transparent",
+	};
+	RuleResult = Hidden;
+	DependentProperty = "Transparent.SortMode";
+	RuleValue = "1";
+	DependentProperty2 = "Transparent.Type";
+	RuleFunction2 = Lower;
+	RuleValue2 = "2";
+}
+CParticleNodePinIn	$EB41CFF7
+{
+	SelfName = "DefaultValue";
+	Owner = "$20D13232";
+}
+CParticleNodePinOut	$240C664B
+{
+	SelfName = "Value";
+	Owner = "$20D13232";
+}
+CParticleRendererFeature	$71D528E3
+{
+	FeatureName = "UseVertexColors";
+	Feature = "$AD0617FC";
+}
+CParticleNodeTemplateExport	$AD0617FC
+{
+	InputPins = {
+		"$187D07DC",
+	};
+	OutputPins = {
+		"$0307D62D",
+	};
+	ExportedName = "UseVertexColors";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+}
+CParticleNodePinIn	$187D07DC
+{
+	SelfName = "DefaultValue";
+	Owner = "$AD0617FC";
+}
+CParticleNodePinOut	$0307D62D
+{
+	SelfName = "Value";
+	Owner = "$AD0617FC";
+}
+CRHIRenderingFeature	$A2DFDBD4
+{
+	FeatureName = "UseVertexColors";
+	UseMeshVertexColor0 = true;
+}
+CParticleNodeTemplateExport	$423262DF
+{
+	Description = {
+		"@eng:When enabled, the triangle will be treated as double-sided, producing proper lighting on both faces.",
+	};
+	InputPins = {
+		"$50093A59",
+	};
+	OutputPins = {
+		"$6BA68CBE",
+	};
+	ExportedName = "TriangleCustomNormals.DoubleSided";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:TriangleCustomNormals",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"False",
+		"True",
+	};
+}
+CParticleNodePinIn	$50093A59
+{
+	SelfName = "DefaultValue";
+	Owner = "$423262DF";
+}
+CParticleNodePinOut	$6BA68CBE
+{
+	SelfName = "Value";
+	Owner = "$423262DF";
+}
+CParticleNodeTemplateExport	$D65CBB1F
+{
+	Description = {
+		"@eng:When enabled, the light will cast shadows onto the scene.\\n(Not yet implemented in the PopcornFX editor)",
+	};
+	InputPins = {
+		"$EC185DF6",
+	};
+	OutputPins = {
+		"$D1C0CF87",
+	};
+	ExportedName = "Light.CastShadows";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Light",
+	};
+}
+CParticleNodePinIn	$EC185DF6
+{
+	SelfName = "DefaultValue";
+	Owner = "$D65CBB1F";
+}
+CParticleNodePinOut	$D1C0CF87
+{
+	SelfName = "Value";
+	Owner = "$D65CBB1F";
+}
+CParticleNodeTemplateExport	$168DB3A8
+{
+	Description = {
+		"@eng:When enabled, the material will cast shadows onto the scene.\\n(Not yet implemented in the PopcornFX editor)",
+	};
+	InputPins = {
+		"$37398ADE",
+	};
+	OutputPins = {
+		"$D2F92C33",
+	};
+	ExportedName = "Opaque.CastShadows";
+	ExportedType = bool;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+}
+CParticleNodePinIn	$37398ADE
+{
+	SelfName = "DefaultValue";
+	Owner = "$168DB3A8";
+}
+CParticleNodePinOut	$D2F92C33
+{
+	SelfName = "Value";
+	Owner = "$168DB3A8";
+}
+CParticleNodeTemplateExport	$CE2F5487
+{
+	Description = {
+		"@eng:Dithering texture UVs offset (only taken into account if <c>Type</c> is <c>Dithered</c>).\\nUsed to introduce variation in overlayed pixels.",
+	};
+	InputPins = {
+		"$C2F0317F",
+	};
+	OutputPins = {
+		"$4F10E4A2",
+	};
+	ExportedName = "Opaque.DitheringOffset";
+	ExportedType = float2;
+	Type = Input;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+	HasMin = true;
+	HasMax = true;
+	UseSlider = true;
+	MaxValueF4 = float4(1.0000000e+00, 1.0000000e+00, 0.0000000e+00, 0.0000000e+00);
+	BaseVisibility = Disabled;
+	RuleResult = Visible;
+	DependentProperty = "Opaque.Type";
+	RuleValue = "2";
+}
+CParticleNodePinIn	$C2F0317F
+{
+	SelfName = "DefaultValue";
+	Owner = "$CE2F5487";
+}
+CParticleNodePinOut	$4F10E4A2
+{
+	SelfName = "Value";
+	Owner = "$CE2F5487";
+}
+CParticleNodeTemplateExport	$6C08EBFF
+{
+	Description = {
+		"@eng:Dithering mode\\n<ul>\\n<li><b>Regular</b>: pixels are visible when alpha = 1, not drawn when alpha = 0</li>\\n<li><b>InversedAlpha</b>: pixels are visible when alpha = 0, not drawn when alpha = 1 (can be used for cross-fading between two renderers)</li>\\n</ul>",
+	};
+	InputPins = {
+		"$54594687",
+	};
+	OutputPins = {
+		"$FD26D29C",
+	};
+	ExportedName = "Opaque.DitheringMode";
+	ExportedType = int;
+	Type = Input;
+	InputType = Property;
+	CategoryName = {
+		"@eng:Opaque",
+	};
+	DropDownMode = SingleSelect;
+	EnumList = {
+		"Regular",
+		"InversedAlpha",
+	};
+	PinRules = Rule1;
+	BaseVisibility = Hidden;
+	RuleResult = Visible;
+	DependentProperty = "Opaque.Type";
+	RuleValue = "2";
+}
+CParticleNodePinIn	$54594687
+{
+	SelfName = "DefaultValue";
+	Owner = "$6C08EBFF";
+}
+CParticleNodePinOut	$FD26D29C
+{
+	SelfName = "Value";
+	Owner = "$6C08EBFF";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Billboard.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Billboard.pkma
@@ -1,0 +1,104 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$3D324B43",
+		"$D857A09F",
+		"$35A36C4E",
+		"$EA3837ED",
+		"$02499109",
+		"$1DB717AE",
+		"$1098ED35",
+		"$CAD62F46",
+		"$C5F9C9BF",
+		"$9154DFA0",
+		"$35A36B4E",
+		"$4B933A29",
+		"$EAC726E3",
+		"$F936652D",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryBillboard";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$35A36B4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$02499109
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LegacyLit";
+}
+CParticleRendererFeatureDesc	$1DB717AE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "FlipUVs";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Opaque_Billboard.frag";
+}
+CParticleRendererFeatureDesc	$F936652D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Ribbon.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Ribbon.pkma
@@ -1,0 +1,122 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$35A36C4E",
+		"$D857A09F",
+		"$3D324B43",
+		"$D279714D",
+		"$EA3837ED",
+		"$02499109",
+		"$4B933A29",
+		"$9154DFA0",
+		"$EAC726E3",
+		"$4ADE8DE2",
+		"$1098ED35",
+		"$CAD62F46",
+		"$C5F9C9BF",
+		"$41E5AFE7",
+		"$D279714E",
+		"$5F621394",
+		"$BEDF8936",
+		"$3011D520",
+	};
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryRibbon";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D279714D
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$EA3837ED
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$02499109
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "LegacyLit";
+}
+CParticleRendererFeatureDesc	$1098ED35
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$CAD62F46
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Atlas";
+}
+CParticleRendererFeatureDesc	$C5F9C9BF
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalWrap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CorrectDeformation";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "CustomTextureU";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TextureUVs";
+}
+CParticleRendererFeatureDesc	$4ADE8DE2
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TextureRepeat";
+}
+CParticleRendererFeatureDesc	$D279714E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$5F621394
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$41E5AFE7
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalBend";
+}
+CParticleRendererFeatureDesc	$BEDF8936
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Opaque_Ribbon.frag";
+}
+CParticleRendererFeatureDesc	$3011D520
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Triangle.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Opaque_Triangle.pkma
@@ -1,0 +1,63 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$191F1761",
+		"$D857A09F",
+		"$3D324B43",
+		"$35A36C4E",
+		"$9154DFA0",
+		"$4B933A29",
+		"$EAC726E3",
+		"$4ADE8DE2",
+	};
+}
+CParticleRendererFeatureDesc	$191F1761
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryTriangle";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$3D324B43
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Opaque";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Lit";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "NormalBend";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TriangleCustomNormals";
+}
+CParticleRendererFeatureDesc	$4ADE8DE2
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TriangleCustomUVs";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Opaque_Triangle.frag";
+}

--- a/PopcornFX/Library/PopcornFXCore/Materials/Transparent_Mesh.pkma
+++ b/PopcornFX/Library/PopcornFXCore/Materials/Transparent_Mesh.pkma
@@ -1,0 +1,86 @@
+Version = 2.12.0.12699;
+CParticleRendererFeatureSet	$6B70D015
+{
+	RendererFeatures = {
+		"$4126ECB5",
+		"$CF8BEC2E",
+		"$BF96EAFE",
+		"$35A36C4E",
+		"$FF800025",
+		"$D857A09F",
+		"$9154ABA0",
+		"$4B933A29",
+		"$EAC726E3",
+		"$9154DFA0",
+		"$178EB8B0",
+		"$30A73448",
+	};
+}
+CParticleRendererFeatureDesc	$4126ECB5
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "GeometryMesh";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$CF8BEC2E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Transparent";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$BF96EAFE
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Diffuse";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$35A36C4E
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EnableRendering";
+	Mandatory = true;
+}
+CParticleRendererFeatureDesc	$D857A09F
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "MeshAtlas";
+}
+CParticleRendererFeatureDesc	$9154ABA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "AlphaRemap";
+}
+CParticleRendererFeatureDesc	$4B933A29
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "Emissive";
+}
+CParticleRendererFeatureDesc	$EAC726E3
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "DiffuseRamp";
+}
+CParticleRendererFeatureDesc	$9154DFA0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "TransformUVs";
+}
+CParticleRendererFeatureDesc	$FF800025
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "SoftParticles";
+}
+CRHIMaterialShaders	$00269EC3
+{
+	FragmentShader = "Library/PopcornFXCore/Shaders/Transparent_Mesh.frag";
+}
+CParticleRendererFeatureDesc	$178EB8B0
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "EmissiveRamp";
+}
+CParticleRendererFeatureDesc	$30A73448
+{
+	RendererInterfacePath = "Library/PopcornFXCore/Materials/Interface/Editor.pkri";
+	RendererFeatureName = "UseVertexColors";
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Billboard.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Billboard.frag
@@ -1,0 +1,364 @@
+
+#if defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+#if defined(HAS_Lit)
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#   define PI                       3.141592
+#   define  METAL_FRESNEL_FACTOR    vec3(0.04, 0.04, 0.04)
+#   define EPSILON                  1e-5
+
+float normalDistFuncGGX(float cosLh, float roughness)
+{
+	float alpha = roughness * roughness;
+	float alphaSq = alpha * alpha;
+
+	float denom = (cosLh * cosLh) * (alphaSq - 1.0) + 1.0;
+	return alphaSq / (PI * denom * denom);
+}
+
+float schlickGGX(float cosLi, float cosLo, float roughness)
+{
+	float r = roughness + 1.0;
+	float k = (r * r) / 8.0; // UE4 remapping
+
+	float t1 = cosLi / (cosLi * (1.0 - k) + k);
+	float t2 = cosLo / (cosLo * (1.0 - k) + k);
+
+	return t1 * t2;
+}
+ 
+vec3 fresnelSchlick(vec3 surfaceMetalColor, float cosTheta)
+{
+	return surfaceMetalColor + (vec3(1.0, 1.0, 1.0) - surfaceMetalColor) * pow(1.0 - cosTheta, 5.0);
+}
+
+vec3	computeBRDF(vec3 surfToLight, vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor FS_ARGS)
+{
+	vec3    halfVec = normalize(surfToLight + surfToView);
+
+	float   NoL = max(0.0f, dot(surfToLight, surfaceNormal));
+
+#if     defined(HAS_NormalWrap)
+	float   normalWrapFactor = GET_CONSTANT(Material, NormalWrap_WrapFactor);
+	NoL = normalWrapFactor + (1.0f - normalWrapFactor) * NoL;
+#endif
+
+	float   specIntensity = max(0.0f, dot(halfVec, surfaceNormal));
+	float   NoV = max(EPSILON, dot(surfToView, surfaceNormal)); // Weird behavior when this is near 0
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+
+	vec3    F  = fresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float   D = normalDistFuncGGX(specIntensity, roughness);
+	float   G = schlickGGX(NoL, NoV, roughness);
+
+	vec3 diffuseBRDF = mix(vec3(1.0, 1.0, 1.0) - F, vec3(0.0, 0.0, 0.0), metalness) * surfaceColor;
+	vec3 specularBRDF = (F * D * G) / max(EPSILON, 4.0 * NoL * NoV);
+
+	return (diffuseBRDF + specularBRDF) * NoL;
+}
+
+vec3	fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+	return F0 + (max(vec3(1.0f - roughness, 1.0f - roughness, 1.0f - roughness), F0) - F0) * pow(1.0f - cosTheta, 5.0f);
+}
+
+vec3	toCubemapSpace(vec3 value FS_ARGS)
+{
+	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
+	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	return valueRHY;
+}
+
+vec3	computeAmbientBRDF(vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor FS_ARGS)
+{
+	// Cubemaps are expected to be cosined filtered up to the 7th mipmap which should contain the fully diffuse 180 degrees cosine-filtered cubemap.
+	const float	kCubemapMipRange = 6;
+
+	vec3	surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+	vec3	kS = fresnelSchlickRoughness(max(dot(surfaceNormal, surfToView), 0.0), surfaceMetalColor, roughness);
+	vec3	kD = 1.0f - kS;
+	kD *= 1.0f - metalness;
+
+	// Ambient diffuse
+	vec3	irradiance = SAMPLELOD_CUBE(EnvironmentMapSampler, toCubemapSpace(surfaceNormal FS_PARAMS), kCubemapMipRange).rgb;
+	vec3	diffuse = irradiance * surfaceColor;
+
+	// Ambient specular
+	vec3	sampleDir = toCubemapSpace(reflect(-surfToView, surfaceNormal) FS_PARAMS);
+	vec3	prefilteredColor = SAMPLELOD_CUBE(EnvironmentMapSampler, sampleDir, roughness * kCubemapMipRange).rgb;
+	vec2	envBRDF  = SAMPLE(BRDFLUTSampler, vec2(max(dot(surfaceNormal, surfToView), 0.0), roughness)).rg;
+	vec3	specular = prefilteredColor * (kS * envBRDF.x + envBRDF.y);
+
+	vec3	ambient = kD * diffuse + specular;
+	
+	return ambient;
+}
+
+#endif
+
+#if defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec4    color;
+
+#if     defined(FINPUT_fragDiffuse_Color)
+	color = fInput.fragDiffuse_Color;
+#else
+	color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if     defined(HAS_Diffuse) || defined(HAS_Lit) || defined(HAS_LegacyLit) || defined(HAS_Emissive) // has texture sampling
+
+	vec2    fragUV0 = fInput.fragUV0;
+
+#if		defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2	fragUV1 = fInput.fragUV1;
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+#endif // has texture sampling
+
+#if	defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif
+
+#if	defined(HAS_Diffuse)
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif
+
+#if defined(HAS_DiffuseRamp)
+	textureColor.rgb = SAMPLE(DiffuseRamp_RampMap, vec2(textureColor.x,0.0)).rgb;
+#endif
+
+	color *= textureColor;
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(color.a, fInput.fragAlphaRemap_Cursor);
+	color.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif 
+
+#endif // defined HAS_Diffuse
+
+#if	defined(HAS_SoftParticles)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	color *= depthfade;
+#endif
+
+#if defined(HAS_Lit)
+	vec3 surfacePosition = fInput.fragWorldPosition;
+
+	vec3 normalTex1 = SAMPLE(Lit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(Lit_NormalMap, fragUV1).xyz;
+		normalTex1 = mix(normalTex1, normalTex2, blendMix);
+	}
+#endif
+	normalTex1 = 2.0f * normalTex1.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex1.xy = mul(UVInverseRotation, normalTex1.xy);
+#	endif
+
+	vec3	T = normalize(fInput.fragTangent.xyz);
+	vec3	N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3	TBN = BUILD_MAT3(T, B, N);
+
+	vec3	surfaceNormal = normalize(mul(TBN, normalTex1.xyz));
+
+	float 	surfaceRoughness = GET_CONSTANT(Material, Lit_Roughness);
+	float	surfaceMetalness = GET_CONSTANT(Material, Lit_Metalness);
+
+	bool 	hasDirLight = GET_CONSTANT(LightInfo, DirectionalLightsCount) >= 1;
+	vec3 	lightDirection = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(0)) : vec3(0, 1, 0);
+	vec3 	lightColor = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(8)) : VEC3_ZERO;
+
+	vec3	viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	vec3	surfToView = viewPosition - surfacePosition;
+	vec3	surfToLight = -lightDirection;
+	vec3	surfToLightDir = normalize(surfToLight);
+	vec3	surfToViewDir = normalize(surfToView);
+
+	vec3	lightDiffuse = computeBRDF(	surfToLightDir,
+										surfToViewDir,
+										surfaceNormal,
+										surfaceRoughness,
+										surfaceMetalness,
+										color.rgb
+										FS_PARAMS);
+
+	vec3	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+	vec3	lightAmbient = computeAmbientBRDF(	surfToViewDir,
+												surfaceNormal,
+												surfaceRoughness,
+												surfaceMetalness,
+												color.rgb
+												FS_PARAMS);
+
+	color.rgb = lightDiffuse * lightColor + lightAmbient * ambientColor;
+
+#elif defined(HAS_LegacyLit)
+
+	vec3 normalTex1 =  SAMPLE(LegacyLit_NormalMap, fragUV0).xyz;
+#if 	defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(LegacyLit_NormalMap, fragUV1).xyz;
+		normalTex1 = mix(normalTex1, normalTex2, blendMix);
+	}
+#endif
+
+	normalTex1 = 2.0f * normalTex1.xyz - vec3(1.0f, 1.0f, 1.0f);
+	
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex1.xy = mul(UVInverseRotation, normalTex1.xy);
+#	endif
+
+	vec3	T = normalize(fInput.fragTangent.xyz);
+	vec3	N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3	TBN = BUILD_MAT3(T, B, N);
+
+	vec3 surfaceNormal = normalize(mul(TBN, normalTex1.xyz));
+
+	bool 	hasDirLight = GET_CONSTANT(LightInfo, DirectionalLightsCount) >= 1;
+	vec3 	lightDirection = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(0)) : vec3(0, 1, 0);
+	vec3 	lightColor = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(8)) : VEC3_ZERO;
+
+	// Compute the light incidence
+	vec3	posToLightDirection = -normalize(lightDirection); // for the directional lights, instead of the position, we get the orientation
+	float	incidenceRemap = GET_CONSTANT(Material, LegacyLit_NormalWrapFactor) * 0.5f;
+	float	lightIncidence = max(0.f, incidenceRemap + (1.f - incidenceRemap) * dot(posToLightDirection, surfaceNormal));
+	lightIncidence = pow(lightIncidence, GET_CONSTANT(Material, LegacyLit_LightExponent));
+	vec3	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+	//  Compute the ambient light
+	vec3	lightAmbient = 	ambientColor + GET_CONSTANT(Material, LegacyLit_AmbientLight);
+	// Final light factor
+	color.rgb *= (lightColor * lightIncidence + lightAmbient) * GET_CONSTANT(Material, LegacyLit_LightScale);
+#endif
+
+#if	defined(HAS_Emissive)
+	vec3	emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;
+
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#endif
+
+#if	defined(HAS_EmissiveRamp)
+	emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
+#endif
+
+	emissiveColor1 *= fInput.fragEmissive_EmissiveColor;
+
+	color.rgb += emissiveColor1.rgb;
+#endif	
+
+	fOutput.Output0 = color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Decal.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Decal.frag
@@ -1,0 +1,112 @@
+
+vec3    DepthToWorldPos(float pDepthValue, vec2 pUv, mat4 pInvViewProj)
+{
+	vec2    clipSpace = pUv * 2.0 - 1.0;
+	vec4    projPos = vec4(clipSpace, pDepthValue, 1.0);
+	projPos = mul(pInvViewProj, projPos);
+	return projPos.xyz / projPos.w;
+}
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec2    screenTexCoord = fInput.fragViewProjPosition.xy / fInput.fragViewProjPosition.w * 0.5 + 0.5;
+	float   depthValue = SAMPLE(DepthSampler, screenTexCoord).r;
+	mat4    invViewProj = GET_CONSTANT(SceneInfo, InvViewProj);
+	vec3    surfacePosition = DepthToWorldPos(depthValue, screenTexCoord, invViewProj);
+
+	mat4	userToLHZ = GET_CONSTANT(SceneInfo, UserToLHZ);
+	mat4 	inverseDecalTransform = mul(userToLHZ, fInput.fragInverseDecalTransform);
+	vec3 	normalizedDecalSpace = mul(inverseDecalTransform, vec4(surfacePosition, 1.0)).xyz;
+	
+	if (ANY_BOOL(VEC_GREATER_THAN(normalizedDecalSpace, VEC3_ONE)) || ANY_BOOL(VEC_LESS_THAN(normalizedDecalSpace, -VEC3_ONE)))
+		discard;
+
+	vec2	fragUV0 = normalizedDecalSpace.xy * vec2(0.5f, 0.5f) + 0.5f;
+
+#if 	defined(HAS_Atlas)
+	vec2	fragUV1 = fragUV0;
+	
+	fragUV0 *= LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1)).xy;
+	fragUV0 += LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1)).zw;
+	fragUV1 *= LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1)).xy;
+	fragUV1 += LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1)).zw;
+	
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif
+
+	float	fadeRangeTop = GET_CONSTANT(Material, Decal_FadeTop);
+	float 	startFadeTop = 1.0f - fadeRangeTop;
+	float	fadeRangeBottom = GET_CONSTANT(Material, Decal_FadeBottom);
+	float 	startFadeBottom = 1.0f - fadeRangeBottom;
+
+	float 	startFade = (normalizedDecalSpace.z < 0.0f) ? startFadeBottom : startFadeTop;
+	float 	fadeRange = (normalizedDecalSpace.z < 0.0f) ? fadeRangeBottom : fadeRangeTop;
+	float	fade = 1.0f - clamp((abs(normalizedDecalSpace.z) - startFade) / fadeRange, 0.0f, 1.0f);
+
+#if 	defined(HAS_Diffuse)
+	vec4 	diffuseColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    diffuseColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+		diffuseColor = mix(diffuseColor, diffuseColor2, blendMix);
+	}
+#	endif
+
+	diffuseColor *= fInput.fragDiffuse_Color;
+
+	diffuseColor.a *= fade;
+	diffuseColor.rgb *= diffuseColor.a;
+	fOutput.Output0 = diffuseColor;
+#else
+	// Diffuse buffer
+	fOutput.Output0 = vec4(0.0, 0.0, 0.0, 0.0);
+#endif
+
+#if 	defined(HAS_Emissive)
+
+	vec4 	emissiveColor = SAMPLE(Emissive_EmissiveMap, fragUV0);
+	
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1);
+		emissiveColor = mix(emissiveColor, emissiveColor2, blendMix);
+	}
+#	endif
+
+	emissiveColor *= vec4(fInput.fragEmissive_EmissiveColor, fade);
+
+	emissiveColor.rgb *= emissiveColor.a;
+	emissiveColor.a = 0.0f; // Not absorptive
+	fOutput.Output1 = emissiveColor;
+#else
+	// Emissive buffer
+	fOutput.Output1 = vec4(0.0, 0.0, 0.0, 0.0);
+#endif
+	// Normal / roughness / metalness
+	fOutput.Output2 = vec4(0.0, 0.0, 0.0, 0.0);
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Decal.vert
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Decal.vert
@@ -1,0 +1,11 @@
+
+void    VertexMain(IN(SVertexInput) vInput, INOUT(SVertexOutput) vOutput VS_ARGS)
+{
+	vec3 	transformedPos = mul(vInput.DecalTransform, vec4(vInput.Position, 1.0)).xyz;
+	mat4    viewProj = GET_CONSTANT(SceneInfo, ViewProj); 
+
+	vOutput.VertexPosition = mul(viewProj, vec4(transformedPos, 1.0));  // World to view
+	vOutput.fragWorldPosition = vInput.Position;
+	vOutput.fragViewProjPosition = vOutput.VertexPosition;
+	vOutput.fragInverseDecalTransform = vInput.InverseDecalTransform;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Light.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Light.frag
@@ -1,0 +1,227 @@
+
+vec3    DepthToWorldPos(float pDepthValue, vec2 pUv, mat4 pInvViewProj)
+{
+	vec2    clipSpace = pUv * 2 - 1;
+	vec4    projPos = vec4(clipSpace, pDepthValue, 1);
+	projPos = mul(pInvViewProj, projPos);
+	return projPos.xyz / projPos.w;
+}
+
+vec3 UnpackNormalSpheremap(vec2 normal FS_ARGS)
+{
+	vec2 	fenc = normal * 4.0f - 2.0f;
+	float 	f = dot(fenc, fenc);
+	float 	g = sqrt(1.0f - f / 4.0f);
+	vec3 	outNormal;
+	outNormal.xy = fenc * g;
+	outNormal.z = 1.0f - f / 2.0f;
+	return mul(GET_CONSTANT(SceneInfo, UnpackNormalView), vec4(outNormal, 0.0f)).xyz;
+}
+
+vec3    UnpackNormalStd(vec3 normal)
+{
+	return normal * 2 - 1;
+}
+
+// Julien's fall-off function:
+// The constants A and B should be computed on CPU and passed as constants to the shader
+//------------------------------
+// k = 1.0 / steepness
+// x = normalized distance
+//------------------------------
+//  float A = 1 / pow(k + 1, 2);
+//  float B = 1 - A;
+//  float C = 1 / pow(x * k + 1, 2);
+//  return (C - A) / B;
+//------------------------------
+float   unlinearizeFalloff(float x FS_ARGS)
+{
+	float k = 1 / (GET_CONSTANT(Material, LightAttenuation_AttenuationSteepness) + 1.0e-3f);
+	float A = 1 / ((k + 1) * (k + 1));
+	float B = 1 - A;
+	float C = 1 / ((x * k + 1) * (x * k + 1));
+	return (C - A) / B;
+}
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#define PI                      3.141592f
+#define METAL_FRESNEL_FACTOR    vec3(0.04f, 0.04f, 0.04f)
+#define EPSILON                 1.0e-5f
+
+#if     HAS_SphereLight // Experimental area-light
+
+float normalDistFuncGGX(float cosLh, float roughness, float normFactor)
+{
+	float alpha   = roughness * roughness;
+	float alphaSq = alpha * alpha;
+
+	float denom = (cosLh * cosLh) * (alphaSq - 1) + 1;
+	return (normFactor * alpha) / (PI * denom * denom);
+}
+
+#else
+
+float   normalDistFuncGGX(float cosLh, float roughness)
+{
+	float alpha   = roughness * roughness;
+	float alphaSq = alpha * alpha;
+
+	float denom = (cosLh * cosLh) * (alphaSq - 1) + 1;
+	return alphaSq / (PI * denom * denom);
+}
+
+#endif
+
+float   schlickGGX(float cosLi, float cosLo, float roughness)
+{
+	float r = roughness + 1;
+	float k = (r * r) / 8; // UE4 remapping
+
+	float t1 = cosLi / (cosLi * (1 - k) + k);
+	float t2 = cosLo / (cosLo * (1 - k) + k);
+
+	return t1 * t2;
+}
+
+vec3    fresnelSchlick(vec3 surfaceMetalColor, float cosTheta)
+{
+	return surfaceMetalColor + (vec3(1, 1, 1) - surfaceMetalColor) * pow(1 - cosTheta, 5.0f);
+}
+
+#if     HAS_SphereLight // Experimental area-light
+
+vec3 computeBRDF(vec3 surfToLightSurf, vec3 surfToLightCenter, vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor, float normFactor)
+{
+	vec3    halfVec = normalize(surfToLightSurf + surfToView);
+
+	float   NoL = max(0.0f, dot(surfToLightCenter, surfaceNormal));
+	float   specIntensity = max(0.0f, dot(halfVec, surfaceNormal));
+	float   NoV = max(EPSILON, dot(surfToView, surfaceNormal)); // Weird behavior when this is near 0
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+
+	vec3    F  = fresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float   D = normalDistFuncGGX(specIntensity, roughness, normFactor);
+	float   G = schlickGGX(NoL, NoV, roughness);
+
+	vec3    diffuseBRDF = mix(vec3(1, 1, 1) - F, vec3(0, 0, 0), metalness) * surfaceColor;
+	vec3    specularBRDF = (F * D * G) / max(EPSILON, 4 * NoL * NoV);
+
+	return (diffuseBRDF + specularBRDF) * NoL;
+}
+
+#else
+
+vec3 computeBRDF(vec3 surfToLight, vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor)
+{
+	vec3    halfVec = normalize(surfToLight + surfToView);
+
+	float   NoL = max(0.0f, dot(surfToLight, surfaceNormal));
+	float   specIntensity = max(0.0f, dot(halfVec, surfaceNormal));
+	float   NoV = max(EPSILON, dot(surfToView, surfaceNormal)); // Weird behavior when this is near 0
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+	
+	vec3    F  = fresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float   D = normalDistFuncGGX(specIntensity, roughness);
+	float   G = schlickGGX(NoL, NoV, roughness);
+
+	vec3 diffuseBRDF = mix(vec3(1, 1, 1) - F, vec3(0, 0, 0), metalness) * surfaceColor;
+	vec3 specularBRDF = (F * D * G) / max(EPSILON, 4 * NoL * NoV);
+
+	return (diffuseBRDF + specularBRDF) * NoL;
+}
+
+#endif
+
+vec3        nearestReflectedSpherePoint(vec3 surfToLight, vec3 viewToSurf, vec3 surfaceNormal, float lightSphereRadius)
+{
+	vec3    reflected = reflect(normalize(viewToSurf), normalize(surfaceNormal));
+	vec3    centerToRay = dot(surfToLight, reflected) * reflected - surfToLight;
+	float   squareRad = lightSphereRadius * lightSphereRadius;
+
+	return normalize(surfToLight + centerToRay * clamp(lightSphereRadius / length(centerToRay), 0.0, 1.0));
+}
+
+void        FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	float 		lightRange = fInput.fragLightAttenuation_Range;
+	vec3    	lightColor = fInput.fragLight_Color.xyz;
+	vec3    	lightPosition = fInput.fragLightPosition;
+
+	vec3		viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	mat4    	invViewProj = GET_CONSTANT(SceneInfo, InvViewProj);
+	mat4    	invView = GET_CONSTANT(SceneInfo, InvView);
+	
+	vec2    	screenTexCoord = fInput.fragViewProjPosition.xy / fInput.fragViewProjPosition.w * 0.5 + 0.5;
+	float   	depthValue = SAMPLE(DepthSampler, screenTexCoord).r;
+	vec3    	surfacePosition = DepthToWorldPos(depthValue, screenTexCoord, invViewProj);
+	vec3    	surfToLight = lightPosition - surfacePosition;
+	float 		sqRange = lightRange * lightRange;
+	float 		sqDistanceToLight = dot(surfToLight, surfToLight);
+
+	if (sqDistanceToLight > sqRange)
+		discard;
+
+	float 		distanceToLight = sqrt(sqDistanceToLight);
+	vec3    	surfToLightDir = normalize(surfToLight);
+	vec3    	surfToView = viewPosition - surfacePosition;
+	vec3    	surfToViewDir = normalize(surfToView);
+	vec3    	surfaceColor = SAMPLE(DiffuseSampler, screenTexCoord).rgb;
+	vec4    	packedNormalRoughMetal = SAMPLE(NormalRoughMetalSampler, screenTexCoord);
+	vec3    	surfaceNormal = UnpackNormalSpheremap(packedNormalRoughMetal.rg FS_PARAMS);
+	float   	surfaceRoughness = packedNormalRoughMetal.z;
+	float   	surfaceMetalness = packedNormalRoughMetal.w;
+
+	if (surfaceRoughness < 0.0f && surfaceMetalness < 0.0f)
+	{
+		// Unlit surface
+		fOutput.Output0 = vec4(surfaceColor, 0.0f);
+		return;
+	}
+	// Lit surface
+	surfaceRoughness = max(0.01f, surfaceRoughness);
+	surfaceMetalness = max(0.01f, surfaceMetalness);
+
+#if     HAS_SphereLight // Experimental area-light
+
+	float   lightSphereRadius = fInput.fragSphereRadius;
+
+	vec3    adjustedSurfToLight = nearestReflectedSpherePoint(surfToLight, surfToView, surfaceNormal, lightSphereRadius);
+	
+	float   lightDist = length(surfToLight);
+	float   alpha = surfaceRoughness * surfaceRoughness;
+	float   alphaPrime = clamp(lightSphereRadius / (lightDist * 2.0) + alpha, 0.0f, 1.0f);
+	
+	vec3    lightContrib = computeBRDF( adjustedSurfToLight,
+										surfToLightDir,
+										surfToViewDir,
+										surfaceNormal,
+										surfaceRoughness,
+										surfaceMetalness,
+										surfaceColor,
+										alphaPrime);
+
+	// Compute the light attenuation:
+	float   distToLightSurface = max(0.0f, length(surfToLight) - lightSphereRadius);
+	float   normalizedDistanceToLight = min(1.0f, (distToLightSurface / lightRange));
+	float   lightAttenuation = unlinearizeFalloff(normalizedDistanceToLight FS_PARAMS);
+	fOutput.Output0 = vec4(lightContrib * lightAttenuation * lightColor, 0.0f);
+
+#else
+
+
+	vec3    lightDiffuse = computeBRDF( surfToLightDir,
+										surfToViewDir,
+										surfaceNormal,
+										surfaceRoughness,
+										surfaceMetalness,
+										surfaceColor);
+	// Compute the light attenuation:
+	float   normalizedDistanceToLight = min(1.0f, distanceToLight / lightRange);
+	float   lightAttenuation = unlinearizeFalloff(normalizedDistanceToLight FS_PARAMS);
+	fOutput.Output0 = vec4(lightDiffuse * lightAttenuation * lightColor, 0.0f);
+#endif
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Light.vert
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Light.vert
@@ -1,0 +1,20 @@
+
+void    VertexMain(IN(SVertexInput) vInput, INOUT(SVertexOutput) vOutput VS_ARGS)
+{
+	// compute world space vertex position:
+
+#if     HAS_SphereLight
+	vec3    transformedPos = vInput.Position * (vInput.LightAttenuation_Range + vInput.SphereRadius) + vInput.LightPosition;
+	vOutput.fragSphereRadius = vInput.SphereRadius;
+#else
+	vec3    transformedPos = vInput.Position * vInput.LightAttenuation_Range + vInput.LightPosition;
+#endif
+
+	mat4    viewProj = GET_CONSTANT(SceneInfo, ViewProj);
+	vOutput.VertexPosition = mul(viewProj, vec4(transformedPos, 1.0));  // World to view
+	vOutput.fragWorldPosition = vInput.Position;
+	vOutput.fragViewProjPosition = vOutput.VertexPosition;
+	vOutput.fragLightPosition = vInput.LightPosition;
+	vOutput.fragLightAttenuation_Range = vInput.LightAttenuation_Range;
+	vOutput.fragLight_Color = vInput.Light_Color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Mesh.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Mesh.frag
@@ -1,0 +1,161 @@
+
+vec2 PackNormalSpheremap(vec3 normal FS_ARGS)
+{
+	normal = normalize(normal);
+	normal = mul(GET_CONSTANT(SceneInfo, PackNormalView), vec4(normal, 0.0f)).xyz;
+	float f = sqrt(8.0f * normal.z + 8.0f);
+	return normal.xy / f + 0.5f;
+}
+
+#if 	defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	float   roughness = -1.0f;
+	float   metalness = -1.0f;
+	vec3    normal = vec3(1,0,0);
+	vec4    color = vec4(0,0,0,0);
+	vec4    emissive = vec4(0,0,0,0);
+
+#if	    defined(FINPUT_fragDiffuse_Color)
+	color = fInput.fragDiffuse_Color;
+#else
+	color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if	    defined(FINPUT_fragColor0)
+	color *= fInput.fragColor0;
+#endif
+
+vec2 fragUV0 = fInput.fragUV0;
+
+#if		defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0);
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif
+
+#if	defined(HAS_Diffuse)
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a = SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif
+
+#if defined(HAS_DiffuseRamp)
+	textureColor.rgb =  SAMPLE(DiffuseRamp_RampMap, vec2(textureColor.x,0.0)).rgb;
+#endif
+
+	color *= textureColor;
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(color.a, fInput.fragAlphaRemap_Cursor);
+	color.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif 
+
+#endif // defined HAS_Diffuse
+
+#if	defined(HAS_Opaque)
+    if (GET_CONSTANT(Material, Opaque_Type) == 1 &&
+		color.a < GET_CONSTANT(Material, Opaque_MaskThreshold))
+        discard;
+#endif
+
+#if defined(HAS_DiffuseRamp)
+	color.rgb = SAMPLE(DiffuseRamp_RampMap, vec2(color.r, 0.0)).rgb;
+#endif
+
+#if     defined(HAS_Lit)
+
+	vec3    normalTex =  SAMPLE(Lit_NormalMap, fragUV0).xyz;
+
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+	
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if	defined(HAS_TransformUVs)
+		float sinMR = -sinR; // sin(-rot) = -sin(rot)
+		float cosMR = cosR; // cos(-rot) = cos(rot)
+		mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+		normalTex.xy = mul(UVInverseRotation, normalTex.xy);
+#	endif
+
+	vec3	T = normalize(fInput.fragTangent.xyz);
+	vec3	N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3	TBN = BUILD_MAT3(T, B, N);
+
+	normal = normalize(mul(TBN, normalTex));
+
+	vec2    roughMetal = SAMPLE(Lit_RoughMetalMap, fragUV0).xy;
+
+	roughness = GET_CONSTANT(Material, Lit_Roughness);
+	roughness *= roughMetal.x;
+	metalness = GET_CONSTANT(Material, Lit_Metalness);
+	metalness *= roughMetal.y;
+
+#elif   defined(HAS_LegacyLit)
+
+	vec3    normalTex =  SAMPLE(LegacyLit_NormalMap, fragUV0).xyz;
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+	
+#	if	defined(HAS_TransformUVs)
+		float sinMR = -sinR; // sin(-rot) = -sin(rot)
+		float cosMR = cosR; // cos(-rot) = cos(rot)
+		mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+		normalTex.xy = mul(UVInverseRotation, normalTex.xy);
+#	endif
+	
+	vec3	T = normalize(fInput.fragTangent.xyz);
+	vec3	N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3	TBN = BUILD_MAT3(T, B, N);
+	normal = normalize(mul(TBN, normalTex));
+
+	// In the old lighting feature, we stored the specular and glossiness in the specular map.
+	// To mimic something similar, we juste set the roughness to (1.0 - specularValue) * 0.7 + 0.3 to avoid very sharp specular which did not exist before
+	// The metalness is always 0.
+	roughness = (1.0 - SAMPLE(LegacyLit_SpecularMap, fragUV0).x) * 0.7 + 0.3;
+	metalness = 0.0f;
+
+#else
+
+	emissive = color;
+	color = vec4(0,0,0,0);
+
+#endif
+
+#if defined(HAS_Emissive)
+
+	vec3 emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;	
+	#if defined(HAS_EmissiveRamp)
+		emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
+	#endif
+	emissive.rgb += emissiveColor1 * fInput.fragEmissive_EmissiveColor;
+
+#endif
+
+	vec4    normalSpec;
+	normalSpec = vec4(PackNormalSpheremap(normal FS_PARAMS), roughness, metalness);
+
+	fOutput.Output0 = color;
+	fOutput.Output1 = fInput.fragViewProjPosition.z / fInput.fragViewProjPosition.w;
+	fOutput.Output2 = emissive;
+	fOutput.Output3 = normalSpec;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Ribbon.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Ribbon.frag
@@ -1,0 +1,382 @@
+
+#if     defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+vec2    applyCorrectDeformation(IN(SFragmentInput) fInput, IN(vec2) fragUVin FS_ARGS)
+{
+#if     defined(HAS_CorrectDeformation)
+	vec2 fragUVout;
+	if (fragUVin.x + fragUVin.y < 1)
+		fragUVout = fragUVin.xy / fInput.fragUVFactors.xy;
+	else
+		fragUVout = 1.0 - ((1.0 - fragUVin.xy) / fInput.fragUVFactors.zw);
+#if     defined(HAS_TextureUVs)
+	if (GET_CONSTANT(Material, TextureUVs_RotateTexture) != 0)
+		fragUVout = fragUVout.yx;
+#endif
+	return fragUVout * fInput.fragUVScaleAndOffset.xy + fInput.fragUVScaleAndOffset.zw;
+#else
+	return fragUVin;
+#endif
+}
+
+
+#if     defined(HAS_Lit)
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#   define PI                       3.141592
+#   define  METAL_FRESNEL_FACTOR    vec3(0.04, 0.04, 0.04)
+#   define EPSILON                  1e-5
+
+float normalDistFuncGGX(float cosLh, float roughness)
+{
+	float alpha   = roughness * roughness;
+	float alphaSq = alpha * alpha;
+
+	float denom = (cosLh * cosLh) * (alphaSq - 1.0) + 1.0;
+	return alphaSq / (PI * denom * denom);
+}
+
+float schlickGGX(float cosLi, float cosLo, float roughness)
+{
+	float r = roughness + 1.0;
+	float k = (r * r) / 8.0; // UE4 remapping
+
+	float t1 = cosLi / (cosLi * (1.0 - k) + k);
+	float t2 = cosLo / (cosLo * (1.0 - k) + k);
+
+	return t1 * t2;
+}
+
+vec3 fresnelSchlick(vec3 surfaceMetalColor, float cosTheta)
+{
+	return surfaceMetalColor + (vec3(1.0, 1.0, 1.0) - surfaceMetalColor) * pow(1.0 - cosTheta, 5.0);
+}
+
+vec3 computeBRDF(vec3 surfToLight, vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor FS_ARGS)
+{
+	vec3    halfVec = normalize(surfToLight + surfToView);
+
+	float   NoL = max(0.0f, dot(surfToLight, surfaceNormal));
+
+#if     defined(HAS_NormalWrap)
+	float   normalWrapFactor = GET_CONSTANT(Material, NormalWrap_WrapFactor);
+	NoL = normalWrapFactor + (1.0f - normalWrapFactor) * NoL;
+#endif
+
+	float   specIntensity = max(0.0f, dot(halfVec, surfaceNormal));
+	float   NoV = max(EPSILON, dot(surfToView, surfaceNormal)); // Weird behavior when this is near 0
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+
+	vec3    F  = fresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float   D = normalDistFuncGGX(specIntensity, roughness);
+	float   G = schlickGGX(NoL, NoV, roughness);
+
+	vec3 diffuseBRDF = mix(vec3(1.0, 1.0, 1.0) - F, vec3(0.0, 0.0, 0.0), metalness) * surfaceColor;
+	vec3 specularBRDF = (F * D * G) / max(EPSILON, 4.0 * NoL * NoV);
+
+	return (diffuseBRDF + specularBRDF) * NoL;
+}
+
+vec3	fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+	return F0 + (max(vec3(1.0f - roughness, 1.0f - roughness, 1.0f - roughness), F0) - F0) * pow(1.0f - cosTheta, 5.0f);
+}
+
+vec3	toCubemapSpace(vec3 value FS_ARGS)
+{
+	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
+	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	return valueRHY;
+}
+
+vec3	computeAmbientBRDF(vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor FS_ARGS)
+{
+	// Cubemaps are expected to be cosined filtered up to the 7th mipmap which should contain the fully diffuse 180 degrees cosine-filtered cubemap.
+	const float	kCubemapMipRange = 6;
+
+	vec3	surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+	vec3	kS = fresnelSchlickRoughness(max(dot(surfaceNormal, surfToView), 0.0), surfaceMetalColor, roughness);
+	vec3	kD = 1.0f - kS;
+	kD *= 1.0f - metalness;
+
+	// Ambient diffuse
+	vec3	irradiance = SAMPLELOD_CUBE(EnvironmentMapSampler, toCubemapSpace(surfaceNormal FS_PARAMS), kCubemapMipRange).rgb;
+	vec3	diffuse = irradiance * surfaceColor;
+
+	// Ambient specular
+	vec3	sampleDir = toCubemapSpace(reflect(-surfToView, surfaceNormal) FS_PARAMS);
+	vec3	prefilteredColor = SAMPLELOD_CUBE(EnvironmentMapSampler, sampleDir, roughness * kCubemapMipRange).rgb;
+	vec2	envBRDF  = SAMPLE(BRDFLUTSampler, vec2(max(dot(surfaceNormal, surfToView), 0.0), roughness)).rg;
+	vec3	specular = prefilteredColor * (kS * envBRDF.x + envBRDF.y);
+
+	vec3	ambient = kD * diffuse + specular;
+	
+	return ambient;
+}
+
+#endif
+
+#if defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec4    color;
+
+#if     defined(FINPUT_fragDiffuse_Color)
+	color = fInput.fragDiffuse_Color;
+#else
+	color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if     defined(HAS_Diffuse) || defined(HAS_Lit) || defined(HAS_LegacyLit) || defined(HAS_Emissive) // has texture sampling
+	vec2    fragUV0 = applyCorrectDeformation(fInput, fInput.fragUV0 FS_PARAMS);
+	
+#   if      defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2    fragUV1 = applyCorrectDeformation(fInput, fInput.fragUV1 FS_PARAMS);
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+#endif // has texture sampling
+
+#if	defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif
+
+#if	defined(HAS_Diffuse)
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif
+
+#if defined(HAS_DiffuseRamp)
+	textureColor.rgb = SAMPLE(DiffuseRamp_RampMap, vec2(textureColor.x,0.0)).rgb;
+#endif
+
+	color *= textureColor;
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(color.a, fInput.fragAlphaRemap_Cursor);
+	color.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif 
+
+#endif // defined HAS_Diffuse
+
+#if     defined(HAS_SoftParticles)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	color *= depthfade;
+#endif
+
+#if     defined(HAS_Lit)
+	vec3 surfacePosition = fInput.fragWorldPosition;
+
+	vec3 normalTex1 =  SAMPLE(Lit_NormalMap, fragUV0).xyz;
+	#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(Lit_NormalMap, fragUV1).xyz;
+		normalTex1 = mix(normalTex1, normalTex2, blendMix);
+	}
+	#endif
+	normalTex1 = 2.0f * normalTex1.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex1.xy = mul(UVInverseRotation, normalTex1.xy);
+#	endif
+
+	vec3 T = normalize(fInput.fragTangent.xyz);
+	vec3 N = normalize(fInput.fragNormal.xyz);
+    vec3 B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3 TBN = BUILD_MAT3(T, B, N);
+
+	vec3 surfaceNormal = normalize(mul(TBN, normalTex1.xyz));
+
+	float   surfaceRoughness = GET_CONSTANT(Material, Lit_Roughness);
+	float   surfaceMetalness = GET_CONSTANT(Material, Lit_Metalness);
+
+	bool 	hasDirLight = GET_CONSTANT(LightInfo, DirectionalLightsCount) >= 1;
+	vec3 	lightDirection = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(0)) : vec3(0, 1, 0);
+	vec3 	lightColor = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(8)) : VEC3_ZERO;
+
+	vec3    viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	vec3    surfToView = viewPosition - surfacePosition;
+	vec3    surfToLight = -lightDirection;
+	vec3    surfToLightDir = normalize(surfToLight);
+	vec3    surfToViewDir = normalize(surfToView);
+
+	vec3	lightDiffuse = computeBRDF(	surfToLightDir,
+										surfToViewDir,
+										surfaceNormal,
+										surfaceRoughness,
+										surfaceMetalness,
+										color.rgb
+										FS_PARAMS);
+
+	vec3	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+	vec3	lightAmbient = computeAmbientBRDF(	surfToViewDir,
+												surfaceNormal,
+												surfaceRoughness,
+												surfaceMetalness,
+												color.rgb
+												FS_PARAMS);
+
+	color.rgb = lightDiffuse * lightColor + lightAmbient * ambientColor;
+
+#elif   defined(HAS_LegacyLit)
+
+	vec3 normalTex1 =  SAMPLE(LegacyLit_NormalMap, fragUV0).xyz;
+#if 	defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(LegacyLit_NormalMap, fragUV1).xyz;
+		normalTex1 = mix(normalTex1, normalTex2, blendMix);
+	}
+#endif
+
+	normalTex1 = 2.0f * normalTex1.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex1.xy = mul(UVInverseRotation, normalTex1.xy);
+#	endif
+
+	vec3 T = normalize(fInput.fragTangent.xyz);
+	vec3 N = normalize(fInput.fragNormal.xyz);
+	vec3 B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3 TBN = BUILD_MAT3(T, B, N);
+
+	vec3 surfaceNormal = normalize(mul(TBN, normalTex1.xyz));
+
+	bool 	hasDirLight = GET_CONSTANT(LightInfo, DirectionalLightsCount) >= 1;
+	vec3 	lightDirection = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(0)) : vec3(0, 1, 0);
+	vec3 	lightColor = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(8)) : VEC3_ZERO;
+
+	// Compute the light incidence
+	vec3    posToLightDirection = normalize(-lightDirection); // for the directional lights, instead of the position, we get the orientation
+	float   incidenceRemap = GET_CONSTANT(Material, LegacyLit_NormalWrapFactor) * 0.5f;
+	float   lightIncidence = max(0.f, incidenceRemap + (1.f - incidenceRemap) * dot(posToLightDirection, surfaceNormal));
+	lightIncidence = pow(lightIncidence, GET_CONSTANT(Material, LegacyLit_LightExponent));
+	vec3	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+	//  Compute the ambient light
+	vec3	lightAmbient = 	ambientColor + GET_CONSTANT(Material, LegacyLit_AmbientLight);
+	// Final light factor
+	color.rgb *= (lightColor * lightIncidence + lightAmbient) * GET_CONSTANT(Material, LegacyLit_LightScale);
+#endif
+
+#if defined(HAS_Emissive)
+	vec3 emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;
+
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#endif
+
+#if defined(HAS_EmissiveRamp)
+	emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
+#endif
+
+	emissiveColor1 *= fInput.fragEmissive_EmissiveColor;
+
+	color.rgb += emissiveColor1.rgb;
+#endif
+
+	fOutput.Output0 = color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Default_Triangle.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Default_Triangle.frag
@@ -1,0 +1,175 @@
+
+#if defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+#if defined(HAS_Lit)
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#   define PI                       3.141592
+#   define  METAL_FRESNEL_FACTOR    vec3(0.04, 0.04, 0.04)
+#   define EPSILON                  1e-5
+
+float normalDistFuncGGX(float cosLh, float roughness)
+{
+	float alpha = roughness * roughness;
+	float alphaSq = alpha * alpha;
+
+	float denom = (cosLh * cosLh) * (alphaSq - 1.0) + 1.0;
+	return alphaSq / (PI * denom * denom);
+}
+
+float schlickGGX(float cosLi, float cosLo, float roughness)
+{
+	float r = roughness + 1.0;
+	float k = (r * r) / 8.0; // UE4 remapping
+
+	float t1 = cosLi / (cosLi * (1.0 - k) + k);
+	float t2 = cosLo / (cosLo * (1.0 - k) + k);
+
+	return t1 * t2;
+}
+ 
+vec3 fresnelSchlick(vec3 surfaceMetalColor, float cosTheta)
+{
+	return surfaceMetalColor + (vec3(1.0, 1.0, 1.0) - surfaceMetalColor) * pow(1.0 - cosTheta, 5.0);
+}
+
+vec3	computeBRDF(vec3 surfToLight, vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor FS_ARGS)
+{
+	vec3    halfVec = normalize(surfToLight + surfToView);
+
+	float   NoL = max(0.0f, dot(surfToLight, surfaceNormal));
+
+#if     defined(HAS_NormalWrap)
+	float   normalWrapFactor = GET_CONSTANT(Material, NormalWrap_WrapFactor);
+	NoL = normalWrapFactor + (1.0f - normalWrapFactor) * NoL;
+#endif
+
+	float   specIntensity = max(0.0f, dot(halfVec, surfaceNormal));
+	float   NoV = max(EPSILON, dot(surfToView, surfaceNormal)); // Weird behavior when this is near 0
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+
+	vec3    F  = fresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float   D = normalDistFuncGGX(specIntensity, roughness);
+	float   G = schlickGGX(NoL, NoV, roughness);
+
+	vec3 diffuseBRDF = mix(vec3(1.0, 1.0, 1.0) - F, vec3(0.0, 0.0, 0.0), metalness) * surfaceColor;
+	vec3 specularBRDF = (F * D * G) / max(EPSILON, 4.0 * NoL * NoV);
+
+	return (diffuseBRDF + specularBRDF) * NoL;
+}
+
+vec3	fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+	return F0 + (max(vec3(1.0f - roughness, 1.0f - roughness, 1.0f - roughness), F0) - F0) * pow(1.0f - cosTheta, 5.0f);
+}
+
+vec3	toCubemapSpace(vec3 value FS_ARGS)
+{
+	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
+	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	return valueRHY;
+}
+
+vec3	computeAmbientBRDF(vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec3 surfaceColor FS_ARGS)
+{
+	// Cubemaps are expected to be cosined filtered up to the 7th mipmap which should contain the fully diffuse 180 degrees cosine-filtered cubemap.
+	const float	kCubemapMipRange = 6;
+
+	vec3	surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceColor, metalness);
+	vec3	kS = fresnelSchlickRoughness(max(dot(surfaceNormal, surfToView), 0.0), surfaceMetalColor, roughness);
+	vec3	kD = 1.0f - kS;
+	kD *= 1.0f - metalness;
+
+	// Ambient diffuse
+	vec3	irradiance = SAMPLELOD_CUBE(EnvironmentMapSampler, toCubemapSpace(surfaceNormal FS_PARAMS), kCubemapMipRange).rgb;
+	vec3	diffuse = irradiance * surfaceColor;
+
+	// Ambient specular
+	vec3	sampleDir = toCubemapSpace(reflect(-surfToView, surfaceNormal) FS_PARAMS);
+	vec3	prefilteredColor = SAMPLELOD_CUBE(EnvironmentMapSampler, sampleDir, roughness * kCubemapMipRange).rgb;
+	vec2	envBRDF  = SAMPLE(BRDFLUTSampler, vec2(max(dot(surfaceNormal, surfToView), 0.0), roughness)).rg;
+	vec3	specular = prefilteredColor * (kS * envBRDF.x + envBRDF.y);
+
+	vec3	ambient = kD * diffuse + specular;
+	
+	return ambient;
+}
+
+#endif
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	float   roughness = 1.0f;
+	float   metalness = 1.0f;
+    vec4    color = vec4(0,0,0,0);
+    vec4    emissive = vec4(0,0,0,0);
+
+#if     defined(FINPUT_fragDiffuse_Color)
+    color = fInput.fragDiffuse_Color;
+#else
+    color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if     defined(HAS_Diffuse)
+	vec4	textureColor1 = SAMPLE(Diffuse_DiffuseMap, fInput.fragUV0);
+	color *= textureColor1;
+#endif
+
+#if defined(HAS_Lit)
+	vec3 surfacePosition = fInput.fragWorldPosition;
+
+	vec3 normalTex1 = SAMPLE(Lit_NormalMap, fInput.fragUV0).xyz;
+
+	normalTex1 = 2.0f * normalTex1.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+	vec3	T = normalize(fInput.fragTangent.xyz);
+	vec3	N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T)  * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3	TBN = BUILD_MAT3(T, B, N);
+
+	vec3	surfaceNormal = normalize(mul(TBN, normalTex1.xyz));
+
+	float 	surfaceRoughness = GET_CONSTANT(Material, Lit_Roughness);
+	float	surfaceMetalness = GET_CONSTANT(Material, Lit_Metalness);
+
+	bool 	hasDirLight = GET_CONSTANT(LightInfo, DirectionalLightsCount) >= 1;
+	vec3 	lightDirection = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(0)) : vec3(0, 1, 0);
+	vec3 	lightColor = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(8)) : VEC3_ZERO;
+
+	vec3	viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	vec3	surfToView = viewPosition - surfacePosition;
+	vec3	surfToLight = -lightDirection;
+	vec3	surfToLightDir = normalize(surfToLight);
+	vec3	surfToViewDir = normalize(surfToView);
+
+	vec3	lightDiffuse = computeBRDF(	surfToLightDir,
+										surfToViewDir,
+										surfaceNormal,
+										surfaceRoughness,
+										surfaceMetalness,
+										color.rgb
+										FS_PARAMS);
+
+	vec3	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+	vec3	lightAmbient = computeAmbientBRDF(	surfToViewDir,
+												surfaceNormal,
+												surfaceRoughness,
+												surfaceMetalness,
+												color.rgb
+												FS_PARAMS);
+
+	color.rgb = lightDiffuse * lightColor + lightAmbient * ambientColor;
+#endif
+	fOutput.Output0 = color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Distortion_Billboard.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Distortion_Billboard.frag
@@ -1,0 +1,94 @@
+
+#if     defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+#if     defined(HAS_Distortion)
+float   clipDepthToDistortionFade(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	float zLinear = (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+	return min(zLinear / zNear - 1.f, sqrt(10.f / zLinear) ); // looks like the v1 (10.f = sqrt(zFar * zNear))
+}
+#endif
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec4    color;
+
+#if     defined(FINPUT_fragDistortion_Color)
+	color = fInput.fragDistortion_Color;
+#else
+	color = vec4(1., 1., 1., 1.);
+#endif
+
+#if     defined(HAS_SoftParticles) || defined(HAS_Distortion)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+#endif
+
+#if     defined(HAS_Distortion)
+	vec4    textureColor;
+	
+	color *= clipDepthToDistortionFade(fragDepth_cs  FS_PARAMS);
+
+#   if      defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fInput.fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fInput.fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+		
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+		vec2	uv0 = fInput.fragUV0 - curVectors;
+		vec2	uv1 = fInput.fragUV1 + nextVectors;
+		
+		vec4	textureColor1 = SAMPLE(Distortion_DistortionMap, uv0);
+		vec4	textureColor2 = SAMPLE(Distortion_DistortionMap, uv1);
+		textureColor = mix(textureColor1, textureColor2, cursor);
+	}
+	else
+	{
+		textureColor = SAMPLE(Distortion_DistortionMap, fInput.fragUV0);
+	
+		if (blendingType == 1)
+		{
+			// Linear
+			vec4    textureColor2 = SAMPLE(Distortion_DistortionMap, fInput.fragUV1);
+			textureColor = mix(textureColor, textureColor2, fract(fInput.fragAtlas_TextureID));
+		}
+	}
+#	else
+	// No atlas
+	textureColor = SAMPLE(Distortion_DistortionMap, fInput.fragUV0);
+#	endif // defined(HAS_Atlas)
+
+	color *= textureColor * vec4(2., 2., 1., 0.) - vec4(1.00392, 1.00392, 0., -1.); // 128 is considered as the mid-value (in range 0-255)
+#endif
+
+#if     defined(HAS_SoftParticles)
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	color *= depthfade;
+#endif
+
+	fOutput.Output0 = color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Distortion_Ribbon.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Distortion_Ribbon.frag
@@ -1,0 +1,115 @@
+
+#if     defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+#if     defined(HAS_Distortion)
+float   clipDepthToDistortionFade(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	float zLinear = (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+	return min(zLinear / zNear - 1.f, sqrt(10.f / zLinear) ); // looks like the v1 (10.f = sqrt(zFar * zNear))
+}
+#endif
+
+vec2    applyCorrectDeformation(IN(SFragmentInput) fInput, IN(vec2) fragUVin FS_ARGS)
+{
+#if     defined(HAS_CorrectDeformation)
+	vec2 fragUVout;
+	if (fragUVin.x + fragUVin.y < 1)
+		fragUVout = fragUVin.xy / fInput.fragUVFactors.xy;
+	else
+		fragUVout = 1.0 - ((1.0 - fragUVin.xy) / fInput.fragUVFactors.zw);
+#if     defined(HAS_TextureUVs)
+	if (GET_CONSTANT(Material, TextureUVs_RotateTexture) != 0)
+		fragUVout = fragUVout.yx;
+#endif
+	return fragUVout * fInput.fragUVScaleAndOffset.xy + fInput.fragUVScaleAndOffset.zw;
+#else
+	return fragUVin;
+#endif
+}
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec4    color;
+
+#if     defined(FINPUT_fragDistortion_Color)
+	color = fInput.fragDistortion_Color;
+#else
+	color = vec4(1., 1., 1., 1.);
+#endif
+
+#if     defined(HAS_SoftParticles) || defined(HAS_Distortion)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+#endif
+
+#if     defined(HAS_Distortion)
+	color *= clipDepthToDistortionFade(fragDepth_cs  FS_PARAMS);
+
+	vec2    fragUV0 = applyCorrectDeformation(fInput, fInput.fragUV0 FS_PARAMS);
+
+#   if      defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2    fragUV1 = applyCorrectDeformation(fInput, fInput.fragUV1 FS_PARAMS);
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+	vec4    textureColor = SAMPLE(Distortion_DistortionMap, fragUV0);
+
+#   if      defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Distortion_DistortionMap, fragUV1);
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif
+
+
+	color *= textureColor * vec4(2., 2., 1., 0.) - vec4(1.00392, 1.00392, 0., -1.); // 128 is considered as the mid-value (in range 0-255)
+#endif
+
+#if     defined(HAS_SoftParticles)
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	color *= depthfade;
+#endif
+
+	fOutput.Output0 = color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Decal_Default.vert
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Decal_Default.vert
@@ -1,0 +1,11 @@
+
+void    VertexMain(IN(SVertexInput) vInput, INOUT(SVertexOutput) vOutput VS_ARGS)
+{
+	vec3 	transformedPos = mul(vInput.DecalTransform, vec4(vInput.Position, 1.0)).xyz;
+	mat4    viewProj = GET_CONSTANT(SceneInfo, ViewProj); 
+
+	vOutput.VertexPosition = mul(viewProj, vec4(transformedPos, 1.0));  // World to view
+	vOutput.fragWorldPosition = vInput.Position;
+	vOutput.fragViewProjPosition = vOutput.VertexPosition;
+	vOutput.fragInverseDecalTransform = vInput.InverseDecalTransform;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Light_Default.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Light_Default.frag
@@ -1,0 +1,26 @@
+
+#include "includes/PKLighting.h"
+#include "includes/PKOutputColor.h"
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#define PI                      3.141592f
+#define METAL_FRESNEL_FACTOR    vec3(0.04f, 0.04f, 0.04f)
+#define EPSILON                 1.0e-5f
+
+void        FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec3 			clipPos = fInput.fragViewProjPosition.xyz / fInput.fragViewProjPosition.w;
+	SFragSurface 	fSurf;
+
+	GBufferToFragSurface(fSurf, clipPos FS_PARAMS);
+
+	float	lightRange = fInput.fragLightAttenuation_Range;
+	vec3	lightColor = fInput.fragLight_Color.xyz;
+	vec3	lightPosition = fInput.fragLightPosition;
+
+	ApplyPointLight(fSurf, lightColor, lightPosition, lightRange FS_PARAMS);
+
+	OutputFragmentColor(fSurf, fOutput FS_PARAMS);
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Light_Default.vert
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Light_Default.vert
@@ -1,0 +1,20 @@
+
+void    VertexMain(IN(SVertexInput) vInput, INOUT(SVertexOutput) vOutput VS_ARGS)
+{
+	// compute world space vertex position:
+
+#if     HAS_SphereLight
+	vec3    transformedPos = vInput.Position * (vInput.LightAttenuation_Range + vInput.SphereRadius) + vInput.LightPosition;
+	vOutput.fragSphereRadius = vInput.SphereRadius;
+#else
+	vec3    transformedPos = vInput.Position * vInput.LightAttenuation_Range + vInput.LightPosition;
+#endif
+
+	mat4    viewProj = GET_CONSTANT(SceneInfo, ViewProj);
+	vOutput.VertexPosition = mul(viewProj, vec4(transformedPos, 1.0));  // World to view
+	vOutput.fragWorldPosition = vInput.Position;
+	vOutput.fragViewProjPosition = vOutput.VertexPosition;
+	vOutput.fragLightPosition = vInput.LightPosition;
+	vOutput.fragLightAttenuation_Range = vInput.LightAttenuation_Range;
+	vOutput.fragLight_Color = vInput.Light_Color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/Particle_Master.frag
@@ -1,0 +1,118 @@
+
+#include "includes/FeatureRibbonCorrectDeformation.h"
+#include "includes/FeatureAtlas.h"
+#include "includes/FeatureTransformUVs.h"
+#include "includes/FeatureDistortion.h"
+#include "includes/FeatureTint.h"
+#include "includes/FeatureDiffuse.h"
+#include "includes/FeatureEmissive.h"
+#include "includes/FeatureSoftParticles.h"
+#include "includes/FeatureDecal.h"
+#include "includes/FeatureDithering.h"
+#include "includes/PKLighting.h"
+#include "includes/PKOutputColor.h"
+
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec3 			clipPos = fInput.fragViewProjPosition.xyz / fInput.fragViewProjPosition.w;
+
+	// -------------------
+	// Frag geom:
+	// -------------------
+	SFragGeometry 	fGeom;
+	FragmentInputToFragGeometry(fInput, fGeom FS_PARAMS);
+
+#if defined(HAS_CorrectDeformation)
+	ApplyRibbonCorrectDeformation(fGeom, fInput.fragUVFactors, fInput.fragUVScaleAndOffset FS_PARAMS);
+#endif
+
+#if defined(HAS_Atlas)
+	ApplyAtlasTexCoords(fGeom FS_PARAMS);
+#endif
+
+#if	defined(HAS_TransformUVs)
+#	if defined(HAS_Atlas)
+	uint	maxAtlasID = LOADU(GET_RAW_BUFFER(Atlas), 0) - 1;
+	vec4	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(maxAtlasID, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(maxAtlasID, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+	ApplyTransformUVs(fGeom, rect0, rect1, fInput.fragTransformUVs_UVRotate, fInput.fragTransformUVs_UVScale, fInput.fragTransformUVs_UVOffset FS_PARAMS);
+#	else
+	ApplyTransformUVs(fGeom, fInput.fragTransformUVs_UVRotate, fInput.fragTransformUVs_UVScale, fInput.fragTransformUVs_UVOffset FS_PARAMS);
+#	endif
+#endif
+#	if	defined(HAS_BasicTransformUVs)
+	ApplyBasicTransformUVs(fGeom FS_PARAMS);
+#	endif
+
+#	if defined(HAS_Lit)
+	ApplyNormalMap(fGeom, fInput.IsFrontFace FS_PARAMS);
+#	endif
+
+	// -------------------
+	// Frag surface:
+	// -------------------
+	SFragSurface 	fSurf;
+	FragGeometryToFragSurface(fGeom, fSurf, clipPos.z FS_PARAMS);
+
+#if 	defined(PK_FORWARD_DISTORTION_PASS)
+
+	// Distortion render pass:
+	ApplyDistortion(fSurf, fGeom, fInput.fragDistortion_DistortionColor, clipPos.z FS_PARAMS);
+
+#elif 	defined(PK_FORWARD_TINT_PASS)
+
+	// Tint render pass:
+	ApplyTint(fSurf, fGeom, fInput.fragTint_TintColor FS_PARAMS);
+
+#elif 	defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS) || defined(PK_DEFERRED_DECAL_PASS)
+
+	// Color render pass:
+#	if	defined(HAS_Diffuse)
+#		if	defined(HAS_AlphaRemap)
+	ApplyDiffuse(fSurf, fGeom, fInput.fragDiffuse_DiffuseColor, fInput.fragAlphaRemap_AlphaRemapCursor FS_PARAMS);
+#		else
+	ApplyDiffuse(fSurf, fGeom, fInput.fragDiffuse_DiffuseColor FS_PARAMS);
+#		endif
+#	endif
+
+#	if	defined(HAS_DiffuseRamp)
+	ApplyDiffuseRamp(fSurf FS_PARAMS);
+#	endif
+
+#	if	defined(HAS_Emissive)
+	ApplyEmissive(fSurf, fGeom, fInput.fragEmissive_EmissiveColor FS_PARAMS);
+#	endif
+#	if	defined(HAS_EmissiveRamp)
+	ApplyEmissiveRamp(fSurf FS_PARAMS);
+#	endif
+
+#	if defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS)
+#		if	defined(HAS_Lit)
+	float 	roughness = GET_CONSTANT(Material, Lit_Roughness);
+	float	metalness = GET_CONSTANT(Material, Lit_Metalness);
+	ApplyLighting(fSurf, fGeom, fInput.fragWorldPosition, roughness, metalness FS_PARAMS);
+#		endif
+#	endif // !defined(PK_DEFERRED_DECAL_PASS)
+
+#	if defined(PK_DEFERRED_COLOR_PASS)
+	if (GET_CONSTANT(Material, Opaque_Type) == 2)
+		ApplyDithering(fSurf, fGeom, fInput FS_PARAMS);
+#	endif
+
+#else
+#	error "Unrecognized particle render pass"
+#endif
+
+#if defined(PK_DEFERRED_DECAL_PASS)
+	ApplyDecalFading(fSurf, fGeom FS_PARAMS);
+#elif !defined(PK_DEFERRED_COLOR_PASS)
+# 	if defined(HAS_SoftParticles)
+	// For all render passes except deferred :
+	ApplySoftParticles(fSurf, clipPos FS_PARAMS);
+# 	endif
+#endif
+
+	OutputFragmentColor(fSurf, fOutput FS_PARAMS);
+}
+

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureAtlas.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureAtlas.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(HAS_Atlas)
+
+void	ApplyAtlasTexCoords(INOUT(SFragGeometry) fGeom FS_ARGS)
+{
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	if (blendingType == 2) // Motion vectors
+	{
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fGeom.m_UV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fGeom.m_UV1).rg * 2.0f) - 1.0f) * scale;
+
+		curVectors *= fGeom.m_BlendMix;
+		nextVectors *= (1.0f - fGeom.m_BlendMix);
+
+		fGeom.m_UV0 = fGeom.m_UV0 - curVectors;
+		fGeom.m_UV1 = fGeom.m_UV1 + nextVectors;
+	}
+}
+
+#endif
+
+vec4	SampleTextureVec4(IN(SFragGeometry) fGeom, SAMPLER2D_DCL_ARG(toSample) FS_ARGS)
+{
+	vec4	color = SAMPLE(toSample, fGeom.m_UV0);
+#if defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	if (blendingType >= 1)
+	{
+		vec4	color1 =  SAMPLE(toSample, fGeom.m_UV1);
+		color = mix(color, color1, fGeom.m_BlendMix);
+	}
+#endif
+	return color;
+}
+
+vec3	SampleTextureVec3(IN(SFragGeometry) fGeom, SAMPLER2D_DCL_ARG(toSample) FS_ARGS)
+{
+	vec3	color = SAMPLE(toSample, fGeom.m_UV0).xyz;
+#if defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	if (blendingType >= 1)
+	{
+		vec3	color1 =  SAMPLE(toSample, fGeom.m_UV1).xyz;
+		color = mix(color, color1, fGeom.m_BlendMix);
+	}
+#endif
+	return color;
+}
+
+vec2	SampleTextureVec2(IN(SFragGeometry) fGeom, SAMPLER2D_DCL_ARG(toSample) FS_ARGS)
+{
+	vec2	color = SAMPLE(toSample, fGeom.m_UV0).xy;
+#if defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	if (blendingType >= 1)
+	{
+		vec2	color1 =  SAMPLE(toSample, fGeom.m_UV1).xy;
+		color = mix(color, color1, fGeom.m_BlendMix);
+	}
+#endif
+	return color;
+}
+
+float	SampleTextureVec1(IN(SFragGeometry) fGeom, SAMPLER2D_DCL_ARG(toSample) FS_ARGS)
+{
+	float	color = SAMPLE(toSample, fGeom.m_UV0).x;
+#if defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	if (blendingType >= 1)
+	{
+		float	color1 =  SAMPLE(toSample, fGeom.m_UV1).x;
+		color = mix(color, color1, fGeom.m_BlendMix);
+	}
+#endif
+	return color;
+}
+
+#if	defined(HAS_TransformUVs)
+float	SampleTextureAlpha(IN(SFragGeometry) fGeom, SAMPLER2D_DCL_ARG(toSample) FS_ARGS)
+{
+	float	color = SAMPLE(toSample, fGeom.m_AlphaUV0).w;
+#	if defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	if (blendingType >= 1)
+	{
+		float	color1 =  SAMPLE(toSample, fGeom.m_AlphaUV1).w;
+		color = mix(color, color1, fGeom.m_BlendMix);
+	}
+#	endif
+	return color;
+}
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDecal.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDecal.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(HAS_GeometryDecal)
+
+void	ApplyDecalFading(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom FS_ARGS)
+{
+	float	fadeRangeTop = GET_CONSTANT(Material, Decal_FadeTop);
+	float	startFadeTop = 1.0f - fadeRangeTop;
+	float	fadeRangeBottom = GET_CONSTANT(Material, Decal_FadeBottom);
+	float	startFadeBottom = 1.0f - fadeRangeBottom;
+
+	float	startFade = (fGeom.m_NormalizedDecalSpace.z < 0.0f) ? startFadeBottom : startFadeTop;
+	float	fadeRange = (fGeom.m_NormalizedDecalSpace.z < 0.0f) ? fadeRangeBottom : fadeRangeTop;
+	float	fade = 1.0f - clamp((abs(fGeom.m_NormalizedDecalSpace.z) - startFade) / fadeRange, 0.0f, 1.0f);
+
+	fSurf.m_Diffuse.a *= fade;
+	fSurf.m_Emissive.rgb *= fade;
+}
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDiffuse.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDiffuse.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS) || defined(PK_DEFERRED_DECAL_PASS)
+
+#	if defined(HAS_Diffuse)
+
+#		if	defined(HAS_AlphaRemap)
+void		ApplyAlphaRemap(INOUT(SFragSurface) fSurf, float cursor FS_ARGS)
+{
+	vec2	alphaTexCoord = vec2(fSurf.m_Diffuse.a, cursor);
+	fSurf.m_Diffuse.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+}
+#		endif // defined(HAS_AlphaRemap)
+
+#		if	defined(HAS_AlphaRemap)
+void		ApplyDiffuse(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, vec4 diffuseColor, float alphaRemapCursor FS_ARGS)
+#		else
+void		ApplyDiffuse(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, vec4 diffuseColor FS_ARGS)
+#		endif // defined(HAS_AlphaRemap)
+{
+	fSurf.m_Diffuse = SampleTextureVec4(fGeom, SAMPLER_ARG(Diffuse_DiffuseMap) FS_PARAMS);
+#		if	defined(HAS_TransformUVs)
+	if (fGeom.m_UseAlphaUVs)
+		fSurf.m_Diffuse.a = SampleTextureAlpha(fGeom, SAMPLER_ARG(Diffuse_DiffuseMap) FS_PARAMS);
+#		endif // defined(HAS_TransformUVs)
+
+#		if	defined(HAS_AlphaRemap)
+	ApplyAlphaRemap(fSurf, alphaRemapCursor FS_ARGS);
+#		endif
+	fSurf.m_Diffuse *= diffuseColor;
+
+	// We clamp the alpha between 0 and 1 now:
+	fSurf.m_Diffuse.a = clamp(fSurf.m_Diffuse.a, 0.0f, 1.0f);
+}
+#	endif // defined(HAS_Diffuse)
+
+#	if defined(HAS_DiffuseRamp)
+void		ApplyDiffuseRamp(INOUT(SFragSurface) fSurf FS_ARGS)
+{
+	fSurf.m_Diffuse.rgb = SAMPLE(DiffuseRamp_RampMap, vec2(fSurf.m_Diffuse.r, 0.0)).rgb;
+}
+#	endif // defined(HAS_DiffuseRamp)
+
+#endif // defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS) || defined(PK_DEFERRED_DECAL_PASS)

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDistortion.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDistortion.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(ParticlePass_Distortion)
+
+float	ClipDepthToDistortionFade(float depth FS_ARGS)
+{
+	float	zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float	zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	float	zLinear = (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+	return min(zLinear / zNear - 1.f, sqrt(10.f / zLinear) ); // looks like the v1 (10.f = sqrt(zFar * zNear))
+}
+
+void	ApplyDistortion(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, vec3 distortionColor, float clipDepth FS_ARGS)
+{
+	// 128 is considered as the mid-value (in range 0-255):
+	vec3	textureColor = SampleTextureVec3(fGeom, SAMPLER_ARG(Distortion_DistortionMap) FS_PARAMS) * vec3(2.0f, 2.0f, 1.0f) - vec3(1.00392f, 1.00392f, 0.0f);
+	fSurf.m_Distortion = distortionColor * textureColor;
+	fSurf.m_Distortion *= ClipDepthToDistortionFade(clipDepth FS_PARAMS);
+}
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDithering.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureDithering.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(PK_DEFERRED_COLOR_PASS)
+void	ApplyDithering(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, IN(SFragmentInput) fInput FS_ARGS)
+{
+	ivec2	iTexDim;
+	TEXTURE_DIMENSIONS(DitheringPatterns, 0, iTexDim)
+	vec2	texDim = CAST(vec2, iTexDim);
+	
+	float	cellCount = 17.0;
+	vec2	cellStart = vec2(floor(fSurf.m_Diffuse.a * cellCount) / cellCount, 0);
+	vec2	cellDim = vec2(texDim.x / cellCount, texDim.y);
+
+	vec2 	viewportSize = GET_CONSTANT(SceneInfo, ViewportSize);
+	vec3 	clipPos = fInput.fragViewProjPosition.xyz / fInput.fragViewProjPosition.w;
+	
+	vec2	screenUV = clipPos.xy * vec2(0.5, 0.5) + 0.5;
+	screenUV = screenUV * viewportSize;
+	screenUV = mod(screenUV, cellDim);
+	screenUV = screenUV / cellDim;
+	screenUV = fract(screenUV + fInput.fragOpaque_DitheringOffset);
+
+	screenUV.x = (cellStart.x + screenUV.x * cellDim.x / texDim.x);
+
+	float	noise =  SAMPLE(DitheringPatterns, screenUV).r;
+	int		ditheringMode = GET_CONSTANT(Material, Opaque_DitheringMode);
+
+	// Note: noise is actually either 0 or 1.
+	if (ditheringMode == 0 && noise < 0.5) // Regular
+		discard;
+	else if (ditheringMode == 1 && noise > 0.5) // InversedAlpha
+		discard;
+
+}
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureEmissive.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureEmissive.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS) || defined(PK_DEFERRED_DECAL_PASS)
+
+#	if defined(HAS_Emissive)
+void	ApplyEmissive(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, vec3 emissiveColor FS_ARGS)
+{
+	vec4	textureColor = SampleTextureVec4(fGeom, SAMPLER_ARG(Emissive_EmissiveMap) FS_PARAMS);
+#		if	defined(HAS_TransformUVs)
+	if (fGeom.m_UseAlphaUVs)
+		textureColor.a = SampleTextureAlpha(fGeom, SAMPLER_ARG(Emissive_EmissiveMap) FS_PARAMS);
+#		endif
+	fSurf.m_Emissive = emissiveColor * textureColor.rgb * textureColor.a;
+}
+#	endif
+
+#	if defined(HAS_EmissiveRamp)
+void	ApplyEmissiveRamp(INOUT(SFragSurface) fSurf FS_ARGS)
+{
+	fSurf.m_Emissive = SAMPLE(EmissiveRamp_RampMap, vec2(fSurf.m_Emissive.r, 0.0)).rgb;
+}
+#	endif
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureRibbonCorrectDeformation.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureRibbonCorrectDeformation.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(HAS_CorrectDeformation)
+
+void	ApplyRibbonCorrectDeformation(INOUT(SFragGeometry) fGeom, vec4 fragUVFactors, vec4 fragUVScaleAndOffset FS_ARGS)
+{
+#	if defined(FINPUT_fragUV0) // Particle has UV0
+
+	vec2	fragUVout;
+	if (fGeom.m_UV0.x + fGeom.m_UV0.y < 1)
+		fragUVout = fGeom.m_UV0.xy / fragUVFactors.xy;
+	else
+		fragUVout = 1.0 - ((1.0 - fGeom.m_UV0.xy) / fragUVFactors.zw);
+
+#		if defined(HAS_BasicTransformUVs)
+	if (GET_CONSTANT(Material, BasicTransformUVs_RotateUV) != 0)
+		fragUVout = fragUVout.yx;
+#		endif
+
+	fGeom.m_UV0 = fragUVout * fragUVScaleAndOffset.xy + fragUVScaleAndOffset.zw;
+
+#	endif
+#	if defined(FINPUT_fragUV1)
+#		error "Ribbon correct deformation is not compatible with atlas"
+#	endif
+}
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureSoftParticles.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureSoftParticles.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(HAS_SoftParticles)
+
+float	ClipToLinearDepth(float depth FS_ARGS)
+{
+	float	zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float	zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+
+void	ApplySoftParticles(INOUT(SFragSurface) fSurf, vec3 clipPos FS_ARGS)
+{
+	vec2	screenUV = clipPos.xy * vec2(0.5, 0.5) + 0.5;
+	float	clipSceneDepth = SAMPLE(DepthSampler, screenUV).x;
+	float	sceneDepth = ClipToLinearDepth(clipSceneDepth FS_PARAMS);
+	float	fragDepth = ClipToLinearDepth(clipPos.z FS_PARAMS);
+	float	invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float	depthFade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+#if defined(PK_FORWARD_DISTORTION_PASS)
+	fSurf.m_Distortion *= vec3(depthFade, depthFade, depthFade);
+#elif defined(PK_FORWARD_TINT_PASS)
+	fSurf.m_Tint = mix(VEC3_ONE, fSurf.m_Tint, depthFade);
+#elif defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS)
+	fSurf.m_Emissive *= vec3(depthFade, depthFade, depthFade);
+	fSurf.m_Diffuse.a *= depthFade;
+#else
+#	error "Unrecognized particle render pass"
+#endif
+}
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureTint.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureTint.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(PK_FORWARD_TINT_PASS)
+
+#	if defined(HAS_Tint)
+void	ApplyTint(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, vec4 tintColor FS_ARGS)
+{
+	vec4	textureColor = SampleTextureVec4(fGeom, SAMPLER_ARG(Tint_TintMap) FS_PARAMS);
+#		if	defined(HAS_TransformUVs)
+	if (fGeom.m_UseAlphaUVs)
+		textureColor.a = SampleTextureAlpha(fGeom, SAMPLER_ARG(Tint_TintMap) FS_PARAMS);
+#		endif
+	vec4	tintColorWithAlpha = tintColor * textureColor;
+	tintColorWithAlpha.a = clamp(tintColorWithAlpha.a, 0.0f, 1.0f);
+	fSurf.m_Tint = mix(vec3(1.0f, 1.0f, 1.0f), tintColorWithAlpha.rgb, tintColorWithAlpha.a);
+}
+#	endif
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureTransformUVs.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/FeatureTransformUVs.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if	defined(HAS_TransformUVs)
+
+vec2	TransformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+
+#	if defined(HAS_Atlas)
+void	ApplyTransformUVs(INOUT(SFragGeometry) fGeom, vec4 rect0, vec4 rect1, float angle, vec2 scale, vec2 offset FS_ARGS)
+#else
+void	ApplyTransformUVs(INOUT(SFragGeometry) fGeom, float angle, vec2 scale, vec2 offset FS_ARGS)
+#endif
+{
+	float	sinR = sin(angle);
+	float	cosR = cos(angle);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+
+#	if defined(HAS_Atlas)
+	fGeom.m_AlphaUV1 = fGeom.m_UV1;
+	fGeom.m_UV1 = ((fGeom.m_UV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fGeom.m_UV1 = TransformUV(fGeom.m_UV1, scale, UVRotation, offset); // scale then rotate then translate UV
+	fGeom.m_UV1 = fract(fGeom.m_UV1) * rect1.xy + rect1.zw; // undo normalize
+#	else
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	endif
+
+	fGeom.m_AlphaUV0 = fGeom.m_UV0;
+	fGeom.m_UV0 = ((fGeom.m_UV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
+	fGeom.m_UV0 = TransformUV(fGeom.m_UV0, scale, UVRotation, offset); // scale then rotate then translate UV
+	fGeom.m_UV0 = fract(fGeom.m_UV0) * rect0.xy + rect0.zw; // undo normalize
+
+	fGeom.m_UseAlphaUVs = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+
+	float	sinMR = -sinR;
+	float	cosMR = cosR;
+	fGeom.m_TangentRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+}
+
+#endif
+
+#if	defined(HAS_BasicTransformUVs)
+
+void	ApplyBasicTransformUVs(INOUT(SFragGeometry) fGeom FS_ARGS)
+{
+#	if !defined(HAS_GeometryRibbon)
+	if (GET_CONSTANT(Material, BasicTransformUVs_RotateUV) != 0)
+	{
+		fGeom.m_UV0 = fGeom.m_UV0.yx;
+#		if defined(HAS_Atlas)
+		fGeom.m_UV1 = fGeom.m_UV1.yx;
+#		endif // defined(HAS_Atlas)
+	}
+#	endif // !defined(HAS_GeometryRibbon)
+}
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKLighting.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKLighting.h
@@ -1,0 +1,295 @@
+#pragma once
+
+#include "PKSurface.h"
+#include "FeatureAtlas.h"
+
+#if (defined(PK_FORWARD_COLOR_PASS) && defined(HAS_Lit)) || defined(PK_LIGHTING_PASS)
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#	define PI						3.141592
+#	define METAL_FRESNEL_FACTOR		vec3(0.04, 0.04, 0.04) // F0
+#	define EPSILON					1e-5
+
+float	NormalDistFuncGGX(float cosLh, float roughness)
+{
+	float	alpha = roughness * roughness;
+	float	alphaSq = alpha * alpha;
+	float	denom = (cosLh * cosLh) * (alphaSq - 1.0) + 1.0;
+	return alphaSq / (PI * denom * denom);
+}
+
+float	SchlickGGX(float cosLi, float cosLo, float roughness)
+{
+	float	r = roughness + 1.0;
+	float	k = (r * r) / 8.0; // UE4 remapping
+	float	t1 = cosLi / (cosLi * (1.0 - k) + k);
+	float	t2 = cosLo / (cosLo * (1.0 - k) + k);
+	return t1 * t2;
+}
+
+vec3	FresnelSchlick(vec3 surfaceMetalColor, float cosTheta)
+{
+	return surfaceMetalColor + (vec3(1.0, 1.0, 1.0) - surfaceMetalColor) * pow(1.0 - cosTheta, 5.0);
+}
+
+void	ApplyLightBRDF(INOUT(SFragSurface) fSurf, vec3 surfToLight, vec3 surfToView, vec3 lightColor, vec3 surfaceDiffuseColor, float attenuation, float litMask FS_ARGS)
+{
+	vec3	halfVec = normalize(surfToLight + surfToView);
+	float	NoL = max(0.0f, dot(surfToLight, fSurf.m_Normal)) * attenuation;
+
+#	if defined(HAS_NormalWrap)
+	float	normalWrapFactor = GET_CONSTANT(Material, NormalWrap_WrapFactor);
+	NoL = normalWrapFactor + (1.0f - normalWrapFactor) * NoL;
+#	endif
+
+	float	specIntensity = max(0.0f, dot(halfVec, fSurf.m_Normal));
+	float	NoV = max(EPSILON, dot(surfToView, fSurf.m_Normal)); // Weird behavior when this is near 0
+
+	vec3	surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceDiffuseColor, fSurf.m_Metalness);
+
+	vec3	F = FresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float	D = NormalDistFuncGGX(specIntensity, fSurf.m_Roughness);
+	float	G = SchlickGGX(NoL, NoV, fSurf.m_Roughness);
+
+	vec3	diffuseBRDF = mix(VEC3_ONE - F, VEC3_ZERO, fSurf.m_Metalness);
+	vec3	specularBRDF = ((F * D * G) / max(EPSILON, 4.0 * NoL * NoV));
+
+#	if defined(PK_LIGHTING_PASS)
+	fSurf.m_LightAccu += surfaceDiffuseColor * (diffuseBRDF + specularBRDF) * lightColor * NoL;
+#	else
+	if (GET_CONSTANT(Material, Lit_Type) == 1)
+	{
+		fSurf.m_Diffuse.rgb += surfaceDiffuseColor * diffuseBRDF * lightColor * NoL;
+		// We write the specular in the emissive output so that it doesn't get affected by the diffuse alpha:
+		fSurf.m_Emissive += specularBRDF * lightColor * NoL * litMask;
+	}
+	else
+	{
+		fSurf.m_Diffuse.rgb += surfaceDiffuseColor * (diffuseBRDF + specularBRDF) * lightColor * NoL;
+	}
+#	endif
+}
+
+#	if defined(PK_FORWARD_COLOR_PASS)
+
+vec3	FresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+	return F0 + (max(vec3(1.0f - roughness, 1.0f - roughness, 1.0f - roughness), F0) - F0) * pow(1.0f - cosTheta, 5.0f);
+}
+
+vec3	toCubemapSpace(vec3 value FS_ARGS)
+{
+	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
+	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	return valueRHY;
+}
+
+void	ApplyAmbientBRDF(INOUT(SFragSurface) fSurf, vec3 surfToView, vec3 ambientColor, vec3 surfaceDiffuseColor, float litMask FS_ARGS)
+{
+	// Cubemaps are expected to be cosined filtered up to the 7th mipmap which should contain the fully diffuse 180 degrees cosine-filtered cubemap.
+	const float	kCubemapMipRange = 6;
+
+	vec3	surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, surfaceDiffuseColor, fSurf.m_Metalness);
+	vec3	kS = FresnelSchlickRoughness(max(dot(fSurf.m_Normal, surfToView), 0.0), surfaceMetalColor, fSurf.m_Roughness);
+	vec3	kD = (1.0f - kS) * (1.0f - fSurf.m_Metalness);
+
+	// Ambient diffuse
+	vec3	diffuseBRDF = kD * SAMPLELOD_CUBE(EnvironmentMapSampler, toCubemapSpace(fSurf.m_Normal FS_PARAMS), kCubemapMipRange).rgb;
+	// Ambient specular
+	vec3	sampleDir = toCubemapSpace(reflect(-surfToView, fSurf.m_Normal) FS_PARAMS);
+	vec3	prefilteredColor = SAMPLELOD_CUBE(EnvironmentMapSampler, sampleDir, fSurf.m_Roughness * kCubemapMipRange).rgb;
+	vec2	envBRDF = SAMPLE(BRDFLUTSampler, vec2(max(dot(fSurf.m_Normal, surfToView), 0.0), fSurf.m_Roughness)).rg;
+	vec3	specularBRDF = prefilteredColor * (kS * envBRDF.x + envBRDF.y);
+
+	if (GET_CONSTANT(Material, Lit_Type) == 1)
+	{
+		vec3	litDiffuse = surfaceDiffuseColor * diffuseBRDF * ambientColor;
+		// Mix between the computed lit color and the original surface color
+		// Completly overrides the previous computed lit color:
+		fSurf.m_Diffuse.rgb = mix(surfaceDiffuseColor, litDiffuse, litMask);
+		// We write the specular in the emissive output so that it doesn't get affected by the diffuse alpha:
+		fSurf.m_Emissive += specularBRDF * ambientColor * litMask;
+	}
+	else
+	{
+		fSurf.m_Diffuse.rgb += surfaceDiffuseColor * (diffuseBRDF + specularBRDF) * ambientColor;
+	}
+}
+
+#	endif // defined(PK_FORWARD_COLOR_PASS)
+
+#endif // defined(PK_FORWARD_COLOR_PASS) || defined(PK_LIGHTING_PASS)
+
+#if defined(HAS_Lit)
+
+void	ApplyNormalMap(INOUT(SFragGeometry) fGeom, bool isFrontFace FS_ARGS)
+{
+	float	crossSign = GET_CONSTANT(SceneInfo, Handedness);
+	vec3	normalTex = SampleTextureVec3(fGeom, SAMPLER_ARG(Lit_NormalMap) FS_PARAMS);
+	normalTex = vec3(2.0f, 2.0f, 2.0f) * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+	// if UVs are rotated, inverse rotate the billboard space normal
+	// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	normalTex.xy = mul(fGeom.m_TangentRotation, normalTex.xy);
+#	endif // defined(HAS_TransformUVs)
+
+	vec3	T = normalize(fGeom.m_Tangent.xyz);
+	vec3	N = normalize(fGeom.m_Normal.xyz);
+	vec3	B = CROSS(N, T) * crossSign * fGeom.m_Tangent.w;
+
+	// Flip the normal for double sided particles:
+	float	normalFlip = isFrontFace ? 1.0f : -1.0f;
+	// Triangle renderers have an option to disable flipping the normal on backfaces:
+#	if defined(HAS_TriangleCustomNormals)
+	normalFlip = (GET_CONSTANT(Material, TriangleCustomNormals_DoubleSided) == 1) ? normalFlip : 1.0f;
+#	endif
+
+	mat3	TBN = BUILD_MAT3(T, B, N * normalFlip);
+
+	fGeom.m_Normal = normalize(mul(TBN, normalTex.xyz));
+}
+
+float 		remapValue(float value, float oldMin, float oldMax, float newMin, float newMax)
+{
+	return newMin + (value - oldMin) * (newMax - newMin) / (oldMax - oldMin);
+}
+
+void	ApplyLighting(INOUT(SFragSurface) fSurf, IN(SFragGeometry) fGeom, vec3 surfacePosition, float roughness, float metalness FS_ARGS)
+{
+#	if defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS)
+	fSurf.m_Roughness = roughness;
+	fSurf.m_Metalness = metalness;
+#	endif
+#	if defined(PK_FORWARD_COLOR_PASS)
+
+	vec3	viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	vec3	surfToView = viewPosition - surfacePosition;
+	vec3	surfToViewDir = normalize(surfToView);
+	// Before lighting, we backup the surface diffuse color and reset the diffuse to 0 to accumulate the light influences:
+	vec3	surfaceDiffuseColor = fSurf.m_Diffuse.rgb;
+	fSurf.m_Diffuse.rgb = VEC3_ZERO;
+
+	float	litMask = SampleTextureVec1(fGeom, SAMPLER_ARG(Lit_LitMaskMap) FS_PARAMS);
+	vec3 	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+
+	ApplyAmbientBRDF(fSurf, surfToViewDir, ambientColor, surfaceDiffuseColor, litMask FS_PARAMS);
+
+	int	lightsDirectional = GET_CONSTANT(LightInfo, DirectionalLightsCount);
+	int	lightsSpot = GET_CONSTANT(LightInfo, SpotLightsCount);
+	int	lightsPoint = GET_CONSTANT(LightInfo, PointLightsCount);
+
+	// 3 x float4 per light:
+	const int 	lightStride = 3 * 4;
+
+	for (int dirIdx = 0; dirIdx < lightsDirectional; ++dirIdx)
+	{
+		// Directional layout is:
+		// float3 direction
+		// float padding
+		// float4 padding
+		// float3 color
+		// float padding
+		vec3	direction = LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(dirIdx * lightStride));
+		vec3	color = LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(dirIdx * lightStride + 8));
+
+		// Compute lighting:
+		vec3	surfToLightDir = normalize(-direction);
+		ApplyLightBRDF(fSurf, surfToLightDir, surfToViewDir, color, surfaceDiffuseColor, 1.0f, litMask FS_ARGS);
+	}
+	for (int spotIdx = 0; spotIdx < lightsSpot; ++spotIdx)
+	{
+		// Spot layout is:
+		// float3 position
+		// float angle
+		// float3 direction
+		// float cone falloff
+		// float3 color
+		// float padding
+		vec4	positionAngle = LOADF4(GET_RAW_BUFFER(SpotLightsInfo), RAW_BUFFER_INDEX(spotIdx * lightStride));
+		vec4	directionFalloff = LOADF4(GET_RAW_BUFFER(SpotLightsInfo), RAW_BUFFER_INDEX(spotIdx * lightStride + 4));
+		vec3	color = LOADF3(GET_RAW_BUFFER(SpotLightsInfo), RAW_BUFFER_INDEX(spotIdx * lightStride + 8));
+
+		vec3	surfToLight = positionAngle.xyz - surfacePosition;
+		vec3	surfToLightDir = normalize(surfToLight);
+		float	sqDistanceToLight = dot(surfToLight, surfToLight);
+	
+		// Compute the light attenuation
+		// Start by fading depending on the cone angle:
+		float   coneAttenuation = dot(-surfToLightDir, directionFalloff.xyz);
+		coneAttenuation = coneAttenuation < positionAngle.w ? 0.0f : remapValue(coneAttenuation, positionAngle.w, 1.0f, 0.0f, 1.0f);
+		coneAttenuation = min(coneAttenuation / max(directionFalloff.w, EPSILON), 1.0f);
+		float   lightAttenuation = coneAttenuation / sqDistanceToLight;
+
+		ApplyLightBRDF(fSurf, surfToLightDir, surfToViewDir, color, surfaceDiffuseColor, lightAttenuation, litMask FS_ARGS);
+	}
+	for (int pointIdx = 0; pointIdx < lightsPoint; ++pointIdx)
+	{
+		// Point layout is:
+		// float3 position
+		// float padding
+		// float4 padding
+		// float3 color
+		// float padding
+		vec3	position = LOADF3(GET_RAW_BUFFER(PointLightsInfo), RAW_BUFFER_INDEX(pointIdx * lightStride));
+		vec3	color = LOADF3(GET_RAW_BUFFER(PointLightsInfo), RAW_BUFFER_INDEX(pointIdx * lightStride + 8));
+
+		// Compute lighting:
+		vec3	surfToLight = position - surfacePosition;
+		float	sqDistanceToLight = dot(surfToLight, surfToLight);
+		vec3	surfToLightDir = normalize(surfToLight);
+		// (here we can use the square distance falloff as this is rendered as a full screen quad and there is no culling):
+		float   lightAttenuation = 1.0f / sqDistanceToLight;
+
+		ApplyLightBRDF(fSurf, surfToLightDir, surfToViewDir, color, surfaceDiffuseColor, lightAttenuation, litMask FS_ARGS);
+	}
+#	endif // defined(PK_FORWARD_COLOR_PASS)
+}
+
+#elif defined(PK_LIGHTING_PASS)
+
+// Julien's fall-off function:
+// The constants A and B should be computed on CPU and passed as constants to the shader
+//------------------------------
+// k = 1.0 / steepness
+// x = normalized distance
+//------------------------------
+//  float A = 1 / pow(k + 1, 2);
+//  float B = 1 - A;
+//  float C = 1 / pow(x * k + 1, 2);
+//  return (C - A) / B;
+//------------------------------
+
+float	UnlinearizeFalloff(float x FS_ARGS)
+{
+	float	k = 1 / (GET_CONSTANT(Material, LightAttenuation_AttenuationSteepness) + 1.0e-3f);
+	float	A = 1 / ((k + 1) * (k + 1));
+	float	B = 1 - A;
+	float	C = 1 / ((x * k + 1) * (x * k + 1));
+	return (C - A) / B;
+}
+
+void	ApplyPointLight(INOUT(SFragSurface) fSurf, vec3 lightColor, vec3 lightPosition, float lightRange FS_ARGS)
+{
+	vec3	viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	vec3	surfToView = viewPosition - fSurf.m_WorldPosition;
+	vec3	surfToLight = lightPosition - fSurf.m_WorldPosition;
+	vec3	surfToLightDir = normalize(surfToLight);
+	vec3	surfToViewDir = normalize(surfToView);
+	float	sqRange = lightRange * lightRange;
+	float	sqDistanceToLight = dot(surfToLight, surfToLight);
+
+	if (sqDistanceToLight > sqRange || (fSurf.m_Roughness < 0.0f || fSurf.m_Metalness < 0.0f))
+		discard; // Outside of the point light range
+
+	float	distanceToLight = sqrt(sqDistanceToLight);
+
+	// Compute the light attenuation:
+	float	normalizedDistanceToLight = min(1.0f, distanceToLight / lightRange);
+	float	lightAttenuation = UnlinearizeFalloff(normalizedDistanceToLight FS_PARAMS);
+
+	ApplyLightBRDF(fSurf, surfToLightDir, surfToViewDir, lightColor, fSurf.m_Diffuse, lightAttenuation, 0.0f FS_PARAMS);
+}
+
+#endif // defined(HAS_Lit)

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKOutputColor.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKOutputColor.h
@@ -1,0 +1,53 @@
+#pragma once
+
+#include "PKSurface.h"
+
+#if defined(PK_DEFERRED_COLOR_PASS) || defined(PK_DEFERRED_DECAL_PASS)
+vec2	PackNormalSpheremap(vec3 normal FS_ARGS)
+{
+	if (ALL_BOOL(VEC_EQ(normal, VEC3_ZERO)))
+		return VEC2_ZERO;
+	normal = normalize(normal);
+	normal = mul(GET_CONSTANT(SceneInfo, PackNormalView), vec4(normal, 0.0f)).xyz;
+	float	f = sqrt(8.0f * normal.z + 8.0f);
+	return normal.xy / f + 0.5f;
+}
+#endif
+
+void	OutputFragmentColor(IN(SFragSurface) fSurf, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+#if defined(PK_FORWARD_DISTORTION_PASS)
+	fOutput.Output0 = vec4(fSurf.m_Distortion, 1.0f);
+#elif defined(PK_FORWARD_TINT_PASS)
+	fOutput.Output0 = vec4(fSurf.m_Tint, 1.0f);
+#elif defined(PK_FORWARD_COLOR_PASS)
+	fOutput.Output0 = vec4(fSurf.m_Emissive + fSurf.m_Diffuse.rgb * fSurf.m_Diffuse.a, fSurf.m_Diffuse.a);
+#elif defined(PK_DEFERRED_COLOR_PASS)
+
+	// Discard pixel if masked:
+	if (GET_CONSTANT(Material, Opaque_Type) == 1 && fSurf.m_Diffuse.a < GET_CONSTANT(Material, Opaque_MaskThreshold))
+		discard;
+
+	// In the case the of unlit opaque, we transfer the diffuse color to the emissve buffer:
+#	if !defined(HAS_Lit)
+	fSurf.m_Emissive += fSurf.m_Diffuse.xyz;
+	fSurf.m_Diffuse = VEC4_ZERO;
+	fSurf.m_Roughness = -1.0f;
+	fSurf.m_Metalness = -1.0f;
+#	endif
+
+	fOutput.Output0 = fSurf.m_Diffuse;
+	fOutput.Output1 = fSurf.m_Depth;
+	fOutput.Output2 = vec4(fSurf.m_Emissive, 0.0f);
+	fOutput.Output3 = vec4(PackNormalSpheremap(fSurf.m_Normal FS_PARAMS), fSurf.m_Roughness, fSurf.m_Metalness);
+
+#elif defined(PK_DEFERRED_DECAL_PASS)
+	fOutput.Output0 = vec4(fSurf.m_Diffuse.rgb * fSurf.m_Diffuse.a, fSurf.m_Diffuse.a);
+	fOutput.Output1 = vec4(fSurf.m_Emissive, 0.0f);
+	fOutput.Output2 = vec4(PackNormalSpheremap(fSurf.m_Normal FS_PARAMS), fSurf.m_Roughness, fSurf.m_Metalness);
+#elif defined(PK_LIGHTING_PASS)
+	fOutput.Output0 = vec4(fSurf.m_LightAccu, 0.0f);
+#else
+#	error "Unrecognized particle render pass"
+#endif
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKSurface.h
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Experimental/includes/PKSurface.h
@@ -1,0 +1,227 @@
+#pragma once
+
+// Render passes
+#if defined(ParticlePass_Distortion)
+#	define	PK_FORWARD_DISTORTION_PASS
+#elif defined(ParticlePass_Tint)
+#	define	PK_FORWARD_TINT_PASS
+#elif defined(ParticlePass_TransparentPostDisto) || defined(ParticlePass_Transparent)
+#	define	PK_FORWARD_COLOR_PASS
+#elif defined(ParticlePass_Opaque)
+#	define	PK_DEFERRED_COLOR_PASS
+#elif defined(ParticlePass_Decal)
+#	define	PK_DEFERRED_DECAL_PASS
+#elif defined(ParticlePass_Lighting)
+#	define	PK_LIGHTING_PASS
+#else
+#	error "Unrecognized particle render pass"
+#endif
+
+// Geometry data for the current fragment (directly coming from vertex shader)
+struct	SFragGeometry
+{
+	vec2	m_UV0;
+	vec2	m_UV1;
+	float	m_BlendMix; // Lerp ratio between UV0 color and UV1 color
+	vec3	m_Normal;
+	vec4	m_Tangent;
+
+#	if defined(HAS_GeometryDecal)
+	vec3	m_NormalizedDecalSpace;
+#	endif
+
+#	if defined(HAS_TransformUVs)
+	// Used by TransformUVs to sample alpha and color separately:
+	vec2	m_AlphaUV0;
+	vec2	m_AlphaUV1;
+	bool	m_UseAlphaUVs;
+
+	// We use m_RotateTangent to store the inverse UV rotation:
+	// we can then rotate the normal in UV space using this instead of rotating the 3D tangent
+	mat2	m_TangentRotation;
+#	endif
+};
+
+// Surface data, used to compute the final color
+#if defined(PK_FORWARD_DISTORTION_PASS)
+struct	SFragSurface
+{
+	vec3	m_Distortion;
+};
+#elif defined(PK_FORWARD_TINT_PASS)
+struct	SFragSurface
+{
+	vec3	m_Tint;
+};
+#elif defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS)
+struct	SFragSurface
+{
+	vec3	m_Emissive;
+	vec4	m_Diffuse;
+	vec3	m_Normal;
+	float	m_Depth;
+	float	m_Roughness;
+	float	m_Metalness;
+};
+#elif defined(PK_DEFERRED_DECAL_PASS)
+struct	SFragSurface
+{
+	vec3	m_Emissive;
+	vec4	m_Diffuse;
+	vec3	m_Normal;
+	float	m_Roughness;
+	float	m_Metalness;
+};
+#elif defined(PK_LIGHTING_PASS)
+struct	SFragSurface
+{
+	// Surface info:
+	vec3	m_Diffuse;
+	vec3	m_WorldPosition;
+	vec3	m_Normal;
+	float	m_Roughness;
+	float	m_Metalness;
+
+	// Lighting output color:
+	vec3	m_LightAccu;
+};
+#else
+#	error "Unrecognized particle render pass"
+#endif
+
+vec3	DepthToWorldPos(float depthValue, vec2 uv, mat4 invViewProj)
+{
+	vec2	clipSpace = uv * 2.0 - 1.0;
+	vec4	projPos = vec4(clipSpace, depthValue, 1.0);
+	projPos = mul(invViewProj, projPos);
+	return projPos.xyz / projPos.w;
+}
+
+#if !defined(PK_LIGHTING_PASS)
+
+void	FragmentInputToFragGeometry(IN(SFragmentInput) fInput, OUT(SFragGeometry) fGeom FS_ARGS)
+{
+#	if defined(HAS_GeometryDecal)
+
+	// For decals, we need to compute the UVs in the fragment shader:
+	vec2	screenTexCoord = fInput.fragViewProjPosition.xy / fInput.fragViewProjPosition.w * 0.5 + 0.5;
+	float	depthValue = SAMPLE(DepthSampler, screenTexCoord).r;
+	mat4	invViewProj = GET_CONSTANT(SceneInfo, InvViewProj);
+	vec3	surfacePosition = DepthToWorldPos(depthValue, screenTexCoord, invViewProj);
+	mat4	userToLHZ = GET_CONSTANT(SceneInfo, UserToLHZ);
+	mat4	inverseDecalTransform = mul(userToLHZ, fInput.fragInverseDecalTransform);
+
+	fGeom.m_NormalizedDecalSpace = mul(inverseDecalTransform, vec4(surfacePosition, 1.0)).xyz;
+
+	if (ANY_BOOL(VEC_GREATER_THAN(fGeom.m_NormalizedDecalSpace, VEC3_ONE)) ||
+		ANY_BOOL(VEC_LESS_THAN(fGeom.m_NormalizedDecalSpace, -VEC3_ONE)))
+		discard;
+
+	fGeom.m_UV0 = fGeom.m_NormalizedDecalSpace.xy * vec2(0.5f, 0.5f) + 0.5f;
+
+// For decals, adjust UVs if the feature atlas is enabled
+// (this is done in the billboarding tasks for billboard and ribbons):
+#		if defined(HAS_Atlas)
+	fGeom.m_UV1 = fGeom.m_UV0;
+	fGeom.m_UV0 *= fInput.fragRect0.xy;
+	fGeom.m_UV0 += fInput.fragRect0.zw;
+	fGeom.m_UV1 *= fInput.fragRect1.xy;
+	fGeom.m_UV1 += fInput.fragRect1.zw;
+#			if !defined(FINPUT_fragRect0) || !defined(FINPUT_fragRect1)
+#				error "Need atlas sub rectangles as fragment shader input"
+#			endif
+#		else
+	fGeom.m_UV1 = VEC2_ZERO;
+#		endif
+
+#	else
+	// Here UVs are computed in the vertex shader, we can just copy the geometry values:
+#		if defined(FINPUT_fragUV0) // Particle has UV0
+	fGeom.m_UV0 = fInput.fragUV0;
+#		else
+	fGeom.m_UV0 = VEC2_ZERO;
+#		endif
+#		if defined(FINPUT_fragUV1) // Particle has UV1
+	fGeom.m_UV1 = fInput.fragUV1;
+#		else
+	fGeom.m_UV1 = VEC2_ZERO;
+#		endif
+#	endif
+
+#	if defined(FINPUT_fragNormal) // Particle has normal
+	fGeom.m_Normal = fInput.fragNormal;
+#	else
+	fGeom.m_Normal = VEC3_ZERO;
+#	endif
+#	if defined(FINPUT_fragTangent) // Particle has tangent
+	fGeom.m_Tangent = fInput.fragTangent;
+#	else
+	fGeom.m_Tangent = VEC4_ZERO;
+#	endif
+#	if defined(FINPUT_fragAtlas_TextureID) // Particle has atlas
+	fGeom.m_BlendMix = fract(fInput.fragAtlas_TextureID);
+#	else
+	fGeom.m_BlendMix = 0.0f;
+#	endif
+
+#	if defined(HAS_TransformUVs)
+	fGeom.m_AlphaUV0 = fGeom.m_UV0;
+	fGeom.m_AlphaUV1 = fGeom.m_UV1;
+	fGeom.m_UseAlphaUVs = false;
+	fGeom.m_TangentRotation = BUILD_MAT2(vec2(1, 0), vec2(0, 1)); // Identity
+#	endif
+}
+
+void	FragGeometryToFragSurface(IN(SFragGeometry) fGeom, OUT(SFragSurface) fSurf, float fragDepth FS_ARGS)
+{
+#	if defined(PK_FORWARD_DISTORTION_PASS)
+	fSurf.m_Distortion = VEC3_ZERO;
+#	elif defined(PK_FORWARD_TINT_PASS)
+	fSurf.m_Tint = VEC3_ZERO;
+#	elif defined(PK_FORWARD_COLOR_PASS) || defined(PK_DEFERRED_COLOR_PASS)
+	fSurf.m_Emissive = VEC3_ZERO;
+	fSurf.m_Diffuse = VEC4_ZERO;
+	fSurf.m_Normal = fGeom.m_Normal;
+	fSurf.m_Depth = fragDepth;
+	fSurf.m_Roughness = 0.0f;
+	fSurf.m_Metalness = 0.0f;
+#	elif defined(PK_DEFERRED_DECAL_PASS)
+	fSurf.m_Emissive = VEC3_ZERO;
+	fSurf.m_Diffuse = VEC4_ZERO;
+	fSurf.m_Normal = fGeom.m_Normal;
+	fSurf.m_Roughness = 0.0f;
+	fSurf.m_Metalness = 0.0f;
+#	else
+#		error "Unrecognized particle render pass"
+#	endif
+}
+
+#else
+
+vec3	UnpackNormalSpheremap(vec2 normal FS_ARGS)
+{
+	vec2	fenc = normal * 4.0f - 2.0f;
+	float	f = dot(fenc, fenc);
+	float	g = sqrt(1.0f - f / 4.0f);
+	vec3	outNormal;
+	outNormal.xy = fenc * g;
+	outNormal.z = 1.0f - f / 2.0f;
+	return mul(GET_CONSTANT(SceneInfo, UnpackNormalView), vec4(outNormal, 0.0f)).xyz;
+}
+
+void	GBufferToFragSurface(OUT(SFragSurface) fSurf, vec3 clipPos FS_ARGS)
+{
+	mat4	invViewProj = GET_CONSTANT(SceneInfo, InvViewProj);
+	vec2	screenTexCoord = clipPos.xy * 0.5f + 0.5f;
+	vec4	packedNormalRoughMetal = SAMPLE(NormalRoughMetalSampler, screenTexCoord);
+	float	depthValue = SAMPLE(DepthSampler, screenTexCoord).r;
+
+	fSurf.m_Diffuse = SAMPLE(DiffuseSampler, screenTexCoord).rgb;
+	fSurf.m_WorldPosition = DepthToWorldPos(depthValue, screenTexCoord, invViewProj);
+	fSurf.m_Normal = UnpackNormalSpheremap(packedNormalRoughMetal.rg FS_PARAMS);
+	fSurf.m_Roughness = packedNormalRoughMetal.z;
+	fSurf.m_Metalness = packedNormalRoughMetal.w;
+	fSurf.m_LightAccu = VEC3_ZERO;
+}
+
+#endif

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Opaque_Billboard.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Opaque_Billboard.frag
@@ -1,0 +1,250 @@
+
+vec2 PackNormalSpheremap(vec3 normal FS_ARGS)
+{
+	normal = normalize(normal);
+	normal = mul(GET_CONSTANT(SceneInfo, PackNormalView), vec4(normal, 0.0f)).xyz;
+	float f = sqrt(8.0f * normal.z + 8.0f);
+	return normal.xy / f + 0.5f;
+}
+
+#if defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+void     FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	float   roughness = -1.0f;
+	float   metalness = -1.0f;
+    vec3    normal = vec3(1,0,0);
+    vec4    color = vec4(0,0,0,0);
+    vec4    emissive = vec4(0,0,0,0);
+
+#if     defined(FINPUT_fragDiffuse_Color)
+    color = fInput.fragDiffuse_Color;
+#else
+    color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if     defined(HAS_Diffuse) || defined(HAS_Lit) || defined(HAS_LegacyLit) || defined(HAS_Emissive) // has texture sampling
+
+	vec2    fragUV0 = fInput.fragUV0;
+
+#if		defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2    fragUV1 = fInput.fragUV1;
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+#endif // has texture sampling
+
+#if	defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif
+
+#if	defined(HAS_Diffuse)
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a = SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif
+
+#if defined(HAS_DiffuseRamp)
+	textureColor.rgb =  SAMPLE(DiffuseRamp_RampMap, vec2(textureColor.x,0.0)).rgb;
+#endif
+
+	color *= textureColor;
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(color.a, fInput.fragAlphaRemap_Cursor);
+	color.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif 
+
+#endif // defined HAS_Diffuse
+
+#if defined(HAS_Opaque)
+    if (GET_CONSTANT(Material, Opaque_Type) == 1 &&
+		color.a < GET_CONSTANT(Material, Opaque_MaskThreshold))
+        discard;
+#endif
+
+#if     defined(HAS_Lit)
+
+	vec3    normalTex =  SAMPLE(Lit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(Lit_NormalMap, fragUV1).xyz;
+		normalTex = mix(normalTex, normalTex2, blendMix);
+	}
+#endif
+
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+	
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex.xy = mul(UVInverseRotation, normalTex.xy);
+#	endif
+
+	vec3    T = normalize(fInput.fragTangent.xyz);
+	vec3    N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3    TBN = BUILD_MAT3(T, B, N);
+
+	normal = normalize(mul(TBN, normalTex));
+
+	vec2    roughMetal = SAMPLE(Lit_RoughMetalMap, fragUV0).xy;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec2    roughMetal2 = SAMPLE(Lit_RoughMetalMap, fragUV1).xy;
+		roughMetal = mix(roughMetal, roughMetal2, blendMix);
+	}
+#endif
+
+	roughness = GET_CONSTANT(Material, Lit_Roughness);
+	roughness *= roughMetal.x;
+	metalness = GET_CONSTANT(Material, Lit_Metalness);
+	metalness *= roughMetal.y;
+
+#elif   defined(HAS_LegacyLit)
+
+	vec3    normalTex =  SAMPLE(LegacyLit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(LegacyLit_NormalMap, fragUV1).xyz;
+		normalTex = mix(normalTex, normalTex2, blendMix);
+	}
+#endif
+
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+	
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex.xy = mul(UVInverseRotation, normalTex.xy);
+#	endif	
+	
+	vec3    T = normalize(fInput.fragTangent.xyz);
+	vec3    N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3    TBN = BUILD_MAT3(T, B, N);
+	normal = normalize(mul(TBN, normalTex));
+
+	// In the old lighting feature, we stored the specular and glossiness in the specular map.
+	// To mimic something similar, we just set the roughness to (1.0 - specularValue) * 0.7 + 0.3 to avoid very sharp specular which did not exist before
+	// The metalness is always 0.
+	roughness = (1.0 - SAMPLE(LegacyLit_SpecularMap, fragUV0).x) * 0.7 + 0.3;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		float roughness2 = (1.0 - SAMPLE(LegacyLit_SpecularMap, fragUV1).x) * 0.7 + 0.3;
+		roughness = mix(roughness, roughness2, blendMix);
+	}
+#endif
+	metalness = 0.0f;
+
+#else
+	emissive = color;
+	color = vec4(0.0,0.0,0.0,0.0);
+
+#endif
+
+#if defined(HAS_Emissive)
+	vec3 emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;
+
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#endif
+
+#if defined(HAS_EmissiveRamp)
+	emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
+#endif
+
+	emissiveColor1 *= fInput.fragEmissive_EmissiveColor;
+
+	emissive.rgb += emissiveColor1;
+#endif
+
+	vec4    normalSpec;
+	normalSpec = vec4(PackNormalSpheremap(normal FS_PARAMS), roughness, metalness);
+
+    fOutput.Output0 = color;
+    fOutput.Output1 = fInput.fragViewProjPosition.z / fInput.fragViewProjPosition.w;
+    fOutput.Output2 = emissive;
+    fOutput.Output3 = normalSpec;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Opaque_Ribbon.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Opaque_Ribbon.frag
@@ -1,0 +1,268 @@
+vec2 PackNormalSpheremap(vec3 normal FS_ARGS)
+{
+	normal = normalize(normal);
+	normal = mul(GET_CONSTANT(SceneInfo, PackNormalView), vec4(normal, 0.0f)).xyz;
+	float f = sqrt(8.0f * normal.z + 8.0f);
+	return normal.xy / f + 0.5f;
+}
+
+#if defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+vec2    applyCorrectDeformation(IN(SFragmentInput) fInput, in vec2 fragUVin)
+{
+#if     defined(HAS_CorrectDeformation)
+	vec2 fragUVout;
+	if (fragUVin.x + fragUVin.y < 1)
+		fragUVout = fragUVin.xy / fInput.fragUVFactors.xy;
+	else
+		fragUVout = 1.0 - ((1.0 - fragUVin.xy) / fInput.fragUVFactors.zw);
+#if     defined(HAS_TextureUVs)
+	if (GET_CONSTANT(Material, TextureUVs_RotateTexture) != 0)
+		fragUVout = fragUVout.yx;
+#endif
+	return fragUVout * fInput.fragUVScaleAndOffset.xy + fInput.fragUVScaleAndOffset.zw;
+#else
+	return fragUVin;
+#endif
+}
+
+void     FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	float   roughness = -1.0f;
+	float   metalness = -1.0f;
+    vec3    normal = vec3(1,0,0);
+    vec4    color = vec4(0,0,0,0);
+    vec4    emissive = vec4(0,0,0,0);
+
+#if     defined(FINPUT_fragDiffuse_Color)
+    color = fInput.fragDiffuse_Color;
+#else
+    color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if     defined(HAS_Diffuse) || defined(HAS_Lit) || defined(HAS_LegacyLit) || defined(HAS_Emissive) // has texture sampling
+
+	vec2    fragUV0 = applyCorrectDeformation(fInput, fInput.fragUV0);
+
+#if		defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2    fragUV1 = applyCorrectDeformation(fInput, fInput.fragUV1);
+
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#endif // defined(HAS_Atlas)
+
+#endif // has texture sampling
+
+#if	defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif
+
+#if	defined(HAS_Diffuse)
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a = SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a = SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif
+
+#if defined(HAS_DiffuseRamp)
+	textureColor.rgb =  SAMPLE(DiffuseRamp_RampMap, vec2(textureColor.x,0.0)).rgb;
+#endif
+
+	color *= textureColor;
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(color.a, fInput.fragAlphaRemap_Cursor);
+	color.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif 
+
+#endif // defined HAS_Diffuse
+
+#if defined(HAS_Opaque)
+    if (GET_CONSTANT(Material, Opaque_Type) == 1 &&
+		color.a < GET_CONSTANT(Material, Opaque_MaskThreshold))
+        discard;
+#endif
+
+#if     defined(HAS_Lit)
+
+	vec3    normalTex =  SAMPLE(Lit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(Lit_NormalMap, fragUV1).xyz;
+		normalTex = mix(normalTex, normalTex2, blendMix);
+	}
+#endif
+
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex.xy = mul(UVInverseRotation, normalTex.xy);
+#	endif
+
+	vec3    T = normalize(fInput.fragTangent.xyz);
+	vec3    N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3    TBN = BUILD_MAT3(T, B, N);
+
+	normal = normalize(mul(TBN, normalTex));
+
+	vec2    roughMetal = SAMPLE(Lit_RoughMetalMap, fragUV0).xy;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec2    roughMetal2 = SAMPLE(Lit_RoughMetalMap, fragUV1).xy;
+		roughMetal = mix(roughMetal, roughMetal2, blendMix);
+	}
+#endif
+
+	roughness = GET_CONSTANT(Material, Lit_Roughness);
+	roughness *= roughMetal.x;
+	metalness = GET_CONSTANT(Material, Lit_Metalness);
+	metalness *= roughMetal.y;
+
+#elif   defined(HAS_LegacyLit)
+
+	vec3    normalTex =  SAMPLE(LegacyLit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(LegacyLit_NormalMap, fragUV1).xyz;
+		normalTex = mix(normalTex, normalTex2, blendMix);
+	}
+#endif
+
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex.xy = mul(UVInverseRotation, normalTex.xy);
+#	endif
+
+	vec3    T = normalize(fInput.fragTangent.xyz);
+	vec3    N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3    TBN = BUILD_MAT3(T, B, N);
+	normal = normalize(mul(TBN, normalTex));
+
+	// In the old lighting feature, we stored the specular and glossiness in the specular map.
+	// To mimic something similar, we just set the roughness to (1.0 - specularValue) * 0.7 + 0.3 to avoid very sharp specular which did not exist before
+	// The metalness is always 0.
+	roughness = (1.0 - SAMPLE(LegacyLit_SpecularMap, fragUV0).x) * 0.7 + 0.3;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		float roughness2 =  (1.0 - SAMPLE(LegacyLit_SpecularMap, fragUV1).x) * 0.7 + 0.3;
+		roughness = mix(roughness, roughness2, blendMix);
+	}
+#endif
+	metalness = 0.0f;
+
+#else
+
+	emissive = color;
+	color = vec4(0,0,0,0);
+
+#endif
+
+#if defined(HAS_Emissive)
+	vec3 emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;
+
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#endif
+
+#if defined(HAS_EmissiveRamp)
+	emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
+#endif
+
+	emissiveColor1 *= fInput.fragEmissive_EmissiveColor;
+
+	emissive.rgb += emissiveColor1;
+#endif
+
+	vec4    normalSpec;
+	normalSpec = vec4(PackNormalSpheremap(normal), roughness, metalness);
+
+    fOutput.Output0 = color;
+    fOutput.Output1 = fInput.fragViewProjPosition.z / fInput.fragViewProjPosition.w;
+    fOutput.Output2 = emissive;
+    fOutput.Output3 = normalSpec;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Opaque_Triangle.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Opaque_Triangle.frag
@@ -1,0 +1,62 @@
+
+vec2 PackNormalSpheremap(vec3 normal FS_ARGS)
+{
+	normal = normalize(normal);
+	normal = mul(GET_CONSTANT(SceneInfo, PackNormalView), vec4(normal, 0.0f)).xyz;
+	float f = sqrt(8.0f * normal.z + 8.0f);
+	return normal.xy / f + 0.5f;
+}
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	float   roughness = -1.0f;
+	float   metalness = -1.0f;
+    vec3    normal = vec3(1,0,0);
+    vec4    color = vec4(0,0,0,0);
+    vec4    emissive = vec4(0,0,0,0);
+
+#if     defined(FINPUT_fragDiffuse_Color)
+    color = fInput.fragDiffuse_Color;
+#else
+    color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if     defined(HAS_Diffuse)
+	vec4	textureColor1 = SAMPLE(Diffuse_DiffuseMap, fInput.fragUV0);
+	color *= textureColor1;
+#endif
+
+#if defined(HAS_Opaque)
+    if (GET_CONSTANT(Material, Opaque_Type) == 1 &&
+		color.a < GET_CONSTANT(Material, Opaque_MaskThreshold))
+        discard;
+#endif
+
+#if     defined(HAS_Lit)
+	vec3    normalTex =  SAMPLE(Lit_NormalMap, fInput.fragUV0).xyz;
+	normalTex = 2.0f * normalTex.xyz - vec3(1.0f, 1.0f, 1.0f);
+
+	vec3    T = normalize(fInput.fragTangent.xyz);
+	vec3    N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3    TBN = BUILD_MAT3(T, B, N);
+
+	normal = normalize(mul(TBN, normalTex));
+
+	vec2    roughMetal = SAMPLE(Lit_RoughMetalMap, fInput.fragUV0).xy;
+
+	roughness = GET_CONSTANT(Material, Lit_Roughness);
+	roughness *= roughMetal.x;
+	metalness = GET_CONSTANT(Material, Lit_Metalness);
+	metalness *= roughMetal.y;
+#endif
+
+	vec2 	packedNormal = PackNormalSpheremap(normal FS_PARAMS);
+	vec4	normalSpec = vec4(packedNormal, roughness, metalness);
+
+	fOutput.Output0 = color;
+    fOutput.Output1 = fInput.fragViewProjPosition.z / fInput.fragViewProjPosition.w;
+    fOutput.Output2 = VEC4_ZERO;
+    fOutput.Output3 = normalSpec;
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Particle_Master.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Particle_Master.frag
@@ -1,0 +1,477 @@
+
+#if     defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+#if     defined(HAS_Distortion)
+float   clipDepthToDistortionFade(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	float zLinear = (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+	return min(zLinear / zNear - 1.f, sqrt(10.f / zLinear) ); // looks like the v1 (10.f = sqrt(zFar * zNear))
+}
+#endif
+
+#if defined(HAS_Lit) && (defined(ParticlePass_TransparentPostDisto) || defined(ParticlePass_Transparent))
+
+//------------------------------
+// BRDF Computation
+//------------------------------
+#   define PI                       3.141592
+#   define  METAL_FRESNEL_FACTOR    vec3(0.04, 0.04, 0.04)
+#   define EPSILON                  1e-5
+
+float normalDistFuncGGX(float cosLh, float roughness)
+{
+	float alpha = roughness * roughness;
+	float alphaSq = alpha * alpha;
+
+	float denom = (cosLh * cosLh) * (alphaSq - 1.0) + 1.0;
+	return alphaSq / (PI * denom * denom);
+}
+
+float schlickGGX(float cosLi, float cosLo, float roughness)
+{
+	float r = roughness + 1.0;
+	float k = (r * r) / 8.0; // UE4 remapping
+
+	float t1 = cosLi / (cosLi * (1.0 - k) + k);
+	float t2 = cosLo / (cosLo * (1.0 - k) + k);
+
+	return t1 * t2;
+}
+ 
+vec3 fresnelSchlick(vec3 surfaceMetalColor, float cosTheta)
+{
+	return surfaceMetalColor + (vec3(1.0, 1.0, 1.0) - surfaceMetalColor) * pow(1.0 - cosTheta, 5.0);
+}
+
+vec3	computeBRDF(vec3 surfToLight, vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec4 diffuseColor, float litMask FS_ARGS)
+{
+	vec3    halfVec = normalize(surfToLight + surfToView);
+
+	float   NoL = max(0.0f, dot(surfToLight, surfaceNormal));
+
+#if     defined(HAS_NormalWrap)
+	float   normalWrapFactor = GET_CONSTANT(Material, NormalWrap_WrapFactor);
+	NoL = normalWrapFactor + (1.0f - normalWrapFactor) * NoL;
+#endif
+
+	float   specIntensity = max(0.0f, dot(halfVec, surfaceNormal));
+	float   NoV = max(EPSILON, dot(surfToView, surfaceNormal)); // Weird behavior when this is near 0
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, diffuseColor.rgb, metalness);
+
+	vec3    F  = fresnelSchlick(surfaceMetalColor, max(0.0f, dot(halfVec, surfToView)));
+	float   D = normalDistFuncGGX(specIntensity, roughness);
+	float   G = schlickGGX(NoL, NoV, roughness);
+
+	float specularMultiplier = GET_CONSTANT(Material, Lit_Type) == 1 ? litMask : diffuseColor.a;
+	vec3 diffuseBRDF = mix(vec3(1.0, 1.0, 1.0) - F, vec3(0.0, 0.0, 0.0), metalness) * diffuseColor.rgb * diffuseColor.a;
+	vec3 specularBRDF = ((F * D * G) / max(EPSILON, 4.0 * NoL * NoV)) * specularMultiplier;
+
+	return (diffuseBRDF + specularBRDF) * NoL;
+}
+
+vec3	fresnelSchlickRoughness(float cosTheta, vec3 F0, float roughness)
+{
+	return F0 + (max(vec3(1.0f - roughness, 1.0f - roughness, 1.0f - roughness), F0) - F0) * pow(1.0f - cosTheta, 5.0f);
+}
+
+vec3	toCubemapSpace(vec3 value FS_ARGS)
+{
+	vec3	valueLHZ = mul(GET_CONSTANT(SceneInfo, UserToLHZ), vec4(value, 0.0f)).xyz;
+	vec3	valueRHY = vec3(valueLHZ.x, valueLHZ.z, valueLHZ.y);
+	return valueRHY;
+}
+
+vec3	computeAmbientBRDF(vec3 surfToView, vec3 surfaceNormal, float roughness, float metalness, vec4 diffuseColor, float litMask FS_ARGS)
+{
+	// Cubemaps are expected to be cosined filtered up to the 7th mipmap which should contain the fully diffuse 180 degrees cosine-filtered cubemap.
+	const float	kCubemapMipRange = 6;
+
+	vec3    surfaceMetalColor = mix(METAL_FRESNEL_FACTOR, diffuseColor.rgb, metalness);
+	vec3	kS = fresnelSchlickRoughness(max(dot(surfaceNormal, surfToView), 0.0), surfaceMetalColor, roughness);
+	vec3	kD = 1.0 - kS;
+	kD *= 1.0 - metalness;
+
+	// Ambient diffuse
+	vec3	irradiance = SAMPLELOD_CUBE(EnvironmentMapSampler, toCubemapSpace(surfaceNormal FS_PARAMS), kCubemapMipRange).rgb;
+	vec3	diffuse = irradiance * diffuseColor.rgb * diffuseColor.a;
+
+	// Ambient specular
+	vec3	prefilteredColor = SAMPLELOD_CUBE(EnvironmentMapSampler, toCubemapSpace(reflect(-surfToView, surfaceNormal) FS_PARAMS), roughness * kCubemapMipRange).rgb;
+	vec2	envBRDF  = SAMPLE(BRDFLUTSampler, vec2(max(dot(surfaceNormal, surfToView), 0.0), roughness)).rg;
+	float 	specularMultiplier = GET_CONSTANT(Material, Lit_Type) == 1 ? litMask : diffuseColor.a;
+	vec3	specular = prefilteredColor * (kS * envBRDF.x + envBRDF.y) * specularMultiplier;
+
+	vec3 ambient = kD * diffuse + specular;
+	return ambient;
+}
+
+#endif
+
+#if defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+vec2    applyCorrectDeformation(IN(SFragmentInput) fInput, IN(vec2) fragUVin FS_ARGS)
+{
+#if     defined(HAS_CorrectDeformation)
+	vec2 fragUVout;
+	if (fragUVin.x + fragUVin.y < 1)
+		fragUVout = fragUVin.xy / fInput.fragUVFactors.xy;
+	else
+		fragUVout = 1.0 - ((1.0 - fragUVin.xy) / fInput.fragUVFactors.zw);
+#if     defined(HAS_TextureUVs)
+	if (GET_CONSTANT(Material, TextureUVs_RotateTexture) != 0)
+		fragUVout = fragUVout.yx;
+#endif
+	return fragUVout * fInput.fragUVScaleAndOffset.xy + fInput.fragUVScaleAndOffset.zw;
+#else
+	return fragUVin;
+#endif
+}
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+//----------------------------------------------------------------------------
+// Gather texture coordinates
+//----------------------------------------------------------------------------
+#if 	defined(FINPUT_fragUV0)
+	vec2    fragUV0 = applyCorrectDeformation(fInput, fInput.fragUV0 FS_PARAMS);
+#	if		defined(HAS_Atlas)
+	int		blendingType = GET_CONSTANT(Material, Atlas_Blending);
+	vec2	fragUV1 = applyCorrectDeformation(fInput, fInput.fragUV1 FS_PARAMS);
+	float	blendMix = 0.f;
+
+	if (blendingType == 2)
+	{
+		// Motion vectors
+		vec2	scale = GET_CONSTANT(Material, Atlas_DistortionStrength);
+		vec2	curVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV0).rg * 2.0f) - 1.0f) * scale;
+		vec2	nextVectors = ((SAMPLE(Atlas_MotionVectorsMap, fragUV1).rg * 2.0f) - 1.0f) * scale;
+		float	cursor = fract(fInput.fragAtlas_TextureID);
+
+		curVectors *= cursor;
+		nextVectors *= (1.0f - cursor);
+
+		fragUV0 = fragUV0 - curVectors;
+		fragUV1 = fragUV1 + nextVectors;
+		blendMix = cursor;
+	}
+	else if (blendingType == 1)
+	{
+		// Linear
+		blendMix = fract(fInput.fragAtlas_TextureID);
+	}
+#	endif // defined(HAS_Atlas)
+#endif // defined(FINPUT_fragUV0)
+
+//----------------------------------------------------------------------------
+// Transform UVs
+//----------------------------------------------------------------------------
+#if	defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec4	rect0 = vec4(1.0f, 1.0f, 0.0f, 0.0f);
+#	if	defined(HAS_Atlas)
+	rect0 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID)) * 4 + 1));
+	vec4	rect1 = LOADF4(GET_RAW_BUFFER(Atlas), RAW_BUFFER_INDEX(min(LOADU(GET_RAW_BUFFER(Atlas), 0) - 1, uint(fInput.fragAtlas_TextureID) + 1) * 4 + 1));
+
+	vec2	oldFragUV1 = fragUV1;
+	fragUV1 = ((fragUV1 - rect1.zw) / rect1.xy); // normalize (if atlas)
+	fragUV1 = transformUV(fragUV1, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV1 = fract(fragUV1) * rect1.xy + rect1.zw; // undo normalize
+#	endif // defined(HAS_Atlas)
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = ((fragUV0 - rect0.zw) / rect0.xy); // normalize (if atlas)
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0) * rect0.xy + rect0.zw; // undo normalize
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif // defined(HAS_TransformUVs)
+
+//----------------------------------------------------------------------------
+// render pass distortion
+//----------------------------------------------------------------------------
+#if 	defined(ParticlePass_Distortion)
+
+	vec4    distoColor = vec4(0.0f, 0.0f, 0.0f, 1.0f);
+
+#if     defined(FINPUT_fragDistortion_Color)
+	distoColor = fInput.fragDistortion_Color;
+#endif
+
+#if     defined(HAS_SoftParticles) || defined(HAS_Distortion)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+#endif
+
+	vec4    textureColor;
+	
+	distoColor *= clipDepthToDistortionFade(fragDepth_cs  FS_PARAMS);
+
+#   if      defined(HAS_Atlas)
+	
+	if (blendingType == 2)
+	{
+		vec4	textureColor1 = SAMPLE(Distortion_DistortionMap, fragUV0);
+		vec4	textureColor2 = SAMPLE(Distortion_DistortionMap, fragUV1);
+		textureColor = mix(textureColor1, textureColor2, blendMix);
+	}
+	else
+	{
+		textureColor = SAMPLE(Distortion_DistortionMap, fragUV0);
+		if (blendingType == 1)
+		{
+			// Linear
+			vec4    textureColor2 = SAMPLE(Distortion_DistortionMap, fragUV1);
+			textureColor = mix(textureColor, textureColor2, blendMix);
+		}
+	}
+#	else
+	// No atlas
+	textureColor = SAMPLE(Distortion_DistortionMap, fInput.fragUV0);
+#	endif // defined(HAS_Atlas)
+
+	distoColor *= textureColor * vec4(2., 2., 1., 0.) - vec4(1.00392, 1.00392, 0., -1.); // 128 is considered as the mid-value (in range 0-255)
+
+#if     defined(HAS_SoftParticles)
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	distoColor *= depthfade;
+#endif
+
+	fOutput.Output0 = distoColor;
+
+//----------------------------------------------------------------------------
+// render pass transparent
+//----------------------------------------------------------------------------
+#elif 	defined(ParticlePass_TransparentPostDisto) || defined(ParticlePass_Transparent)
+
+	vec4    diffuseColor = vec4(0.0f, 0.0f, 0.0f, 0.0f);
+	vec3    emissiveColor = vec3(0.0f, 0.0f, 0.0f);
+
+//----------------------------------------------------------------------------
+// DIFFUSE
+//----------------------------------------------------------------------------
+#if	defined(HAS_Diffuse)
+	diffuseColor = fInput.fragDiffuse_Color;
+
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif // defined(HAS_TransformUVs)
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Diffuse_DiffuseMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV1).a;
+		}
+#		endif // defined(HAS_TransformUVs)
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif // defined(HAS_Atlas)
+
+	diffuseColor *= textureColor;
+
+#	if defined(HAS_DiffuseRamp)
+	diffuseColor.rgb =  SAMPLE(DiffuseRamp_RampMap, vec2(diffuseColor.x, 0.0)).rgb;
+#	endif // defined(HAS_DiffuseRamp)
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(diffuseColor.a, fInput.fragAlphaRemap_Cursor);
+	diffuseColor.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif // defined(HAS_AlphaRemap)
+#endif // defined(HAS_Diffuse)
+
+//----------------------------------------------------------------------------
+// LIT
+//----------------------------------------------------------------------------
+#if defined(HAS_Lit)
+	vec3 surfacePosition = fInput.fragWorldPosition;
+
+	float litMask1 = SAMPLE(Lit_LitMaskMap, fragUV0).r;
+	vec3 normalTex1 = SAMPLE(Lit_NormalMap, fragUV0).xyz;
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 normalTex2 =  SAMPLE(Lit_NormalMap, fragUV1).xyz;
+		float litMask2 = SAMPLE(Lit_LitMaskMap, fragUV1).r;
+
+		normalTex1 = mix(normalTex1, normalTex2, blendMix);
+		litMask1 = mix(litMask1, litMask2, blendMix);
+	}
+#endif // defined(HAS_Atlas)
+	normalTex1 = 2.0f * normalTex1.xyz - vec3(1.0f, 1.0f, 1.0f);
+	diffuseColor.a *= litMask1;
+
+// if uv are rotated, inverse rotate the billboard space normal
+// to cancel tangent-UV mismatch
+#	if defined(HAS_TransformUVs)
+	float sinMR = -sinR; // sin(-x) = -sin(x)
+	float cosMR = cosR; // cos(-x) = cos(x)
+	mat2 UVInverseRotation = mat2(cosMR, sinMR, -sinMR, cosMR);
+	normalTex1.xy = mul(UVInverseRotation, normalTex1.xy);
+#	endif // defined(HAS_TransformUVs)
+
+	vec3	T = normalize(fInput.fragTangent.xyz);
+	vec3	N = normalize(fInput.fragNormal.xyz);
+	vec3	B = CROSS(N, T) * fInput.fragTangent.w * GET_CONSTANT(SceneInfo, Handedness);
+	N = fInput.IsFrontFace ? N : -N;
+	mat3	TBN = BUILD_MAT3(T, B, N);
+
+	vec3	surfaceNormal = normalize(mul(TBN, normalTex1.xyz));
+
+	float 	surfaceRoughness = GET_CONSTANT(Material, Lit_Roughness);
+	float	surfaceMetalness = GET_CONSTANT(Material, Lit_Metalness);
+
+	bool 	hasDirLight = GET_CONSTANT(LightInfo, DirectionalLightsCount) >= 1;
+	vec3 	lightDirection = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(0)) : vec3(0, 1, 0);
+	vec3 	lightColor = hasDirLight ? LOADF3(GET_RAW_BUFFER(DirectionalLightsInfo), RAW_BUFFER_INDEX(8)) : VEC3_ZERO;
+
+	vec3	viewPosition = GET_MATRIX_W_AXIS(GET_CONSTANT(SceneInfo, UnpackNormalView)).xyz;
+	vec3	surfToView = viewPosition - surfacePosition;
+	vec3	surfToLight = -lightDirection;
+	vec3	surfToLightDir = normalize(surfToLight);
+	vec3	surfToViewDir = normalize(surfToView);
+
+	vec3	lightDiffuse = computeBRDF(	surfToLightDir,
+										surfToViewDir,
+										surfaceNormal,
+										surfaceRoughness,
+										surfaceMetalness,
+										diffuseColor,
+										litMask1
+										FS_PARAMS);
+
+	vec3	ambientColor = GET_CONSTANT(LightInfo, AmbientColor);
+	vec3	lightAmbient = computeAmbientBRDF(	surfToViewDir,
+												surfaceNormal,
+												surfaceRoughness,
+												surfaceMetalness,
+												diffuseColor,
+												litMask1
+												FS_PARAMS);
+
+	diffuseColor.rgb = lightDiffuse * lightColor + lightAmbient * ambientColor;
+#else // !defined(HAS_Lit)
+	diffuseColor.rgb *= diffuseColor.a; // If we are unlit, we fade the diffuse color by it's alpha value
+#endif
+
+//----------------------------------------------------------------------------
+// EMISSIVE
+//----------------------------------------------------------------------------
+#if	defined(HAS_Emissive)
+
+#if     defined(FINPUT_fragEmissive_EmissiveColor)
+	emissiveColor = fInput.fragEmissive_EmissiveColor;
+#endif
+
+	vec3	emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;
+
+#if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec3 emissiveColor2 = SAMPLE(Emissive_EmissiveMap, fragUV1).rgb;
+		emissiveColor1 = mix(emissiveColor1, emissiveColor2, blendMix);
+	}
+#endif // defined(HAS_Atlas)
+
+	emissiveColor *= emissiveColor1;
+
+#if	defined(HAS_EmissiveRamp)
+	emissiveColor = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor.x,0.0)).rgb;
+#endif // defined(HAS_EmissiveRamp)
+
+#endif // defined(HAS_Emissive)
+
+#if	defined(HAS_SoftParticles)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	emissiveColor *= depthfade;
+	diffuseColor.a *= depthfade;
+#endif // defined(HAS_SoftParticles)
+
+	fOutput.Output0 = vec4(emissiveColor + diffuseColor.rgb, diffuseColor.a);
+
+// !defined(ParticlePass_TransparentPostDisto)
+#elif defined(ParticlePass_Tint)
+
+	vec4	tintColor = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+
+//----------------------------------------------------------------------------
+// Tint
+//----------------------------------------------------------------------------
+#if     defined(FINPUT_fragTint_Color)
+	tintColor = fInput.fragTint_Color;
+#endif
+
+#if	defined(HAS_Tint)
+	vec4    textureColor = SAMPLE(Tint_TintMap, fragUV0);
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a =  SAMPLE(Tint_TintMap, oldFragUV0).a;
+		}
+#	endif // defined(HAS_TransformUVs)
+
+#   if defined(HAS_Atlas)
+	if (blendingType >= 1)
+	{
+		vec4    textureColor2 = SAMPLE(Tint_TintMap, fragUV1);
+#		if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor2.a =  SAMPLE(Tint_TintMap, oldFragUV1).a;
+		}
+#		endif // defined(HAS_TransformUVs)
+		textureColor = mix(textureColor, textureColor2, blendMix);
+	}
+#	endif // defined(HAS_Atlas)
+
+	tintColor *= textureColor;
+	tintColor.rgb = mix(vec3(1.0f, 1.0f, 1.0f), tintColor.rgb, tintColor.a);
+
+#endif // defined(HAS_Tint)
+
+	fOutput.Output0 = tintColor;
+
+#endif
+
+}

--- a/PopcornFX/Library/PopcornFXCore/Shaders/Transparent_Mesh.frag
+++ b/PopcornFX/Library/PopcornFXCore/Shaders/Transparent_Mesh.frag
@@ -1,0 +1,92 @@
+#if 	defined(HAS_TransformUVs)
+vec2 transformUV(vec2 UV, vec2 scale, mat2 rotation, vec2 offset)
+{
+	return mul(rotation, UV * scale) + offset;
+}
+#endif
+
+#if defined(HAS_SoftParticles)
+float   clipToLinearDepth(float depth FS_ARGS)
+{
+	float zNear = GET_CONSTANT(SceneInfo, ZBufferLimits).x;
+	float zFar = GET_CONSTANT(SceneInfo, ZBufferLimits).y;
+	return (-zNear * zFar) / (depth * (zFar - zNear) - zFar);
+}
+#endif
+
+void    FragmentMain(IN(SFragmentInput) fInput, OUT(SFragmentOutput) fOutput FS_ARGS)
+{
+	vec4    color = vec4(0,0,0,0);
+
+#if     defined(FINPUT_fragDiffuse_Color)
+	color = fInput.fragDiffuse_Color;
+#else
+	color = vec4(1.0f, 1.0f, 1.0f, 0.1f);
+#endif
+
+#if	    defined(FINPUT_fragColor0)
+	color *= fInput.fragColor0;
+#endif
+
+vec2 fragUV0 = fInput.fragUV0;
+#if		defined(HAS_TransformUVs)
+	float	sinR = sin(fInput.fragTransformUVs_UVRotate);
+	float	cosR = cos(fInput.fragTransformUVs_UVRotate);
+	mat2	UVRotation = mat2(cosR, sinR, -sinR, cosR);
+	vec2	UVScale = fInput.fragTransformUVs_UVScale;
+	vec2	UVOffset = fInput.fragTransformUVs_UVOffset;
+	vec2	oldFragUV0 = fragUV0;	
+	fragUV0 = transformUV(fragUV0, UVScale, UVRotation, UVOffset); // scale then rotate then translate UV
+	fragUV0 = fract(fragUV0);
+	bool	RGBOnly = GET_CONSTANT(Material, TransformUVs_RGBOnly) != 0;
+#endif
+
+#if	defined(HAS_Diffuse)
+	vec4    textureColor = SAMPLE(Diffuse_DiffuseMap, fragUV0);
+	
+#	if defined(HAS_TransformUVs)
+		if (RGBOnly)
+		{
+			textureColor.a =  SAMPLE(Diffuse_DiffuseMap, oldFragUV0).a;
+		}
+#	endif
+
+#if defined(HAS_DiffuseRamp)
+	textureColor.rgb = SAMPLE(DiffuseRamp_RampMap, vec2(textureColor.x,0.0)).rgb;
+#endif
+
+	color *= textureColor;
+
+#if	defined(HAS_AlphaRemap)
+	vec2    alphaTexCoord = vec2(color.a, fInput.fragAlphaRemap_Cursor);
+	color.a = SAMPLE(AlphaRemap_AlphaMap, alphaTexCoord).r;
+#endif 
+
+#endif // defined HAS_Diffuse
+
+#if	defined(HAS_SoftParticles)
+	vec4    projPos = fInput.fragViewProjPosition;
+	float   rcpw = 1.0 / projPos.w;
+	float   fragDepth_cs = projPos.z * rcpw;
+	//  if (IsDepthReversed())
+	//      fragDepth_cs = 1.0 - fragDepth_cs;
+	vec2    screenUV = projPos.xy * rcpw * vec2(0.5, 0.5) + 0.5;
+	float   sceneDepth_cs = SAMPLE(DepthSampler, screenUV).x;
+	float   sceneDepth = clipToLinearDepth(sceneDepth_cs FS_PARAMS);
+	float   fragDepth = clipToLinearDepth(fragDepth_cs FS_PARAMS);
+	float   invSoftnessDistance = 1.0f / GET_CONSTANT(Material, SoftParticles_SoftnessDistance);
+	float   depthfade = clamp((sceneDepth - fragDepth) * invSoftnessDistance, 0.f, 1.f);
+	color *= depthfade;
+#endif
+
+#if	defined(HAS_Emissive)
+	vec3	emissiveColor1 = SAMPLE(Emissive_EmissiveMap, fragUV0).rgb;	
+#if	defined(HAS_EmissiveRamp)
+	emissiveColor1 = SAMPLE(EmissiveRamp_RampMap, vec2(emissiveColor1.x,0.0)).rgb;
+#endif
+	emissiveColor1 *= fInput.fragEmissive_EmissiveColor;
+	color.rgb += emissiveColor1.rgb;
+#endif
+
+	fOutput.Output0 = color;
+}

--- a/PopcornFX/Library/PopcornFXCore/Templates/Color.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Color.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:4df99768032001847fc299134901e3b5edc901b0a8270c4bbed100cc30723352
+size 75221

--- a/PopcornFX/Library/PopcornFXCore/Templates/Core.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Core.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:07d63f88bd417e96502027a0ec7ad2832fcfdcfc5bf144bea3388aa72eed010d
+size 397549

--- a/PopcornFX/Library/PopcornFXCore/Templates/CurvePresets.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/CurvePresets.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e44c2839cf3b493f871abc4a1896190b29d467759bfda58a4cf0ded9a5c7b3ef
+size 20838

--- a/PopcornFX/Library/PopcornFXCore/Templates/Debug.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Debug.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:01773abf592dc709195cfbaec23d1a509b822c26ade0360f73199f62fbfa0706
+size 86552

--- a/PopcornFX/Library/PopcornFXCore/Templates/Dynamics.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Dynamics.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:621c82da983a1c89126d8bf3e4a38f667c667721c9e423d3c4de8fdf9b4aa970
+size 691522

--- a/PopcornFX/Library/PopcornFXCore/Templates/Events.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Events.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3d5d1c367bf8725b037c8427817cedaf2962f3c028c23c1794a7920e9f2b400a
+size 369182

--- a/PopcornFX/Library/PopcornFXCore/Templates/Legacy.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Legacy.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05a8e78f9894ea50bd6b2c02128ebf476074cb23bde38cea047bfc7459deb2b7
+size 453057

--- a/PopcornFX/Library/PopcornFXCore/Templates/Placement.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Placement.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b6a043c997c8aa1db746c52457f4dfe831ff5a6e2a5a7bf4b0d57e0959e44338
+size 192375

--- a/PopcornFX/Library/PopcornFXCore/Templates/Samplers.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Samplers.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:90346b2282fdb68b9ed86c95db290336a2305c93065ee811ad2d21d221bd39a5
+size 343899

--- a/PopcornFX/Library/PopcornFXCore/Templates/Trails.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Trails.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48eee1eafd2191b8e526355ae34f20d1dc84eb14e0827e0fd64e8da5402a2069
+size 113127

--- a/PopcornFX/Library/PopcornFXCore/Templates/Utils.pkfx
+++ b/PopcornFX/Library/PopcornFXCore/Templates/Utils.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c7a22c7e398dbc729eb59c6cb1e18972be875fe653587ed79bb6c3109f5ec8a4
+size 453275

--- a/PopcornFX/Particles/ParticleBall.pkfx
+++ b/PopcornFX/Particles/ParticleBall.pkfx
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d4cdf00c7d3699a2c9eb532db8b12360c1ed231466c61ab4ca2861a8347ec748
+size 47354

--- a/PopcornFX/PopcornProject.pkproj
+++ b/PopcornFX/PopcornProject.pkproj
@@ -1,0 +1,147 @@
+Version = 2.12.6.13518;
+CProjectSettings	$D857A09F
+{
+	General = "$35A36C4E";
+	Scene = "$4B933A29";
+	LOD = "$9154DFA0";
+	Constants = "$EAC726E3";
+	Assets = "$4ADE8DE2";
+	Budgets = "$D279714D";
+	Baking = "$5F621394";
+	Editor = "$41E5AFE7";
+	Features = "$BEDF8936";
+	Documentation = "$2909A531";
+}
+CProjectSettingsGeneral	$35A36C4E
+{
+	ProjectName = "PopcornFX";
+	RootDir = "";
+	PresetsDir = "Editor/Presets";
+	AnimationTracksDir = "Editor/AnimationTracks";
+	ThumbnailsDir = "Editor/Thumbnails";
+	LibraryDir = "Library";
+	RuntimeConfigsDir = "Config";
+	DocumentationDir = "Documentation";
+	EditorCacheDir = "Editor/Cache";
+}
+CProjectSettingsScene	$4B933A29
+{
+	CoordinateFrame = Right_Handed_Z_Up;
+	CoordinateFrameAxisX = Right;
+	CoordinateFrameAxisY = Up;
+	CoordinateFrameAxisZ = Backward;
+	DistanceUnits = Meter;
+	MaxDistanceBeforeTeleport = inf;
+}
+CProjectSettingsLOD	$9154DFA0
+{
+}
+CProjectSettingsConstants	$EAC726E3
+{
+	Constants = {
+		"$D6EEA348",
+		"$5F44DFAB",
+		"$D806D24A",
+		"$D03359D5",
+	};
+}
+CProjectSettingsAssets	$4ADE8DE2
+{
+	EffectExtensions = {
+		"pkfx",
+	};
+	MeshExtensions = {
+		"fbx",
+		"gr2",
+	};
+	ImageExtensions = {
+		"dds",
+		"png",
+		"jpg",
+		"jpeg",
+		"tga",
+		"tif",
+		"tiff",
+		"pkm",
+		"pvr",
+		"exr",
+		"hdr",
+	};
+	ImageAtlasExtensions = {
+		"pkat",
+	};
+	VectorFieldExtensions = {
+		"fga",
+		"pkvf",
+	};
+	SimCacheExtensions = {
+		"pksc",
+	};
+	FontExtensions = {
+		"ttf",
+		"otf",
+		"pkfm",
+	};
+	FeatureSetExtensions = {
+		"pkma",
+	};
+	VertexShaderExtensions = {
+		"vert",
+	};
+	FragmentShaderExtensions = {
+		"frag",
+	};
+	ShaderIncludeExtensions = {
+		"h",
+		"inl",
+	};
+	RendererInterfaceExtensions = {
+		"pkri",
+	};
+	VideoExtensions = {
+		"mp4",
+		"avi",
+		"ogv",
+		"wmv",
+	};
+}
+CProjectSettingsBudgets	$D279714D
+{
+}
+CProjectSettingsBaking	$5F621394
+{
+}
+CProjectSettingsEditor	$41E5AFE7
+{
+	DefaultRestitution = 1.0000000e+00;
+	DefaultRestitutionCombineMode = Multiply;
+	DefaultFriction = 5.0000000e-01;
+	DefaultFrictionCombineMode = Average;
+	WindScale = 1.0000000e+00;
+}
+CProjectSettingsFeatures	$BEDF8936
+{
+}
+CProjectSettingsDocumentation	$2909A531
+{
+}
+CProjectSettingsConstantItem	$D6EEA348
+{
+	Name = "build.tags.low";
+	Value = 28;
+}
+CProjectSettingsConstantItem	$5F44DFAB
+{
+	Name = "build.tags.medium";
+	Value = 29;
+}
+CProjectSettingsConstantItem	$D806D24A
+{
+	Name = "build.tags.high";
+	Value = 30;
+}
+CProjectSettingsConstantItem	$D03359D5
+{
+	Name = "build.tags.veryhigh";
+	Value = 31;
+}

--- a/project.json
+++ b/project.json
@@ -13,5 +13,8 @@
     ],
     "icon_path": "preview.png",
     "engine": "o3de",
-    "external_subdirectories": []
+    "external_subdirectories": [],
+    "gem_names": [
+        "PopcornFX"
+    ]
 }


### PR DESCRIPTION
Enabled the PopcornFX gem and added a default PopcornFX project to the game.

Added a new "particle ball" entity to the SampleBase level that you can kick around. It's similar to the other ball, except rendered as a particle system instead of a mesh. I verified that the particle system component does get replicated across multiple clients. Of course the particles themselves won't be in sync but the overall system is attached to an entity that does get synced, so the overall gameplay mechanism is the same.

![image](https://user-images.githubusercontent.com/55155825/178406316-31675463-ab89-4a9e-8623-2003309f4dd0.png)

![image](https://user-images.githubusercontent.com/55155825/178406393-7ec4456e-491f-4577-b370-b84d13d32afb.png)

After these changes go in, all developers will need to set up PopcornFX locally...
The setup process isn't sqeaky clean because the version on the official PopcornFX package server (https://downloads.popcornfx.com/o3de-repo) is version 2.9 which is a bit dated and not compatible with the development branch of o3de. The current version at the time of writing is 2.12.7 and it must be installed manually. Also note that some of their shaders (for some kind of "legacy" support) don't compile (again due to API changes we've made) but we probably don't need those particular shaders to work anyway.

1. Download the gem from https://www.popcornfx.com/plugin-o3de/ and extract somewhere. I used D:\o3de-gems\PopcornFX_2_12_7
2. Run O3DE Project Manager. 
3. Go to the Gems tab.
4. Click Add Existing Gem.
5. Browse to where you extracted the PopcornFX gem (D:\o3de-gems\PopcornFX_2_12_7) and click Select Folder.
6. In the gem list, you should be able to find and select the PopcornFX gem. In the details panel confirm the Gem Version is 2.12.7
7. Download the PopcornFX 2.12.7 editor at https://www.popcornfx.com/download/ (if you want to edit particles)
8. I had to comment out a use of the SCRIPT_CANVAS_PERFORMANCE_SCOPE_LATENT macro, it seems the API changed.
