### PR TITLE
Replacing the non-portable reference to the Multiplayer Gem location

### DIFF
--- a/Gem/Code/multiplayersample_autogen_files.cmake
+++ b/Gem/Code/multiplayersample_autogen_files.cmake
@@ -5,12 +5,14 @@
 #
 #
 
+get_property(multiplayer_gem_root GLOBAL PROPERTY "@GEMROOT:Multiplayer@")
+
 set(FILES
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Header.jinja
-    ${LY_ROOT_FOLDER}/Gems/Multiplayer/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponent_Common.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponent_Header.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponent_Source.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Header.jinja
+    ${multiplayer_gem_root}/Code/Include/Multiplayer/AutoGen/AutoComponentTypes_Source.jinja
     
     # Scripting samples
     Source/AutoGen/ScriptingPlayerMovementComponent.AutoComponent.xml


### PR DESCRIPTION
Cherry-picking over https://github.com/o3de/o3de-multiplayersample/pull/242/commits/49c4c364d41f1be348592f7f9b5794d018fd7c8b