### PR TITLE
Tweak preview icons to work in ProjectManager

### DIFF
--- a/Gem/preview.png
+++ b/Gem/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:936e6057fd22a0c7ef6c48b66d7495dcab105052eaaf24d11b3baff8cce932dc
-size 29895
+oid sha256:248e3ffe1fc9ffc02afb2ba8914e222a5a5d13ac45a48b98c95ee062e959a94c
+size 4475

--- a/preview.png
+++ b/preview.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:06e6db9ae8c332ef40921ede4ac1aa5637e9125cf616787d1640809ed8fc565a
-size 117744
+oid sha256:fbf7a7aa55e6b1c8332e9947a507c2ea61a566251fea7edfdc81e31598e5e9e8
+size 98730


### PR DESCRIPTION
* Update project preview so it works better in ProjectManager 
![preview](https://user-images.githubusercontent.com/61438964/228381788-3048df0b-dc54-4d60-80a7-9ff428c56ab1.png)
* Text is not perfectly centered, but ok I hope


* Use generic black and white O3DE gem preview icon to match style of other Gem icons in O3DE
![preview](https://user-images.githubusercontent.com/61438964/228381811-702b4aac-f594-493e-bc80-fabc03877d99.png)


Project Preview in Project manager now looks like:
![preview_preview](https://user-images.githubusercontent.com/61438964/228381901-47d39c15-3e86-46c9-89a8-44a1a7383670.PNG)

Project name is not obscured by buttons.