### PR TITLE
Remove FlyCameraComponent and update SimplePlayerCamera interpolation

### DIFF
--- a/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.h
+++ b/Gem/Code/Source/Components/NetworkSimplePlayerCameraComponent.h
@@ -26,6 +26,10 @@ namespace MultiplayerSample
         float GetCameraPitch() const;
         float GetCameraRoll() const;
 
+        float GetCameraYawPrevious() const;
+        float GetCameraPitchPrevious() const;
+        float GetCameraRollPrevious() const;
+
     private:
         //! AZ::TickBus interface
         //! @{

--- a/Levels/SampleBase/SampleBase.prefab
+++ b/Levels/SampleBase/SampleBase.prefab
@@ -1925,13 +1925,6 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 154105298091518109
                 },
-                "Component_[15452140819580244001]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 15452140819580244001,
-                    "m_template": {
-                        "$type": "FlyCameraInputComponent"
-                    }
-                },
                 "Component_[17443734220531699641]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 17443734220531699641


### PR DESCRIPTION
This removes the FlyCameraComponent from SampleBase's camera. It fights with NetworkSimplePlayerCameraComponent on position causing a lot of jittering on the camera's position. This change also updates NetworkSimplePlayerCameraComponent to use blend factor to interpolate between current and previous aim angles much like NetworkTransformComponent.

Signed-off-by: puvvadar <puvvadar@amazon.com>