### PR TITLE
Updated prefabs to follow new pattern that colliders require a rigid body

### DIFF
--- a/Levels/MultiplayerScriptingSample/MultiplayerScriptingSample.prefab
+++ b/Levels/MultiplayerScriptingSample/MultiplayerScriptingSample.prefab
@@ -153,6 +153,10 @@
                     "$type": "EditorInspectorComponent",
                     "Id": 16919232076966545697
                 },
+                "Component_[2960678723173417090]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 2960678723173417090
+                },
                 "Component_[5182430712893438093]": {
                     "$type": "EditorMaterialComponent",
                     "Id": 5182430712893438093
@@ -611,6 +615,10 @@
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 4359509050153721746
                 },
+                "Component_[4943889438335863246]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4943889438335863246
+                },
                 "Component_[5426140991145363755]": {
                     "$type": "EditorLockComponent",
                     "Id": 5426140991145363755
@@ -674,6 +682,10 @@
                 "Component_[11533263361782952832]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 11533263361782952832
+                },
+                "Component_[1172507344006396694]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 1172507344006396694
                 },
                 "Component_[2379775448271128582]": {
                     "$type": "EditorEntitySortComponent",
@@ -913,6 +925,10 @@
                 "Component_[7477730162211838733]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 7477730162211838733
+                },
+                "Component_[9012462486346722248]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 9012462486346722248
                 },
                 "Component_[9017206101099697396]": {
                     "$type": "GenericComponentWrapper",

--- a/Levels/SampleBase/SampleBase.prefab
+++ b/Levels/SampleBase/SampleBase.prefab
@@ -1006,6 +1006,10 @@
             "Id": "Entity_[412839637138]",
             "Name": "Ground",
             "Components": {
+                "Component_[11010496959374222323]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 11010496959374222323
+                },
                 "Component_[14576502551830180300]": {
                     "$type": "EditorColliderComponent",
                     "Id": 14576502551830180300,
@@ -1020,11 +1024,6 @@
                                 {
                                     "Name": "Entire object"
                                 }
-                            ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
                             ]
                         }
                     },
@@ -1189,6 +1188,10 @@
                 "Component_[13545070526863732984]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 13545070526863732984
+                },
+                "Component_[17214965729815923865]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 17214965729815923865
                 },
                 "Component_[2917092960552172245]": {
                     "$type": "EditorVisibilityComponent",

--- a/Levels/SpawningPerfTest/SpawningPerfTest.prefab
+++ b/Levels/SpawningPerfTest/SpawningPerfTest.prefab
@@ -324,11 +324,6 @@
                                     "Name": "Entire object"
                                 }
                             ]
-                        },
-                        "MaterialSelection": {
-                            "MaterialIds": [
-                                {}
-                            ]
                         }
                     },
                     "ShapeConfiguration": {
@@ -365,6 +360,10 @@
                 "Component_[8118181039276487398]": {
                     "$type": "EditorOnlyEntityComponent",
                     "Id": 8118181039276487398
+                },
+                "Component_[8934621788354185078]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 8934621788354185078
                 },
                 "Component_[9189909764215270515]": {
                     "$type": "EditorLockComponent",


### PR DESCRIPTION
**IMPORTANT: Please approve but DO NOT merge this PR yet!** 

@moraaar will merge it once the work in [PhysX_StaticRigidBody_Staging](https://github.com/aws-lumberyard-dev/o3de/tree/PhysX_StaticRigidBody_Staging) branch is in o3de/development.

More information about this update here: https://github.com/o3de/o3de/pull/14261

Steps done:
- Open Editor.
- Run command `ed_physxUpdatePrefabsWithColliderComponents`.

Signed-off-by: moraaar <moraaar@amazon.com>