### PR TITLE
Add gem spawning on death

### DIFF
--- a/Gem/Code/Source/AutoGen/GemSpawnerComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/GemSpawnerComponent.AutoComponent.xml
@@ -26,14 +26,14 @@
                        ExposeToEditor="true" Description="A tag value for entities the describe the location of gems spawn points." />
 
     <RemoteProcedure Name="RPC_SpawnGem" InvokeFrom="Server" HandleOn="Authority" 
-                     IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="Spawn a gem at a specific location">
+                     IsPublic="true" IsReliable="true" GenerateEventBindings="true" Description="Spawn a gem at a specific location">
       <Param Type="Multiplayer::NetEntityId" Name="PlayerEntity"/>
       <Param Type="AZ::Vector3" Name="SpawnLocation"/>
       <Param Type="AZStd::string" Name="GemTag"/>
     </RemoteProcedure>
 
   <RemoteProcedure Name="RPC_SpawnGemWithValue" InvokeFrom="Server" HandleOn="Authority"
-                   IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="Spawn a gem at a specific location with the given value">
+                   IsPublic="true" IsReliable="true" GenerateEventBindings="true" Description="Spawn a gem at a specific location with the given value">
     <Param Type="Multiplayer::NetEntityId" Name="PlayerEntity"/>
     <Param Type="AZ::Vector3" Name="SpawnLocation"/>
     <Param Type="AZStd::string" Name="GemTag"/>

--- a/Gem/Code/Source/AutoGen/GemSpawnerComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/GemSpawnerComponent.AutoComponent.xml
@@ -24,4 +24,20 @@
 
     <ArchetypeProperty Type="AZStd::string" Name="GemSpawnTag"
                        ExposeToEditor="true" Description="A tag value for entities the describe the location of gems spawn points." />
+
+    <RemoteProcedure Name="RPC_SpawnGem" InvokeFrom="Server" HandleOn="Authority" 
+                     IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="Spawn a gem at a specific location">
+      <Param Type="Multiplayer::NetEntityId" Name="PlayerEntity"/>
+      <Param Type="AZ::Vector3" Name="SpawnLocation"/>
+      <Param Type="AZStd::string" Name="GemTag"/>
+    </RemoteProcedure>
+
+  <RemoteProcedure Name="RPC_SpawnGemWithValue" InvokeFrom="Server" HandleOn="Authority"
+                   IsPublic="true" IsReliable="true" GenerateEventBindings="false" Description="Spawn a gem at a specific location with the given value">
+    <Param Type="Multiplayer::NetEntityId" Name="PlayerEntity"/>
+    <Param Type="AZ::Vector3" Name="SpawnLocation"/>
+    <Param Type="AZStd::string" Name="GemTag"/>
+    <Param Type="uint16_t" Name="GemValue"/>
+  </RemoteProcedure>
+
 </Component>

--- a/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
+++ b/Gem/Code/Source/AutoGen/NetworkMatchComponent.AutoComponent.xml
@@ -29,6 +29,7 @@
     <ArchetypeProperty Type="float"  Name="RoundDuration"  Init="120.f" ExposeToEditor="true" Description="Total time of a round in seconds" />
     <ArchetypeProperty Type="uint16_t"  Name="TotalRounds"  Init="3" ExposeToEditor="true" Description="Total number of rounds" />
     <ArchetypeProperty Type="uint16_t"  Name="RespawnPenaltyPercent" Init="50" ExposeToEditor="true" Description="Percent of score to deduct on armor depletion"/>
+    <ArchetypeProperty Type="AZStd::string"  Name="RespawnGemTag" ExposeToEditor="true" Description="The type of gem to spawn on armor depletion" />
     <ArchetypeProperty Type="float"  Name="RestDurationBetweenRounds"  Init="10.0f" ExposeToEditor="true" Description="The time between rounds to rest and look at the score." />
 
     <RemoteProcedure Name="RPC_EndMatch" InvokeFrom="Authority" HandleOn="Client" IsPublic="false" IsReliable="true"

