### PR TITLE
Add missing virtual destructor required for RTTI

### DIFF
--- a/Gem/Code/Include/DecalBus.h
+++ b/Gem/Code/Include/DecalBus.h
@@ -19,6 +19,8 @@ namespace MultiplayerSample
         AZ_RTTI(MultiplayerSample::SpawnDecalConfig, "{FC3DA616-174B-48FD-9BFB-BC277132FB47}");
         inline static void Reflect(AZ::ReflectContext* context);
 
+        virtual ~SpawnDecalConfig() = default;
+
         AZ::Data::AssetId m_materialAssetId; // Asset Id of the material.
         float m_scale = 1.0f;                // Scale in meters.
         float m_opacity = 1.0f;              // How visible the decal is.


### PR DESCRIPTION
Fix for this linux build issue:

```
/data/workspace/o3de/Code/Framework/AzCore/./AzCore/RTTI/BehaviorContext.h:1339:13: error: destructor called on non-final 'MultiplayerSample::SpawnDecalConfig' that has virtual functions but non-virtual destructor [-Werror,-Wdelete-non-abstract-non-virtual-dtor]
            reinterpret_cast<T*>(object)->~T();

```

# Testing

* Fetched latest `58f5d4253cdcea8c7e223d397f5dd2c1d7f273e0`
* Built
* No build errors

Resolves ﻿﻿https://github.com/o3de/o3de-multiplayersample/issues/303
