### PR TITLE
PlayerId TickBus Disconnect

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/PlayerIdentityComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/PlayerIdentityComponent.cpp
@@ -64,6 +64,7 @@ namespace MultiplayerSample
     void PlayerIdentityComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
         #if AZ_TRAIT_CLIENT
+            AZ::TickBus::Handler::BusDisconnect();
         #endif
     }
 


### PR DESCRIPTION
Making sure to disconnect from the tickbus when the component deactivates. 
Otherwise OnTick can be called with an invalid entity and crash.