### PR TITLE
ClientServer Fix

### DIFF
--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
@@ -108,20 +108,12 @@ namespace MultiplayerSample
         return AZ::TICK_PLACEMENT + 2;
     }
 
-    Multiplayer::NetworkEntityHandle MultiplayerSampleSystemComponent::OnPlayerJoin([[maybe_unused]] uint64_t userId, [[maybe_unused]] const Multiplayer::MultiplayerAgentDatum& agentDatum, EntityPreActivationCallback preActivationCallback)
+    Multiplayer::NetworkEntityHandle MultiplayerSampleSystemComponent::OnPlayerJoin([[maybe_unused]] uint64_t userId, const Multiplayer::MultiplayerAgentDatum& agentDatum)
     {
-        AZStd::pair<Multiplayer::PrefabEntityId, AZ::Transform> entityParams = AZ::Interface<IPlayerSpawner>::Get()->GetNextPlayerSpawn();
+        const AZStd::pair<Multiplayer::PrefabEntityId, AZ::Transform> entityParams = AZ::Interface<IPlayerSpawner>::Get()->GetNextPlayerSpawn();
 
-        Multiplayer::INetworkEntityManager::EntityList entityList =
-            AZ::Interface<Multiplayer::IMultiplayer>::Get()->GetNetworkEntityManager()->CreateEntitiesImmediate(
-            entityParams.first, Multiplayer::NetEntityRole::Authority, entityParams.second, Multiplayer::AutoActivate::DoNotActivate);
-
-        preActivationCallback(entityList);
-
-        for (Multiplayer::NetworkEntityHandle subEntity : entityList)
-        {
-            subEntity.Activate();
-        }
+        Multiplayer::INetworkEntityManager::EntityList entityList = Multiplayer::GetNetworkEntityManager()->CreateAutomonousPlayerImmediate(
+            entityParams.first, entityParams.second, agentDatum.m_id, Multiplayer::AutoActivate::Activate);
 
         Multiplayer::NetworkEntityHandle controlledEntity;
         if (!entityList.empty())

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.cpp
@@ -108,6 +108,41 @@ namespace MultiplayerSample
         return AZ::TICK_PLACEMENT + 2;
     }
 
+    void MultiplayerSampleSystemComponent::EnableAutonomousControl(Multiplayer::NetworkEntityHandle entityHandle, AzNetworking::ConnectionId connectionId)
+    {
+        if (!entityHandle.Exists())
+        {
+            AZLOG_WARN("Attempting to enable autonomous control for an invalid entity");
+            return;
+        }
+
+        entityHandle.GetNetBindComponent()->SetOwningConnectionId(connectionId);
+        if (connectionId == InvalidConnectionId)
+        {
+            entityHandle.GetNetBindComponent()->SetAllowAutonomy(true);
+        }
+
+        /*auto* hierarchyComponent = entityHandle.FindComponent<NetworkHierarchyRootComponent>();
+        if (hierarchyComponent != nullptr)
+        {
+            for (AZ::Entity* subEntity : hierarchyComponent->GetHierarchicalEntities())
+            {
+                NetworkEntityHandle subEntityHandle = NetworkEntityHandle(subEntity);
+                NetBindComponent* subEntityNetBindComponent = subEntityHandle.GetNetBindComponent();
+
+                if (subEntityNetBindComponent != nullptr)
+                {
+                    subEntityNetBindComponent->SetOwningConnectionId(connectionId);
+                    if (connectionId == InvalidConnectionId)
+                    {
+                        subEntityNetBindComponent->SetAllowAutonomy(true);
+                    }
+                }
+            }
+        }*/
+    }
+
+
     Multiplayer::NetworkEntityHandle MultiplayerSampleSystemComponent::OnPlayerJoin(
         [[maybe_unused]] uint64_t userId, [[maybe_unused]] const Multiplayer::MultiplayerAgentDatum& agentDatum)
     {
@@ -119,6 +154,7 @@ namespace MultiplayerSample
 
         for (Multiplayer::NetworkEntityHandle subEntity : entityList)
         {
+            EnableAutonomousControl(subEntity, AzNetworking::InvalidConnectionId);
             subEntity.Activate();
         }
 

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.h
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.h
@@ -64,6 +64,9 @@ namespace MultiplayerSample
             AzNetworking::DisconnectReason reason) override;
         ////////////////////////////////////////////////////////////////////////
 
+        void EnableAutonomousControl(Multiplayer::NetworkEntityHandle entityHandle, AzNetworking::ConnectionId connectionId);
+
+
         AZStd::unique_ptr<MultiplayerSample::IPlayerSpawner> m_playerSpawner;
     };
 }

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.h
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.h
@@ -57,7 +57,7 @@ namespace MultiplayerSample
 
         ////////////////////////////////////////////////////////////////////////
         // IMultiplayerSpawner overrides
-        Multiplayer::NetworkEntityHandle OnPlayerJoin(uint64_t userId, const Multiplayer::MultiplayerAgentDatum& agentDatum, EntityPreActivationCallback preActivationCallback) override;
+        Multiplayer::NetworkEntityHandle OnPlayerJoin(uint64_t userId, const Multiplayer::MultiplayerAgentDatum& agentDatum) override;
         void OnPlayerLeave(
             Multiplayer::ConstNetworkEntityHandle entityHandle,
             const Multiplayer::ReplicationSet& replicationSet,

--- a/Gem/Code/Source/MultiplayerSampleSystemComponent.h
+++ b/Gem/Code/Source/MultiplayerSampleSystemComponent.h
@@ -57,15 +57,12 @@ namespace MultiplayerSample
 
         ////////////////////////////////////////////////////////////////////////
         // IMultiplayerSpawner overrides
-        Multiplayer::NetworkEntityHandle OnPlayerJoin(uint64_t userId, const Multiplayer::MultiplayerAgentDatum& agentDatum) override;
+        Multiplayer::NetworkEntityHandle OnPlayerJoin(uint64_t userId, const Multiplayer::MultiplayerAgentDatum& agentDatum, EntityPreActivationCallback preActivationCallback) override;
         void OnPlayerLeave(
             Multiplayer::ConstNetworkEntityHandle entityHandle,
             const Multiplayer::ReplicationSet& replicationSet,
             AzNetworking::DisconnectReason reason) override;
         ////////////////////////////////////////////////////////////////////////
-
-        void EnableAutonomousControl(Multiplayer::NetworkEntityHandle entityHandle, AzNetworking::ConnectionId connectionId);
-
 
         AZStd::unique_ptr<MultiplayerSample::IPlayerSpawner> m_playerSpawner;
     };


### PR DESCRIPTION
Adding entity preactivation callback to network spawners in order for multiplayer system to edit the network entities before it's activated (used to turn on autonomous role)
This change depends on an o3de change: https://github.com/o3de/o3de/pull/10951

Signed-off-by: Gene Walters <genewalt@amazon.com>