--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
@@ -174,8 +174,8 @@ namespace MultiplayerSample
         [[maybe_unused]] const Multiplayer::NetEntityId& playerEntity, 
         const AZ::Vector3& spawnLocation, const AZStd::string& gemTag, const uint16_t& gemValue)
     {
-        auto gemEntry = GetGemSpawnable(AZ::Crc32(gemTag));
-        if (gemEntry)
+        
+        if (auto gemEntry = GetGemSpawnable(AZ::Crc32(gemTag)); gemEntry)
         { 
             // Spawn the gem with the max value between what's requested and what's in the gem table.
             uint16_t value = AZStd::max(gemEntry->m_scoreValue, gemValue);
@@ -198,8 +198,7 @@ namespace MultiplayerSample
 
     void GemSpawnerComponentController::SpawnGem(const AZ::Vector3& location, const AZ::Crc32& type)
     {
-        auto gemEntry = GetGemSpawnable(type);
-        if (gemEntry)
+        if (auto gemEntry = GetGemSpawnable(type); gemEntry)
         {
             SpawnGem(location, gemEntry->m_gemAsset, gemEntry->m_scoreValue);
         }

--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.cpp
@@ -162,28 +162,59 @@ namespace MultiplayerSample
         }
     }
 
-    void GemSpawnerComponentController::SpawnGem(const AZ::Vector3& location, const AZ::Crc32& type)
+    void GemSpawnerComponentController::HandleRPC_SpawnGem(
+        [[maybe_unused]] AzNetworking::IConnection* invokingConnection, 
+        [[maybe_unused]] const Multiplayer::NetEntityId& playerEntity, const AZ::Vector3& spawnLocation, const AZStd::string& gemTag)
     {
-        if (GetParent().GetGemSpawnables().empty())
-        {
-            return;
-        }
+        SpawnGem(spawnLocation, AZ::Crc32(gemTag));
+    }
 
-        const GemSpawnable* spawnable = nullptr;
-        for (const GemSpawnable& gemType : GetParent().GetGemSpawnables())
+    void GemSpawnerComponentController::HandleRPC_SpawnGemWithValue(
+        [[maybe_unused]] AzNetworking::IConnection* invokingConnection,
+        [[maybe_unused]] const Multiplayer::NetEntityId& playerEntity, 
+        const AZ::Vector3& spawnLocation, const AZStd::string& gemTag, const uint16_t& gemValue)
+    {
+        auto gemEntry = GetGemSpawnable(AZ::Crc32(gemTag));
+        if (gemEntry)
+        { 
+            // Spawn the gem with the max value between what's requested and what's in the gem table.
+            uint16_t value = AZStd::max(gemEntry->m_scoreValue, gemValue);
+            SpawnGem(spawnLocation, gemEntry->m_gemAsset, value);
+        }
+    }
+
+    AZStd::optional<const GemSpawnable> GemSpawnerComponentController::GetGemSpawnable(AZ::Crc32 gemTag) const
+    {
+        for (const GemSpawnable gemType : GetParent().GetGemSpawnables())
         {
-            if (type == AZ::Crc32(gemType.m_tag.c_str()))
+            if (gemTag == AZ::Crc32(gemType.m_tag.c_str()))
             {
-                spawnable = &gemType;
+                return gemType;
             }
         }
-        if (!spawnable)
+
+        return {};
+    }
+
+    void GemSpawnerComponentController::SpawnGem(const AZ::Vector3& location, const AZ::Crc32& type)
+    {
+        auto gemEntry = GetGemSpawnable(type);
+        if (gemEntry)
+        {
+            SpawnGem(location, gemEntry->m_gemAsset, gemEntry->m_scoreValue);
+        }
+    }
+
+    void GemSpawnerComponentController::SpawnGem(const AZ::Vector3& location, const AzFramework::SpawnableAsset& gemAsset, uint16_t gemValue)
+    {
+        // Don't spawn gems with 0 value.
+        if (gemValue == 0)
         {
             return;
         }
 
         PrefabCallbacks callbacks;
-        callbacks.m_onActivateCallback = [this, spawnable](AZStd::shared_ptr<AzFramework::EntitySpawnTicket> ticket,
+        callbacks.m_onActivateCallback = [this, gemValue](AZStd::shared_ptr<AzFramework::EntitySpawnTicket> ticket,
             AzFramework::SpawnableConstEntityContainerView view)
         {
             if (view.empty())
@@ -200,7 +231,7 @@ namespace MultiplayerSample
                     if (GemComponentController* gemController = static_cast<GemComponentController*>(gem->GetController()))
                     {
                         gemController->SetRandomPeriodOffset(GetNetworkRandomComponentController()->GetRandomInt() % 1000);
-                        gemController->SetGemScoreValue(spawnable->m_scoreValue);
+                        gemController->SetGemScoreValue(gemValue);
                         gemController->SetGemSpawnerController(this);
                     }
                 }
@@ -213,7 +244,7 @@ namespace MultiplayerSample
 
         GetParent().GetNetworkPrefabSpawnerComponent()->SpawnPrefabAsset(
             AZ::Transform::CreateFromQuaternionAndTranslation(AZ::Quaternion::CreateIdentity(), location),
-            spawnable->m_gemAsset, AZStd::move(callbacks));
+            gemAsset, AZStd::move(callbacks));
     }
 
     void GemSpawnerComponentController::RemoveGems()

--- a/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/GemSpawnerComponent.h
@@ -38,15 +38,23 @@ namespace MultiplayerSample
 
 #if AZ_TRAIT_SERVER
         void SpawnGems();
+        void SpawnGem(const AZ::Vector3& location, const AZ::Crc32& type);
         void RemoveGem(AzFramework::EntitySpawnTicket::Id gemTicketId);
+        void RemoveGems();
+
+        void HandleRPC_SpawnGem(
+            AzNetworking::IConnection* invokingConnection, const Multiplayer::NetEntityId& playerEntity, 
+            const AZ::Vector3& spawnLocation, const AZStd::string& gemTag) override;
+        void HandleRPC_SpawnGemWithValue(
+            AzNetworking::IConnection* invokingConnection, const Multiplayer::NetEntityId& playerEntity, 
+            const AZ::Vector3& spawnLocation, const AZStd::string& gemTag, const uint16_t& gemValue) override;
 #endif
 
     private:
 #if AZ_TRAIT_SERVER
-        void SpawnGem(const AZ::Vector3& location, const AZ::Crc32& type);
-        void RemoveGems();
+        AZStd::optional<const GemSpawnable> GetGemSpawnable(AZ::Crc32 gemTag) const;
+        void SpawnGem(const AZ::Vector3& location, const AzFramework::SpawnableAsset& gemAsset, uint16_t gemValue);
 #endif
-        
         AZStd::unordered_map<AzFramework::EntitySpawnTicket::Id, AZStd::shared_ptr<AzFramework::EntitySpawnTicket>> m_spawnedGems;
 
         struct GemSpawnEntry

--- a/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.cpp
+++ b/Gem/Code/Source/Components/NetworkTeleportCompatibleComponent.cpp
@@ -10,7 +10,7 @@
 #include <Multiplayer/Components/NetworkTransformComponent.h>
 #include <AzCore/Component/TransformBus.h>
 #include <AzCore/Serialization/SerializeContext.h>
-#include <AzFramework/Physics/RigidBodyBus.h>
+#include <AzFramework/Physics/Components/SimulatedBodyComponentBus.h>
 
 namespace MultiplayerSample
 {
@@ -63,7 +63,7 @@ namespace MultiplayerSample
         
         // disable physics (needed to move rigid bodies)
         // see: https://github.com/o3de/o3de/issues/2541
-        Physics::RigidBodyRequestBus::Event(selfId, &Physics::RigidBodyRequestBus::Events::DisablePhysics);
+        AzPhysics::SimulatedBodyComponentRequestsBus::Event(selfId, &AzPhysics::SimulatedBodyComponentRequestsBus::Events::DisablePhysics);
 
         // move self and increment resetCount to prevent transform interpolation
         AZ::TransformBus::Event(selfId,
@@ -73,7 +73,7 @@ namespace MultiplayerSample
         netTransform->SetResetCount(netTransform->GetResetCount() + 1);
 
         // re-enable physics
-        Physics::RigidBodyRequestBus::Event(selfId, &Physics::RigidBodyRequestBus::Events::EnablePhysics);
+        AzPhysics::SimulatedBodyComponentRequestsBus::Event(selfId, &AzPhysics::SimulatedBodyComponentRequestsBus::Events::EnablePhysics);
 
         NotifyTeleport(teleportedLocation);
     }

--- a/Levels/NewStarbase/NewStarbase.prefab
+++ b/Levels/NewStarbase/NewStarbase.prefab
@@ -5538,7 +5538,8 @@
                     "Id": 110022581788315572,
                     "m_template": {
                         "$type": "MultiplayerSample::NetworkMatchComponent",
-                        "RespawnPenaltyPercent": 20
+                        "RespawnPenaltyPercent": 20,
+                        "RespawnGemTag": "Respawn Gem"
                     }
                 },
                 "Component_[11474776527615145837]": {
@@ -5690,6 +5691,17 @@
                                     "assetHint": "prefabs/diamond_gem.spawnable"
                                 },
                                 "Score": 20
+                            },
+                            {
+                                "Tag": "Respawn Gem",
+                                "Asset": {
+                                    "assetId": {
+                                        "guid": "{0A633BA0-57EE-51B7-8722-1EBC551740F2}",
+                                        "subId": 3148544445
+                                    },
+                                    "assetHint": "prefabs/player_drop_gem.spawnable"
+                                },
+                                "Score": 0
                             }
                         ],
                         "SpawnTablesPerRound": [
@@ -30467,7 +30479,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30507,7 +30519,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30547,7 +30559,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30587,7 +30599,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30627,7 +30639,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30667,7 +30679,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30707,7 +30719,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",
@@ -30747,7 +30759,7 @@
                 {
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[2563122736071885678]/Transform Data/Rotate/1",
-                    "value": 1.273830758756478e-12
+                    "value": 1.2738307587564779e-12
                 },
                 {
                     "op": "replace",


### PR DESCRIPTION
When a player dies, they will now spawn a gem cluster where they died worth the same amount that they lose upon death.

Design notes:
* A gem will be spawned from a player's health going to 0, no matter the cause (other player shooting, energy trap, etc).
* The gem will be spawned at the player's position.
* The gem will be worth the exact amount that the dying player loses, or the value set for the gem in the gem table, whichever is higher. (Current configuration sets the gem cluster to 0)
* A gem that is worth 0 will not spawn.
* The gem will despawn at the end of the round if nobody has picked it up.
* The gem will be configured by listing a gem tag on the Network Match component for which gem type to spawn
* The gem tag will be expected to match an entry in the Gem Spawner component in the "Gem Spawnables" table to determine the gem prefab to spawn and the minimum value of the spawned gem.

This PR also has a couple of small cleanups:
* Fixes the physics bus used to teleport a player. The previous bus caused the player to exist for an extra frame by changing the physics representation incorrectly, so the dying player would immediately pick up the spawned gem.
* Small bit of polish to despawn all the gems at round end, as opposed to doing a despawn/spawn both at round start. it just looks a bit nicer IMO.

![image](https://user-images.githubusercontent.com/82224783/229230278-a17ddf62-2362-4ad7-a64a-951c6b3083c0.png)
![image](https://user-images.githubusercontent.com/82224783/229230463-490f693b-6eb7-4a6b-aaf4-f5f611851380.png)
