### PR TITLE
Replacing the non-portable reference to the Multiplayer Gem location with a portable reference

### DIFF
--- a/Gem/Code/multiplayersample_autogen_files.cmake
+++ b/Gem/Code/multiplayersample_autogen_files.cmake
@@ -5,12 +5,14 @@
 #
 #
 
+get_property(multiplayer_gem_root GLOBAL PROPERTY "@GEMROOT:Multiplayer@")
+
 set(FILES
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Header.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Header.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
     
     # Scripting samples
     Source/AutoGen/ScriptingPlayerMovementComponent.AutoComponent.xml


### PR DESCRIPTION
If the Multiplayer Gem location is ever moved or renamed it would break the autogen references in the project

fixes #44


## How was this PR tested?

Configured and built the Multiplayer Sample project successfully