### PR TITLE
Update preview screens

### DIFF
--- a/Gem/preview.png
+++ b/Gem/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6d6204c6730e5675791765ca194e9b1cbec282208e280507de830afc2805e5fa
-size 41127
+oid sha256:936e6057fd22a0c7ef6c48b66d7495dcab105052eaaf24d11b3baff8cce932dc
+size 29895

--- a/preview.png
+++ b/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:682ecefceef4c154e386cd2dcdca2db7a3357c078777018968b181fd94abe7c8
-size 75685
+oid sha256:06e6db9ae8c332ef40921ede4ac1aa5637e9125cf616787d1640809ed8fc565a
+size 117744


### PR DESCRIPTION
Add new preview.png

1. For project manager
![preview](https://user-images.githubusercontent.com/61438964/228002602-2445f5df-8494-4673-9610-9f23123c8c05.png)


2. For gem preview (temporary, expect to replace with something better, but removes Lumberyard beaver icon.
![preview](https://user-images.githubusercontent.com/61438964/228002658-beb18aa0-c477-49f6-b2ab-184a3ef65b6d.png)

Old icons for reference:

1. Project Manager
![preview](https://user-images.githubusercontent.com/61438964/228002958-e2beaa47-8d0f-48c0-9cc7-31b4cb57dd17.png)

2. Gem
![preview](https://user-images.githubusercontent.com/61438964/228002935-d52ffafe-8b18-4c2e-a79c-02e3dff76e44.png)
