### PR TITLE
Sprint toggle

### DIFF
--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -137,12 +137,6 @@ namespace MultiplayerSample
         // Inputs for your own component always exist
         NetworkPlayerMovementComponentNetworkInput* playerInput = input.FindComponentInput<NetworkPlayerMovementComponentNetworkInput>();
 
-        if (m_toggleSprint)
-        {
-            m_sprinting = !m_sprinting;
-            m_toggleSprint = false;
-        }
-
         // Check current game-play state
         INetworkMatch* networkMatchComponent = AZ::Interface<INetworkMatch>::Get();
         if (networkMatchComponent && (networkMatchComponent->PlayerActionsAllowed() != AllowedPlayerActions::None))
@@ -159,6 +153,13 @@ namespace MultiplayerSample
 
         if (networkMatchComponent && (networkMatchComponent->PlayerActionsAllowed() == AllowedPlayerActions::All))
         {
+            // Check if the user requested to toggle sprint-state
+            if (m_toggleSprint)
+            {
+                m_sprinting = !m_sprinting;
+                m_toggleSprint = false;
+            }
+
             // Movement axis
             // Since we're on a keyboard, this adds a touch of an acceleration curve to the keyboard inputs
             // This is so that tapping the keyboard moves the virtual stick less than just holding it down

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -137,6 +137,12 @@ namespace MultiplayerSample
         // Inputs for your own component always exist
         NetworkPlayerMovementComponentNetworkInput* playerInput = input.FindComponentInput<NetworkPlayerMovementComponentNetworkInput>();
 
+        if (m_toggleSprint)
+        {
+            m_sprinting = !m_sprinting;
+            m_toggleSprint = false;
+        }
+
         // Check current game-play state
         INetworkMatch* networkMatchComponent = AZ::Interface<INetworkMatch>::Get();
         if (networkMatchComponent && (networkMatchComponent->PlayerActionsAllowed() != AllowedPlayerActions::None))
@@ -542,7 +548,7 @@ namespace MultiplayerSample
         }
         else if (*inputId == SprintEventId)
         {
-            m_sprinting = true;
+            m_toggleSprint = true;
         }
         else if (*inputId == JumpEventId)
         {
@@ -588,10 +594,6 @@ namespace MultiplayerSample
         else if (*inputId == MoveRightEventId)
         {
             m_rightDown = false;
-        }
-        else if (*inputId == SprintEventId)
-        {
-            m_sprinting = false;
         }
         else if (*inputId == JumpEventId)
         {

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.cpp
@@ -281,6 +281,14 @@ namespace MultiplayerSample
         GetNetworkAnimationComponentController()->ModifyActiveAnimStates().SetBit(
             aznumeric_cast<uint32_t>(CharacterAnimState::Falling), isFalling);
 
+        // If we're still on the ground, then zero out our velocity from external forces
+        // This prevents us from sliding along the ground after we land
+        PhysX::CharacterGameplayRequestBus::EventResult(onGround, GetEntityId(), &PhysX::CharacterGameplayRequestBus::Events::IsOnGround);
+        if (onGround)
+        {
+            SetVelocityFromExternalSources(AZ::Vector3::CreateZero());
+        }
+
         // At the end, track whether or not we were on the ground for this input so we can compare states when processing the next input.
         SetWasOnGround(onGround);
     }

--- a/Gem/Code/Source/Components/NetworkPlayerMovementComponent.h
+++ b/Gem/Code/Source/Components/NetworkPlayerMovementComponent.h
@@ -101,6 +101,8 @@ namespace MultiplayerSample
         float m_viewYaw = 0.0f;
         float m_viewPitch = 0.0f;
 
+        bool m_toggleSprint = false;
+
         bool m_forwardDown = false;
         bool m_leftDown = false;
         bool m_backwardDown = false;


### PR DESCRIPTION
Makes the shift key toggle player sprint state, rather than require the shift key to be held down to sprint.