### PR TITLE
Temp logging to help diagnose movement "disconnect"

### DIFF
--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -200,6 +200,11 @@ namespace MultiplayerSample
         NetworkPlayerMovementComponentNetworkInput* playerInput = input.FindComponentInput<NetworkPlayerMovementComponentNetworkInput>();
         if (playerInput->m_resetCount != GetNetworkTransformComponentController()->GetResetCount())
         {
+            // TEMPORARY LOGGING TO HELP DIAGNOSE MOVEMENT DISCONNECTIONS.
+            // Specifically, sometimes a player will still be able to move around locally, but on the server and other connected clients,
+            // the player has stopped moving. They can no longer interact with the environment, but they are still connected and can see
+            // the other players moving around, still receive damage notifications,e tc.
+            // This logging will get removed after the root cause has been found and resolved.
             AZLOG_INFO("netEntityId=%u: Different reset count, discarding player input. Input / local reset=%u / %u, clientInputId=%u, hostFrame=%u",
                 GetNetEntityId(), playerInput->m_resetCount, GetNetworkTransformComponentController()->GetResetCount(), 
                 input.GetClientInputId(), input.GetHostFrameId()

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -200,6 +200,10 @@ namespace MultiplayerSample
         NetworkPlayerMovementComponentNetworkInput* playerInput = input.FindComponentInput<NetworkPlayerMovementComponentNetworkInput>();
         if (playerInput->m_resetCount != GetNetworkTransformComponentController()->GetResetCount())
         {
+            AZLOG_INFO("netEntityId=%u: Different reset count, discarding player input. Input / local reset=%u / %u, clientInputId=%u, hostFrame=%u",
+                GetNetEntityId(), playerInput->m_resetCount, GetNetworkTransformComponentController()->GetResetCount(), 
+                input.GetClientInputId(), input.GetHostFrameId()
+            );
             return;
         }
 


### PR DESCRIPTION
Currently, MPS has a bug where a player stops getting movement updates on the server. They can move around locally, but the replicated player stops moving. This logging is a temporary addition to help diagnose whether the input is getting discarded in ProcessInput() or if it's getting discarded somewhere else somehow. It will be removed again once we verify if the problem is occurring in ProcessInput() or somewhere else.