### PR TITLE
Fixes the damage applied by shield generator explosions

### DIFF
--- a/scriptcanvas/ShieldGeneratorRoundEffects.scriptcanvas
+++ b/scriptcanvas/ShieldGeneratorRoundEffects.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 2267351748472
+                "id": 96042450349155
             },
             "Name": "Script Canvas Graph",
             "Components": {
@@ -16,7 +16,7 @@
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 2310301421432
+                                    "id": 96085400022115
                                 },
                                 "Name": "SC-Node(SendHealthDelta)",
                                 "Components": {
@@ -132,7 +132,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2331776257912
+                                    "id": 96106874858595
                                 },
                                 "Name": "SC-Node(Play)",
                                 "Components": {
@@ -218,7 +218,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2353251094392
+                                    "id": 96128349695075
                                 },
                                 "Name": "SC-Node(Get roundtime remaining in seconds)",
                                 "Components": {
@@ -288,7 +288,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2370430963576
+                                    "id": 96149824531555
                                 },
                                 "Name": "SC-Node(OperatorSub)",
                                 "Components": {
@@ -513,7 +513,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2396200767352
+                                    "id": 96175594335331
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -584,7 +584,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2383315865464
+                                    "id": 96162709433443
                                 },
                                 "Name": "SC-Node(OperatorDiv)",
                                 "Components": {
@@ -785,7 +785,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2409085669240
+                                    "id": 96188479237219
                                 },
                                 "Name": "SC-Node(TimeDelayNodeableNode)",
                                 "Components": {
@@ -922,7 +922,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2280236650360
+                                    "id": 96055335251043
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -993,7 +993,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 62753376178040
+                                    "id": 96072515120227
                                 },
                                 "Name": "SC-Node(SpawnDecal)",
                                 "Components": {
@@ -1087,7 +1087,9 @@
                                                     "m_type": 4,
                                                     "m_azType": "{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"
                                                 },
-                                                "isNullPointer": true,
+                                                "isNullPointer": false,
+                                                "$type": "AZ::Uuid",
+                                                "value": "{00000000-0000-0000-0000-000000000000}",
                                                 "label": "Source"
                                             },
                                             {
@@ -1119,13 +1121,17 @@
                                                     "m_type": 4,
                                                     "m_azType": "{FC3DA616-174B-48FD-9BFB-BC277132FB47}"
                                                 },
-                                                "isNullPointer": true,
+                                                "isNullPointer": false,
+                                                "$type": "MultiplayerSample::SpawnDecalConfig",
                                                 "label": "SpawnDecalConfig: 2"
                                             }
                                         ],
                                         "methodType": 0,
                                         "methodName": "SpawnDecal",
                                         "className": "RequestBus",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
                                         "inputSlots": [
                                             {
                                                 "m_id": "{DB61774C-D56B-49C9-B35C-33E5A3F2A7A5}"
@@ -1143,7 +1149,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2297416519544
+                                    "id": 96093989956707
                                 },
                                 "Name": "SC-Node(ForEach)",
                                 "Components": {
@@ -1261,7 +1267,6 @@
                                         ],
                                         "Datums": [
                                             {
-                                                "isOverloadedStorage": false,
                                                 "scriptCanvasType": {
                                                     "m_type": 4,
                                                     "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
@@ -1291,7 +1296,77 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2340366192504
+                                    "id": 96115464793187
+                                },
+                                "Name": "SC-Node(NetworkHealthComponentTypeId::Getter)",
+                                "Components": {
+                                    "Component_[15851503404628616245]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 15851503404628616245,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{285C18A0-4CB7-444D-80AB-A7E66AAB5B07}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{D21B2B42-7EA6-46BC-91DD-C4A4657F9BE6}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{DB1DE106-13B4-40C1-8AC9-FDA1FB47C61E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Uuid",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "methodType": 1,
+                                        "methodName": "NetworkHealthComponentTypeId::Getter",
+                                        "resultSlotIDs": [
+                                            {}
+                                        ],
+                                        "prettyClassName": "NetworkHealthComponentTypeId"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96136939629667
                                 },
                                 "Name": "SC-Node(Restart)",
                                 "Components": {
@@ -1425,7 +1500,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2361841028984
+                                    "id": 96158414466147
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -1666,7 +1741,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2379020898168
+                                    "id": 96184184269923
                                 },
                                 "Name": "SC-Node(TimeDelayNodeableNode)",
                                 "Components": {
@@ -1803,7 +1878,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2404790701944
+                                    "id": 96051040283747
                                 },
                                 "Name": "SC-Node(SetAttributeAsFloat)",
                                 "Components": {
@@ -1966,7 +2041,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2275941683064
+                                    "id": 96068220152931
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -2037,7 +2112,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2293121552248
+                                    "id": 96089694989411
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -2139,7 +2214,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2314596388728
+                                    "id": 96111169825891
                                 },
                                 "Name": "SC-Node(HeartBeatNodeableNode)",
                                 "Components": {
@@ -2325,7 +2400,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2336071225208
+                                    "id": 96132644662371
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -2396,7 +2471,220 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2357546061688
+                                    "id": 96154119498851
+                                },
+                                "Name": "SC-Node(GatherEntitiesByComponentSphereNode)",
+                                "Components": {
+                                    "Component_[3527830048028782077]": {
+                                        "$type": "GatherEntitiesByComponentSphereNode",
+                                        "Id": 3527830048028782077,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{CF2A0398-329B-4A73-8A55-E2A779792D19}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "toolTip": "Parameters controlling the entity gather",
+                                                "DisplayGroup": {
+                                                    "Value": 1609338446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{7844882A-9533-4DD9-8B4C-D603A2BE64D0}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "ComponentId",
+                                                "toolTip": "The typeId of the components to look for.",
+                                                "DisplayGroup": {
+                                                    "Value": 1609338446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{A57C112E-AA49-43F6-BD93-ECD4EA4CF602}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Position",
+                                                "toolTip": "The position of the sphere used to gather.",
+                                                "DisplayGroup": {
+                                                    "Value": 1609338446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{CA21A757-F63C-4A18-ADC6-735DC9A77594}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Radius",
+                                                "toolTip": "The radius of the sphere used to gather.",
+                                                "DisplayGroup": {
+                                                    "Value": 1609338446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{9354E84E-57AD-4964-AF99-CE86A259602E}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "On In",
+                                                "toolTip": "Parameters controlling the entity gather",
+                                                "DisplayGroup": {
+                                                    "Value": 1609338446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{7E2ABB2A-EC1E-4F92-8EBA-F6F85DBBD610}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Entities",
+                                                "DisplayDataType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
+                                                },
+                                                "DisplayGroup": {
+                                                    "Value": 1609338446
+                                                },
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 4,
+                                                    "m_azType": "{E152C105-A133-4D03-BBF8-3D4B2FBA3E2A}"
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "AZ::Uuid",
+                                                "value": "{00000000-0000-0000-0000-000000000000}",
+                                                "label": "ComponentId"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 8
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "Vector3",
+                                                "value": [
+                                                    0.0,
+                                                    0.0,
+                                                    0.0
+                                                ],
+                                                "label": "Position"
+                                            },
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 3
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "double",
+                                                "value": 0.0,
+                                                "label": "Radius"
+                                            }
+                                        ],
+                                        "slotExecutionMap": {
+                                            "ins": [
+                                                {
+                                                    "_slotId": {
+                                                        "m_id": "{CF2A0398-329B-4A73-8A55-E2A779792D19}"
+                                                    },
+                                                    "_inputs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{7844882A-9533-4DD9-8B4C-D603A2BE64D0}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{A57C112E-AA49-43F6-BD93-ECD4EA4CF602}"
+                                                            }
+                                                        },
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{CA21A757-F63C-4A18-ADC6-735DC9A77594}"
+                                                            }
+                                                        }
+                                                    ],
+                                                    "_outs": [
+                                                        {
+                                                            "_slotId": {
+                                                                "m_id": "{9354E84E-57AD-4964-AF99-CE86A259602E}"
+                                                            },
+                                                            "_name": "On In",
+                                                            "_outputs": [
+                                                                {
+                                                                    "_slotId": {
+                                                                        "m_id": "{7E2ABB2A-EC1E-4F92-8EBA-F6F85DBBD610}"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96179889302627
                                 },
                                 "Name": "SC-Node(GetWorldTranslation)",
                                 "Components": {
@@ -2501,7 +2789,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2374725930872
+                                    "id": 96046745316451
                                 },
                                 "Name": "SC-Node(Get total roundtime in seconds)",
                                 "Components": {
@@ -2571,222 +2859,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2400495734648
-                                },
-                                "Name": "SC-Node(ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup)",
-                                "Components": {
-                                    "Component_[4754017161586349756]": {
-                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
-                                        "Id": 4754017161586349756,
-                                        "Slots": [
-                                            {
-                                                "id": {
-                                                    "m_id": "{20A42FD8-44ED-4D2A-9D49-CB05565C9EBD}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Position",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{4E5A2E13-08FB-49B7-A613-C7C37EBA9375}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Radius",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{C586A756-C53E-4FCB-94BA-DBBCE9DC0198}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Collision Group",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{707945FB-7AA0-4951-B992-583625AF27E7}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Ignore",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{02F2AB43-BA99-4EBC-955D-6465BEB53413}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "In",
-                                                "Descriptor": {
-                                                    "ConnectionType": 1,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{880A5936-A0F2-45D2-BB22-60A0B3BE7E40}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Out",
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 1
-                                                }
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{6641C4E0-2AE3-4975-B50B-37E762FD38CD}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Boolean: 0",
-                                                "DisplayDataType": {
-                                                    "m_type": 0
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            },
-                                            {
-                                                "id": {
-                                                    "m_id": "{62916108-6155-4CE9-81E6-80B58B489F69}"
-                                                },
-                                                "contracts": [
-                                                    {
-                                                        "$type": "SlotTypeContract"
-                                                    }
-                                                ],
-                                                "slotName": "Array<EntityId>: 1",
-                                                "DisplayDataType": {
-                                                    "m_type": 4,
-                                                    "m_azType": "{4841CFF0-7A5C-519C-BD16-D3625E99605E}"
-                                                },
-                                                "Descriptor": {
-                                                    "ConnectionType": 2,
-                                                    "SlotType": 2
-                                                },
-                                                "DataType": 1
-                                            }
-                                        ],
-                                        "Datums": [
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 8
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "Vector3",
-                                                "value": [
-                                                    0.0,
-                                                    0.0,
-                                                    0.0
-                                                ],
-                                                "label": "Position"
-                                            },
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 3
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "double",
-                                                "value": 1.0,
-                                                "label": "Radius"
-                                            },
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 5
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
-                                                "value": "Players",
-                                                "label": "Collision Group"
-                                            },
-                                            {
-                                                "isOverloadedStorage": false,
-                                                "scriptCanvasType": {
-                                                    "m_type": 1
-                                                },
-                                                "isNullPointer": false,
-                                                "$type": "EntityId",
-                                                "value": {
-                                                    "id": 2901262558
-                                                },
-                                                "label": "Ignore"
-                                            }
-                                        ],
-                                        "methodType": 1,
-                                        "methodName": "ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup",
-                                        "resultSlotIDs": [
-                                            {}
-                                        ],
-                                        "inputSlots": [
-                                            {
-                                                "m_id": "{20A42FD8-44ED-4D2A-9D49-CB05565C9EBD}"
-                                            },
-                                            {
-                                                "m_id": "{4E5A2E13-08FB-49B7-A613-C7C37EBA9375}"
-                                            },
-                                            {
-                                                "m_id": "{C586A756-C53E-4FCB-94BA-DBBCE9DC0198}"
-                                            },
-                                            {
-                                                "m_id": "{707945FB-7AA0-4951-B992-583625AF27E7}"
-                                            }
-                                        ],
-                                        "prettyClassName": "ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup"
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 2271646715768
+                                    "id": 96063925185635
                                 },
                                 "Name": "SC-Node(GetRenderSceneIdByName)",
                                 "Components": {
@@ -2889,7 +2962,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2288826584952
+                                    "id": 96081105054819
                                 },
                                 "Name": "SC-Node(OperatorMul)",
                                 "Components": {
@@ -3135,7 +3208,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2306006454136
+                                    "id": 96102579891299
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -3237,7 +3310,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2348956127096
+                                    "id": 96124054727779
                                 },
                                 "Name": "SC-Node(GetWorldTM)",
                                 "Components": {
@@ -3342,7 +3415,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2366135996280
+                                    "id": 96145529564259
                                 },
                                 "Name": "SC-Node(Greater)",
                                 "Components": {
@@ -3491,7 +3564,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2391905800056
+                                    "id": 96171299368035
                                 },
                                 "Name": "SC-Node(OperatorMul)",
                                 "Components": {
@@ -3737,7 +3810,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2387610832760
+                                    "id": 96167004400739
                                 },
                                 "Name": "SC-Node(IfAgentTypeNodeableNode)",
                                 "Components": {
@@ -3881,7 +3954,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2413380636536
+                                    "id": 96192774204515
                                 },
                                 "Name": "SC-Node(IfAgentTypeNodeableNode)",
                                 "Components": {
@@ -4025,7 +4098,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2284531617656
+                                    "id": 96059630218339
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -4096,7 +4169,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2301711486840
+                                    "id": 96076810087523
                                 },
                                 "Name": "SC-Node(GetAttributeId)",
                                 "Components": {
@@ -4230,7 +4303,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2323186323320
+                                    "id": 96098284924003
                                 },
                                 "Name": "SC Node(SetVariable)",
                                 "Components": {
@@ -4332,7 +4405,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 32722964844408
+                                    "id": 96119759760483
                                 },
                                 "Name": "SC Node(GetVariable)",
                                 "Components": {
@@ -4658,7 +4731,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2344661159800
+                                    "id": 96141234596963
                                 },
                                 "Name": "SC-Node(Mod)",
                                 "Components": {
@@ -4792,7 +4865,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 2417675603832
+                                    "id": 96197069171811
                                 },
                                 "Name": "srcEndpoint=(GetAttributeId: Number), destEndpoint=(SetAttributeAsFloat: Number: 1)",
                                 "Components": {
@@ -4801,7 +4874,7 @@
                                         "Id": 3631372586840153144,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2301711486840
+                                                "id": 96076810087523
                                             },
                                             "slotId": {
                                                 "m_id": "{5FCBD72E-6B1A-49B5-87AF-00C487F9F42D}"
@@ -4809,7 +4882,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2404790701944
+                                                "id": 96051040283747
                                             },
                                             "slotId": {
                                                 "m_id": "{98DCD577-13AC-4087-9DE7-6F3F3952205A}"
@@ -4820,7 +4893,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2421970571128
+                                    "id": 96201364139107
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Mod: In)",
                                 "Components": {
@@ -4829,7 +4902,7 @@
                                         "Id": 13122921624327002742,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2391905800056
+                                                "id": 96171299368035
                                             },
                                             "slotId": {
                                                 "m_id": "{763D230C-56F0-4819-9369-0D776176DAFB}"
@@ -4837,7 +4910,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{51E478E5-4202-45A0-A8E1-12332D6846F4}"
@@ -4848,7 +4921,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2426265538424
+                                    "id": 96205659106403
                                 },
                                 "Name": "srcEndpoint=(Get roundtime remaining in seconds: Number), destEndpoint=(Divide (/): Number 0)",
                                 "Components": {
@@ -4857,7 +4930,7 @@
                                         "Id": 17984612025253119145,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2353251094392
+                                                "id": 96128349695075
                                             },
                                             "slotId": {
                                                 "m_id": "{15A44D1E-C210-4946-90B2-0E470EBE9B21}"
@@ -4865,7 +4938,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2383315865464
+                                                "id": 96162709433443
                                             },
                                             "slotId": {
                                                 "m_id": "{39EED2EE-2287-4727-8E42-C31022194D77}"
@@ -4876,7 +4949,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2430560505720
+                                    "id": 96209954073699
                                 },
                                 "Name": "srcEndpoint=(Get roundtime remaining in seconds: Out), destEndpoint=(Get total roundtime in seconds: In)",
                                 "Components": {
@@ -4885,7 +4958,7 @@
                                         "Id": 2392199445285643560,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2353251094392
+                                                "id": 96128349695075
                                             },
                                             "slotId": {
                                                 "m_id": "{2B2A0094-F04A-4B38-9BA6-3611CFA82722}"
@@ -4893,7 +4966,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2374725930872
+                                                "id": 96046745316451
                                             },
                                             "slotId": {
                                                 "m_id": "{A6A33357-D4BA-45DA-9721-95FF88CF07D4}"
@@ -4904,7 +4977,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2434855473016
+                                    "id": 96214249040995
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Mod: Number: 0)",
                                 "Components": {
@@ -4913,7 +4986,7 @@
                                         "Id": 8346261065667341900,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2391905800056
+                                                "id": 96171299368035
                                             },
                                             "slotId": {
                                                 "m_id": "{C71F6DC6-4CD8-4DAC-8750-614BC8FCAB2C}"
@@ -4921,7 +4994,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{37E08DEE-7B7D-4BED-B608-051C02A65BCC}"
@@ -4932,7 +5005,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2439150440312
+                                    "id": 96218544008291
                                 },
                                 "Name": "srcEndpoint=(Get total roundtime in seconds: Out), destEndpoint=(Divide (/): In)",
                                 "Components": {
@@ -4941,7 +5014,7 @@
                                         "Id": 13749902543685681044,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2374725930872
+                                                "id": 96046745316451
                                             },
                                             "slotId": {
                                                 "m_id": "{B8F40490-FF66-41EA-B2B1-7D5C7B18AE91}"
@@ -4949,7 +5022,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2383315865464
+                                                "id": 96162709433443
                                             },
                                             "slotId": {
                                                 "m_id": "{54ED2D32-B0BE-4CF3-A80C-6576AB6B0752}"
@@ -4960,7 +5033,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2443445407608
+                                    "id": 96222838975587
                                 },
                                 "Name": "srcEndpoint=(Get total roundtime in seconds: Number), destEndpoint=(Divide (/): Number 1)",
                                 "Components": {
@@ -4969,7 +5042,7 @@
                                         "Id": 16465896439637144109,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2374725930872
+                                                "id": 96046745316451
                                             },
                                             "slotId": {
                                                 "m_id": "{140F876E-6F1B-494D-82FB-4710230F2DB7}"
@@ -4977,7 +5050,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2383315865464
+                                                "id": 96162709433443
                                             },
                                             "slotId": {
                                                 "m_id": "{8CA38FEF-56BA-4CA3-AA18-E523E0324A45}"
@@ -4988,7 +5061,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2447740374904
+                                    "id": 96227133942883
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If Client Type), destEndpoint=(GetAttributeId: In)",
                                 "Components": {
@@ -4997,7 +5070,7 @@
                                         "Id": 9403500395311412001,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2387610832760
+                                                "id": 96167004400739
                                             },
                                             "slotId": {
                                                 "m_id": "{CE734BE6-DF29-4758-86A6-247D9AF48AA4}"
@@ -5005,7 +5078,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2301711486840
+                                                "id": 96076810087523
                                             },
                                             "slotId": {
                                                 "m_id": "{B0B6E460-76DB-444B-BAD0-DB610F9C1E8A}"
@@ -5016,7 +5089,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2452035342200
+                                    "id": 96231428910179
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If ClientServer Type), destEndpoint=(GetAttributeId: In)",
                                 "Components": {
@@ -5025,7 +5098,7 @@
                                         "Id": 15531383872528267976,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2387610832760
+                                                "id": 96167004400739
                                             },
                                             "slotId": {
                                                 "m_id": "{E0D24ABA-56FB-488A-8C3D-A6DFC4DD5814}"
@@ -5033,7 +5106,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2301711486840
+                                                "id": 96076810087523
                                             },
                                             "slotId": {
                                                 "m_id": "{B0B6E460-76DB-444B-BAD0-DB610F9C1E8A}"
@@ -5044,7 +5117,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2456330309496
+                                    "id": 96235723877475
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If Singleplayer), destEndpoint=(GetAttributeId: In)",
                                 "Components": {
@@ -5053,7 +5126,7 @@
                                         "Id": 15734152885570727292,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2387610832760
+                                                "id": 96167004400739
                                             },
                                             "slotId": {
                                                 "m_id": "{12FD09E5-FE0A-4136-A7DE-3689AD521315}"
@@ -5061,7 +5134,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2301711486840
+                                                "id": 96076810087523
                                             },
                                             "slotId": {
                                                 "m_id": "{B0B6E460-76DB-444B-BAD0-DB610F9C1E8A}"
@@ -5072,7 +5145,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2460625276792
+                                    "id": 96240018844771
                                 },
                                 "Name": "srcEndpoint=(Mod: Number), destEndpoint=(Greater Than (>): Value A)",
                                 "Components": {
@@ -5081,7 +5154,7 @@
                                         "Id": 17994989574094265112,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{4A7A16CC-E307-464A-AD51-15B63F1A9BFC}"
@@ -5089,7 +5162,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2366135996280
+                                                "id": 96145529564259
                                             },
                                             "slotId": {
                                                 "m_id": "{5B61C8F1-438E-4182-8395-007E83943B58}"
@@ -5100,7 +5173,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2464920244088
+                                    "id": 96244313812067
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Greater Than (>): Value B)",
                                 "Components": {
@@ -5109,7 +5182,7 @@
                                         "Id": 6974616544631859745,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2396200767352
+                                                "id": 96175594335331
                                             },
                                             "slotId": {
                                                 "m_id": "{6B946166-57A0-47C1-91E2-FB4477FCD43C}"
@@ -5117,7 +5190,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2366135996280
+                                                "id": 96145529564259
                                             },
                                             "slotId": {
                                                 "m_id": "{2A9072F2-DD89-4C97-B586-2CF2641A65FD}"
@@ -5128,7 +5201,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2469215211384
+                                    "id": 96248608779363
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Greater Than (>): In)",
                                 "Components": {
@@ -5137,7 +5210,7 @@
                                         "Id": 4060417504593206010,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2396200767352
+                                                "id": 96175594335331
                                             },
                                             "slotId": {
                                                 "m_id": "{DBDCD0C7-9D67-49B0-9DC9-F22FE798C993}"
@@ -5145,7 +5218,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2366135996280
+                                                "id": 96145529564259
                                             },
                                             "slotId": {
                                                 "m_id": "{94B5DB37-C798-44F1-8E73-684D0291FD98}"
@@ -5156,7 +5229,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2473510178680
+                                    "id": 96252903746659
                                 },
                                 "Name": "srcEndpoint=(Mod: Out), destEndpoint=(IfMultiplayerAgentType: In)",
                                 "Components": {
@@ -5165,7 +5238,7 @@
                                         "Id": 12132631203436103119,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{EA499506-B635-4EB8-944C-CBA6502A954E}"
@@ -5173,7 +5246,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2387610832760
+                                                "id": 96167004400739
                                             },
                                             "slotId": {
                                                 "m_id": "{97DFED3B-4B82-4E89-9980-10687A1EC4F9}"
@@ -5184,7 +5257,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2477805145976
+                                    "id": 96257198713955
                                 },
                                 "Name": "srcEndpoint=(GetAttributeId: Out), destEndpoint=(SetAttributeAsFloat: In)",
                                 "Components": {
@@ -5193,7 +5266,7 @@
                                         "Id": 1657392596108110994,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2301711486840
+                                                "id": 96076810087523
                                             },
                                             "slotId": {
                                                 "m_id": "{BE61B7F2-B504-45AC-BEC9-F9AE0222C70D}"
@@ -5201,7 +5274,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2404790701944
+                                                "id": 96051040283747
                                             },
                                             "slotId": {
                                                 "m_id": "{B1D95B86-BBBF-486B-B054-A1A1641A335B}"
@@ -5212,7 +5285,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2482100113272
+                                    "id": 96261493681251
                                 },
                                 "Name": "srcEndpoint=(Mod: Number), destEndpoint=(SetAttributeAsFloat: Number: 2)",
                                 "Components": {
@@ -5221,7 +5294,7 @@
                                         "Id": 16706459051664039655,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{4A7A16CC-E307-464A-AD51-15B63F1A9BFC}"
@@ -5229,7 +5302,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2404790701944
+                                                "id": 96051040283747
                                             },
                                             "slotId": {
                                                 "m_id": "{05A4C7BD-503F-4012-AB67-EF40A30E245B}"
@@ -5240,7 +5313,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2486395080568
+                                    "id": 96265788648547
                                 },
                                 "Name": "srcEndpoint=(HeartBeat: Pulse), destEndpoint=(Get roundtime remaining in seconds: In)",
                                 "Components": {
@@ -5249,7 +5322,7 @@
                                         "Id": 8114551859676001282,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2314596388728
+                                                "id": 96111169825891
                                             },
                                             "slotId": {
                                                 "m_id": "{6BFC526A-79DC-48FF-9B8D-11F44D5F35C9}"
@@ -5257,7 +5330,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2353251094392
+                                                "id": 96128349695075
                                             },
                                             "slotId": {
                                                 "m_id": "{CCE1D877-B290-45B3-930C-194FE9A15C75}"
@@ -5268,7 +5341,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2490690047864
+                                    "id": 96270083615843
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -5277,7 +5350,7 @@
                                         "Id": 14049964353010989624,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2361841028984
+                                                "id": 96158414466147
                                             },
                                             "slotId": {
                                                 "m_id": "{EFFB2732-B237-4A6C-91F1-0996EF54E53B}"
@@ -5285,7 +5358,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2306006454136
+                                                "id": 96102579891299
                                             },
                                             "slotId": {
                                                 "m_id": "{FACB7C4C-4B2A-4595-AA51-5C034E1BC755}"
@@ -5296,7 +5369,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2494985015160
+                                    "id": 96274378583139
                                 },
                                 "Name": "srcEndpoint=(Greater Than (>): False), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -5305,7 +5378,7 @@
                                         "Id": 10270014576399529346,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2366135996280
+                                                "id": 96145529564259
                                             },
                                             "slotId": {
                                                 "m_id": "{6211CA16-F2DB-4D53-B867-4C7772D0DE49}"
@@ -5313,7 +5386,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2293121552248
+                                                "id": 96089694989411
                                             },
                                             "slotId": {
                                                 "m_id": "{D51F9D1E-3158-41AA-8D7C-0DF1BC60A5A9}"
@@ -5324,7 +5397,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2499279982456
+                                    "id": 96278673550435
                                 },
                                 "Name": "srcEndpoint=(Mod: Number), destEndpoint=(Set Variable: Number)",
                                 "Components": {
@@ -5333,7 +5406,7 @@
                                         "Id": 13657299905818264725,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{4A7A16CC-E307-464A-AD51-15B63F1A9BFC}"
@@ -5341,7 +5414,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2293121552248
+                                                "id": 96089694989411
                                             },
                                             "slotId": {
                                                 "m_id": "{8DD9C86F-13F4-4170-BEF6-C72E4FF2428A}"
@@ -5352,7 +5425,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2503574949752
+                                    "id": 96282968517731
                                 },
                                 "Name": "srcEndpoint=(Mod: Out), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -5361,7 +5434,7 @@
                                         "Id": 8995572168315794171,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2344661159800
+                                                "id": 96141234596963
                                             },
                                             "slotId": {
                                                 "m_id": "{EA499506-B635-4EB8-944C-CBA6502A954E}"
@@ -5369,7 +5442,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2396200767352
+                                                "id": 96175594335331
                                             },
                                             "slotId": {
                                                 "m_id": "{5A1FECD5-E6CD-4410-8AAE-D5F1AC44EC11}"
@@ -5380,7 +5453,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2507869917048
+                                    "id": 96287263485027
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
@@ -5389,7 +5462,7 @@
                                         "Id": 1038098693301472620,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2275941683064
+                                                "id": 96068220152931
                                             },
                                             "slotId": {
                                                 "m_id": "{A5F43AB3-D627-4031-BBE5-9BAC3ACD5F96}"
@@ -5397,7 +5470,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2288826584952
+                                                "id": 96081105054819
                                             },
                                             "slotId": {
                                                 "m_id": "{022910D4-2C8C-4275-A984-75BEF5C224BC}"
@@ -5408,7 +5481,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2512164884344
+                                    "id": 96291558452323
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Multiply (*): Value 0)",
                                 "Components": {
@@ -5417,7 +5490,7 @@
                                         "Id": 9040682423048663410,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2275941683064
+                                                "id": 96068220152931
                                             },
                                             "slotId": {
                                                 "m_id": "{73D730C0-AACC-4A53-BDB0-FF3BEF90C783}"
@@ -5425,7 +5498,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2288826584952
+                                                "id": 96081105054819
                                             },
                                             "slotId": {
                                                 "m_id": "{F8D4704F-06DF-4181-AAF7-75CDDFECCF8B}"
@@ -5436,7 +5509,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2516459851640
+                                    "id": 96295853419619
                                 },
                                 "Name": "srcEndpoint=(Divide (/): Out), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -5445,7 +5518,7 @@
                                         "Id": 1432987453636084962,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2383315865464
+                                                "id": 96162709433443
                                             },
                                             "slotId": {
                                                 "m_id": "{BD8B529F-C462-4C21-9C81-0EC595D028CA}"
@@ -5453,7 +5526,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2275941683064
+                                                "id": 96068220152931
                                             },
                                             "slotId": {
                                                 "m_id": "{658E31AF-93CA-43BC-B889-5AC0E0CAAA18}"
@@ -5464,7 +5537,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2520754818936
+                                    "id": 96300148386915
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Out), destEndpoint=(Multiply (*): In)",
                                 "Components": {
@@ -5473,7 +5546,7 @@
                                         "Id": 16039352293474383075,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2288826584952
+                                                "id": 96081105054819
                                             },
                                             "slotId": {
                                                 "m_id": "{062B068C-86AC-4764-925F-43278FB77432}"
@@ -5481,7 +5554,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2391905800056
+                                                "id": 96171299368035
                                             },
                                             "slotId": {
                                                 "m_id": "{F58D6529-7AFE-418F-AEFE-914CACBAD143}"
@@ -5492,7 +5565,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2525049786232
+                                    "id": 96304443354211
                                 },
                                 "Name": "srcEndpoint=(Multiply (*): Result), destEndpoint=(Multiply (*): Number 0)",
                                 "Components": {
@@ -5501,7 +5574,7 @@
                                         "Id": 3928381498303186272,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2288826584952
+                                                "id": 96081105054819
                                             },
                                             "slotId": {
                                                 "m_id": "{ED9F794D-8902-460F-84C3-05089CD9E19F}"
@@ -5509,7 +5582,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2391905800056
+                                                "id": 96171299368035
                                             },
                                             "slotId": {
                                                 "m_id": "{C5A8AFC3-C7C2-4DC0-BD52-C596854DDCC2}"
@@ -5520,7 +5593,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2529344753528
+                                    "id": 96308738321507
                                 },
                                 "Name": "srcEndpoint=(Divide (/): Result), destEndpoint=(Multiply (*): Number 1)",
                                 "Components": {
@@ -5529,7 +5602,7 @@
                                         "Id": 5301294462838338463,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2383315865464
+                                                "id": 96162709433443
                                             },
                                             "slotId": {
                                                 "m_id": "{B2ADB827-4DE6-428F-8F82-605E3F115C4A}"
@@ -5537,7 +5610,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2391905800056
+                                                "id": 96171299368035
                                             },
                                             "slotId": {
                                                 "m_id": "{2CD56A76-1C54-49A5-8BA0-631E66C0AD84}"
@@ -5548,7 +5621,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2533639720824
+                                    "id": 96313033288803
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(HeartBeat: Start)",
                                 "Components": {
@@ -5557,7 +5630,7 @@
                                         "Id": 15572122649512184085,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2361841028984
+                                                "id": 96158414466147
                                             },
                                             "slotId": {
                                                 "m_id": "{EFFB2732-B237-4A6C-91F1-0996EF54E53B}"
@@ -5565,7 +5638,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2314596388728
+                                                "id": 96111169825891
                                             },
                                             "slotId": {
                                                 "m_id": "{1C12B576-DD9C-4353-B193-FA815C0A38F5}"
@@ -5576,7 +5649,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2537934688120
+                                    "id": 96317328256099
                                 },
                                 "Name": "srcEndpoint=(Set Variable: Out), destEndpoint=(IfMultiplayerAgentType: In)",
                                 "Components": {
@@ -5585,7 +5658,7 @@
                                         "Id": 8730329322265170037,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2323186323320
+                                                "id": 96098284924003
                                             },
                                             "slotId": {
                                                 "m_id": "{834D4B39-E806-41F0-97EC-C087AAA1E063}"
@@ -5593,7 +5666,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2413380636536
+                                                "id": 96192774204515
                                             },
                                             "slotId": {
                                                 "m_id": "{97DFED3B-4B82-4E89-9980-10687A1EC4F9}"
@@ -5604,7 +5677,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2542229655416
+                                    "id": 96321623223395
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If Client Type), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -5613,7 +5686,7 @@
                                         "Id": 16847085520853092328,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2413380636536
+                                                "id": 96192774204515
                                             },
                                             "slotId": {
                                                 "m_id": "{CE734BE6-DF29-4758-86A6-247D9AF48AA4}"
@@ -5621,7 +5694,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{FA317AFB-77E7-4859-98B1-BCF8C6E1C9A4}"
@@ -5632,7 +5705,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2546524622712
+                                    "id": 96325918190691
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If ClientServer Type), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -5641,7 +5714,7 @@
                                         "Id": 8278654645524208407,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2413380636536
+                                                "id": 96192774204515
                                             },
                                             "slotId": {
                                                 "m_id": "{E0D24ABA-56FB-488A-8C3D-A6DFC4DD5814}"
@@ -5649,7 +5722,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{FA317AFB-77E7-4859-98B1-BCF8C6E1C9A4}"
@@ -5660,7 +5733,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2550819590008
+                                    "id": 96330213157987
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If Singleplayer), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -5669,7 +5742,7 @@
                                         "Id": 4603947763760275163,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2413380636536
+                                                "id": 96192774204515
                                             },
                                             "slotId": {
                                                 "m_id": "{12FD09E5-FE0A-4136-A7DE-3689AD521315}"
@@ -5677,7 +5750,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{FA317AFB-77E7-4859-98B1-BCF8C6E1C9A4}"
@@ -5688,7 +5761,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2555114557304
+                                    "id": 96334508125283
                                 },
                                 "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(Play: EntityId)",
                                 "Components": {
@@ -5697,7 +5770,7 @@
                                         "Id": 7450176186117282384,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{C62D0C16-8D8B-45BC-A87A-4ED208744392}"
@@ -5705,7 +5778,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2331776257912
+                                                "id": 96106874858595
                                             },
                                             "slotId": {
                                                 "m_id": "{BE3E2DE1-2504-4899-8690-B863839A37E1}"
@@ -5716,7 +5789,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2559409524600
+                                    "id": 96338803092579
                                 },
                                 "Name": "srcEndpoint=(Get Variable: EntityId), destEndpoint=(Restart: EntityId: 0)",
                                 "Components": {
@@ -5725,7 +5798,7 @@
                                         "Id": 17896004437304999211,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{C62D0C16-8D8B-45BC-A87A-4ED208744392}"
@@ -5733,7 +5806,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2340366192504
+                                                "id": 96136939629667
                                             },
                                             "slotId": {
                                                 "m_id": "{95DC8491-CDF7-4619-8848-6980C16AA21C}"
@@ -5744,7 +5817,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2563704491896
+                                    "id": 96343098059875
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Restart: In)",
                                 "Components": {
@@ -5753,7 +5826,7 @@
                                         "Id": 8831191551904003745,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{5B9913DF-A026-428F-AFB1-5FDDF103DE61}"
@@ -5761,7 +5834,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2340366192504
+                                                "id": 96136939629667
                                             },
                                             "slotId": {
                                                 "m_id": "{12AD2A87-2315-4E60-9B2D-06DB244AC4E4}"
@@ -5772,7 +5845,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2567999459192
+                                    "id": 96347393027171
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Play: In)",
                                 "Components": {
@@ -5781,7 +5854,7 @@
                                         "Id": 1615283111984897269,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2284531617656
+                                                "id": 96059630218339
                                             },
                                             "slotId": {
                                                 "m_id": "{5B9913DF-A026-428F-AFB1-5FDDF103DE61}"
@@ -5789,7 +5862,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2331776257912
+                                                "id": 96106874858595
                                             },
                                             "slotId": {
                                                 "m_id": "{17AABFC3-9DB6-4688-AEF6-0A077B4DA52F}"
@@ -5800,63 +5873,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2572294426488
-                                },
-                                "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup: Array<EntityId>: 1), destEndpoint=(For Each: Source)",
-                                "Components": {
-                                    "Component_[18342562723858175608]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 18342562723858175608,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 2400495734648
-                                            },
-                                            "slotId": {
-                                                "m_id": "{62916108-6155-4CE9-81E6-80B58B489F69}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 2297416519544
-                                            },
-                                            "slotId": {
-                                                "m_id": "{0CDB3DDC-0074-4488-B713-2548D6D8C60A}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 2576589393784
-                                },
-                                "Name": "srcEndpoint=(ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup: Out), destEndpoint=(For Each: In)",
-                                "Components": {
-                                    "Component_[12888683122559848040]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 12888683122559848040,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 2400495734648
-                                            },
-                                            "slotId": {
-                                                "m_id": "{880A5936-A0F2-45D2-BB22-60A0B3BE7E40}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 2297416519544
-                                            },
-                                            "slotId": {
-                                                "m_id": "{EB9B11B1-39CA-4277-BF41-DFD255249B86}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 2580884361080
+                                    "id": 96351687994467
                                 },
                                 "Name": "srcEndpoint=(Greater Than (>): True), destEndpoint=(Set Variable: In)",
                                 "Components": {
@@ -5865,7 +5882,7 @@
                                         "Id": 6203674095643582910,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2366135996280
+                                                "id": 96145529564259
                                             },
                                             "slotId": {
                                                 "m_id": "{FBFBB859-D01E-425B-99F3-CCCB98A592BF}"
@@ -5873,7 +5890,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2323186323320
+                                                "id": 96098284924003
                                             },
                                             "slotId": {
                                                 "m_id": "{945DAAF3-30E9-4A53-A22F-5C93338CBA6E}"
@@ -5884,7 +5901,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2585179328376
+                                    "id": 96355982961763
                                 },
                                 "Name": "srcEndpoint=(GetWorldTranslation: Out), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -5893,7 +5910,7 @@
                                         "Id": 13978314399655551480,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2357546061688
+                                                "id": 96179889302627
                                             },
                                             "slotId": {
                                                 "m_id": "{3B12B534-F3A4-4345-8316-624F6BB70500}"
@@ -5901,7 +5918,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2280236650360
+                                                "id": 96055335251043
                                             },
                                             "slotId": {
                                                 "m_id": "{9694EBDC-E053-4D7C-A13C-DDDF60534604}"
@@ -5912,91 +5929,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2589474295672
-                                },
-                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup: In)",
-                                "Components": {
-                                    "Component_[11497188988845642486]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 11497188988845642486,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 2280236650360
-                                            },
-                                            "slotId": {
-                                                "m_id": "{BC191F77-AE00-4246-866E-65E2C34A52B7}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 2400495734648
-                                            },
-                                            "slotId": {
-                                                "m_id": "{02F2AB43-BA99-4EBC-955D-6465BEB53413}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 2593769262968
-                                },
-                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup: Radius)",
-                                "Components": {
-                                    "Component_[9748006656730557692]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 9748006656730557692,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 2280236650360
-                                            },
-                                            "slotId": {
-                                                "m_id": "{0FBC7B23-8910-4810-BB0B-322FDF13B678}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 2400495734648
-                                            },
-                                            "slotId": {
-                                                "m_id": "{4E5A2E13-08FB-49B7-A613-C7C37EBA9375}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 2598064230264
-                                },
-                                "Name": "srcEndpoint=(GetWorldTranslation: Vector3), destEndpoint=(ScriptCanvasPhysics_WorldFunctions_OverlapSphereWithGroup: Position)",
-                                "Components": {
-                                    "Component_[14807493889719125333]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 14807493889719125333,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 2357546061688
-                                            },
-                                            "slotId": {
-                                                "m_id": "{E886274D-9298-449E-A73E-65C41A331710}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 2400495734648
-                                            },
-                                            "slotId": {
-                                                "m_id": "{20A42FD8-44ED-4D2A-9D49-CB05565C9EBD}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 2602359197560
+                                    "id": 96360277929059
                                 },
                                 "Name": "srcEndpoint=(For Each: Each), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -6005,7 +5938,7 @@
                                         "Id": 8082582445022641301,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2297416519544
+                                                "id": 96093989956707
                                             },
                                             "slotId": {
                                                 "m_id": "{2AE5D9C0-EF80-425B-B638-CA841696C639}"
@@ -6013,7 +5946,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2336071225208
+                                                "id": 96132644662371
                                             },
                                             "slotId": {
                                                 "m_id": "{20437EF1-B4EE-4E67-8CAA-2C40893C108F}"
@@ -6024,7 +5957,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2606654164856
+                                    "id": 96364572896355
                                 },
                                 "Name": "srcEndpoint=(For Each: EntityId), destEndpoint=(SendHealthDelta: Source)",
                                 "Components": {
@@ -6033,7 +5966,7 @@
                                         "Id": 13623409625600681696,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2297416519544
+                                                "id": 96093989956707
                                             },
                                             "slotId": {
                                                 "m_id": "{F7CA733F-2FEC-42F2-A297-B6FE88B3F97C}"
@@ -6041,7 +5974,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2310301421432
+                                                "id": 96085400022115
                                             },
                                             "slotId": {
                                                 "m_id": "{826634BA-EA61-4303-905A-B339161B3290}"
@@ -6052,7 +5985,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2610949132152
+                                    "id": 96368867863651
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(Subtract (-): In)",
                                 "Components": {
@@ -6061,7 +5994,7 @@
                                         "Id": 7175779264265223149,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2336071225208
+                                                "id": 96132644662371
                                             },
                                             "slotId": {
                                                 "m_id": "{3F484021-A395-462B-8993-494BFCB709D8}"
@@ -6069,7 +6002,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2370430963576
+                                                "id": 96149824531555
                                             },
                                             "slotId": {
                                                 "m_id": "{3B2A67B1-E829-4718-BAA5-D967D05024DC}"
@@ -6080,7 +6013,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2615244099448
+                                    "id": 96373162830947
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(Subtract (-): Value 1)",
                                 "Components": {
@@ -6089,7 +6022,7 @@
                                         "Id": 13291983034613772476,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2336071225208
+                                                "id": 96132644662371
                                             },
                                             "slotId": {
                                                 "m_id": "{CE38269C-DCBC-4B69-82BB-ED46265C189F}"
@@ -6097,7 +6030,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2370430963576
+                                                "id": 96149824531555
                                             },
                                             "slotId": {
                                                 "m_id": "{C26DE57E-38D1-4C23-AE50-A4C4D96386E9}"
@@ -6108,7 +6041,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2619539066744
+                                    "id": 96377457798243
                                 },
                                 "Name": "srcEndpoint=(Subtract (-): Out), destEndpoint=(SendHealthDelta: In)",
                                 "Components": {
@@ -6117,7 +6050,7 @@
                                         "Id": 2936415080084597037,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2370430963576
+                                                "id": 96149824531555
                                             },
                                             "slotId": {
                                                 "m_id": "{9B011A4A-683C-4FB4-9275-2D99F3856EB4}"
@@ -6125,7 +6058,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2310301421432
+                                                "id": 96085400022115
                                             },
                                             "slotId": {
                                                 "m_id": "{2A66DB40-3148-4EF5-A964-A9A96E1CD7CC}"
@@ -6136,7 +6069,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2623834034040
+                                    "id": 96381752765539
                                 },
                                 "Name": "srcEndpoint=(Subtract (-): Result), destEndpoint=(SendHealthDelta: deltaHealth)",
                                 "Components": {
@@ -6145,7 +6078,7 @@
                                         "Id": 7510508210446274316,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2370430963576
+                                                "id": 96149824531555
                                             },
                                             "slotId": {
                                                 "m_id": "{BFC7CDF9-3492-4F91-BB15-BD2F322ECAA6}"
@@ -6153,7 +6086,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2310301421432
+                                                "id": 96085400022115
                                             },
                                             "slotId": {
                                                 "m_id": "{58F991AE-DB95-4113-8450-837E0334156A}"
@@ -6164,7 +6097,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2628129001336
+                                    "id": 96386047732835
                                 },
                                 "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(GetWorldTranslation: In)",
                                 "Components": {
@@ -6173,7 +6106,7 @@
                                         "Id": 7122466128899486485,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2379020898168
+                                                "id": 96184184269923
                                             },
                                             "slotId": {
                                                 "m_id": "{DFD59E82-3AD7-4237-910F-7B5B95B7B8DB}"
@@ -6181,7 +6114,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2357546061688
+                                                "id": 96179889302627
                                             },
                                             "slotId": {
                                                 "m_id": "{52524396-575E-40FC-92F4-42997E414A6A}"
@@ -6192,7 +6125,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2632423968632
+                                    "id": 96390342700131
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If DedicatedServer Type), destEndpoint=(TimeDelay: Start)",
                                 "Components": {
@@ -6201,7 +6134,7 @@
                                         "Id": 13178362915439625379,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2413380636536
+                                                "id": 96192774204515
                                             },
                                             "slotId": {
                                                 "m_id": "{9F4065C8-AB6E-4A09-AC5C-DAD972C3555F}"
@@ -6209,7 +6142,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2379020898168
+                                                "id": 96184184269923
                                             },
                                             "slotId": {
                                                 "m_id": "{81F44DC0-E223-4510-8FCE-C906980B95EC}"
@@ -6220,7 +6153,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2636718935928
+                                    "id": 96394637667427
                                 },
                                 "Name": "srcEndpoint=(IfMultiplayerAgentType: If ClientServer Type), destEndpoint=(TimeDelay: Start)",
                                 "Components": {
@@ -6229,7 +6162,7 @@
                                         "Id": 6336201788782976372,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2413380636536
+                                                "id": 96192774204515
                                             },
                                             "slotId": {
                                                 "m_id": "{E0D24ABA-56FB-488A-8C3D-A6DFC4DD5814}"
@@ -6237,7 +6170,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2379020898168
+                                                "id": 96184184269923
                                             },
                                             "slotId": {
                                                 "m_id": "{81F44DC0-E223-4510-8FCE-C906980B95EC}"
@@ -6248,7 +6181,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2653898805112
+                                    "id": 96398932634723
                                 },
                                 "Name": "srcEndpoint=(Restart: Out), destEndpoint=(TimeDelay: Start)",
                                 "Components": {
@@ -6257,7 +6190,7 @@
                                         "Id": 17599072886696092429,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2340366192504
+                                                "id": 96136939629667
                                             },
                                             "slotId": {
                                                 "m_id": "{4ACC1BB3-4876-4961-839E-76D1A16ED9B1}"
@@ -6265,7 +6198,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2409085669240
+                                                "id": 96188479237219
                                             },
                                             "slotId": {
                                                 "m_id": "{55A8F169-29BB-44FA-A449-96A8CAB4C607}"
@@ -6276,7 +6209,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 2658193772408
+                                    "id": 96403227602019
                                 },
                                 "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(GetRenderSceneIdByName: In)",
                                 "Components": {
@@ -6285,7 +6218,7 @@
                                         "Id": 7083084457820755759,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2409085669240
+                                                "id": 96188479237219
                                             },
                                             "slotId": {
                                                 "m_id": "{F5937F73-42FA-4E16-BC35-C57F877C62D1}"
@@ -6293,7 +6226,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2271646715768
+                                                "id": 96063925185635
                                             },
                                             "slotId": {
                                                 "m_id": "{24906429-04AF-4674-AD8F-4C059AAFEC0E}"
@@ -6304,7 +6237,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 43567757266808
+                                    "id": 96407522569315
                                 },
                                 "Name": "srcEndpoint=(GetRenderSceneIdByName: Out), destEndpoint=(Get Variable: In)",
                                 "Components": {
@@ -6313,7 +6246,7 @@
                                         "Id": 11107871310257551858,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2271646715768
+                                                "id": 96063925185635
                                             },
                                             "slotId": {
                                                 "m_id": "{51A62B12-7E10-44D3-8329-E8EC1BA88994}"
@@ -6321,7 +6254,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 32722964844408
+                                                "id": 96119759760483
                                             },
                                             "slotId": {
                                                 "m_id": "{30263768-3CA6-4656-A061-9D68B54A53D7}"
@@ -6332,7 +6265,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 49305833574264
+                                    "id": 96411817536611
                                 },
                                 "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(GetWorldTM: In)",
                                 "Components": {
@@ -6341,7 +6274,7 @@
                                         "Id": 8343888937682323462,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 32722964844408
+                                                "id": 96119759760483
                                             },
                                             "slotId": {
                                                 "m_id": "{69A06D5E-6477-4CDB-A19F-98B832A49F44}"
@@ -6349,7 +6282,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 2348956127096
+                                                "id": 96124054727779
                                             },
                                             "slotId": {
                                                 "m_id": "{6EFE098C-E769-4915-A01E-9AF7162482C5}"
@@ -6360,7 +6293,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 64505722834808
+                                    "id": 96416112503907
                                 },
                                 "Name": "srcEndpoint=(GetWorldTM: Out), destEndpoint=(SpawnDecal: In)",
                                 "Components": {
@@ -6369,7 +6302,7 @@
                                         "Id": 16595642200122138992,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2348956127096
+                                                "id": 96124054727779
                                             },
                                             "slotId": {
                                                 "m_id": "{FB15926E-DFC5-48CF-900D-62CA02429CA5}"
@@ -6377,7 +6310,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 62753376178040
+                                                "id": 96072515120227
                                             },
                                             "slotId": {
                                                 "m_id": "{2BE5BE1F-344E-46C4-98E7-0EEDBCB52134}"
@@ -6388,7 +6321,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 65721198579576
+                                    "id": 96420407471203
                                 },
                                 "Name": "srcEndpoint=(GetWorldTM: Transform), destEndpoint=(SpawnDecal: Transform: 1)",
                                 "Components": {
@@ -6397,7 +6330,7 @@
                                         "Id": 17655568693828546326,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2348956127096
+                                                "id": 96124054727779
                                             },
                                             "slotId": {
                                                 "m_id": "{8D79AC78-B808-4E77-A8BE-571635627C25}"
@@ -6405,7 +6338,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 62753376178040
+                                                "id": 96072515120227
                                             },
                                             "slotId": {
                                                 "m_id": "{99DA4AF9-0E5C-4F89-86A4-EBDCF4DD2183}"
@@ -6416,7 +6349,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 67872977194872
+                                    "id": 96424702438499
                                 },
                                 "Name": "srcEndpoint=(Get Variable: SpawnDecalConfig), destEndpoint=(SpawnDecal: SpawnDecalConfig: 2)",
                                 "Components": {
@@ -6425,7 +6358,7 @@
                                         "Id": 16897753387592284878,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 32722964844408
+                                                "id": 96119759760483
                                             },
                                             "slotId": {
                                                 "m_id": "{42AD5967-38D6-4F71-83B1-01064D60B0E1}"
@@ -6433,7 +6366,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 62753376178040
+                                                "id": 96072515120227
                                             },
                                             "slotId": {
                                                 "m_id": "{1A9B2127-A517-471E-A9E5-265FBCA519A1}"
@@ -6444,7 +6377,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 71807167238008
+                                    "id": 96428997405795
                                 },
                                 "Name": "srcEndpoint=(GetRenderSceneIdByName: Uuid), destEndpoint=(SpawnDecal: Uuid: 0)",
                                 "Components": {
@@ -6453,7 +6386,7 @@
                                         "Id": 18200720317962106136,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 2271646715768
+                                                "id": 96063925185635
                                             },
                                             "slotId": {
                                                 "m_id": "{C93D559F-BC84-446A-AD0F-A29EC77DD894}"
@@ -6461,10 +6394,206 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 62753376178040
+                                                "id": 96072515120227
                                             },
                                             "slotId": {
                                                 "m_id": "{DB61774C-D56B-49C9-B35C-33E5A3F2A7A5}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96433292373091
+                                },
+                                "Name": "srcEndpoint=(NetworkHealthComponentTypeId::Getter: Out), destEndpoint=(GatherEntitiesbyComponentSphere: In)",
+                                "Components": {
+                                    "Component_[17158274068684049730]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 17158274068684049730,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96115464793187
+                                            },
+                                            "slotId": {
+                                                "m_id": "{D21B2B42-7EA6-46BC-91DD-C4A4657F9BE6}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96154119498851
+                                            },
+                                            "slotId": {
+                                                "m_id": "{CF2A0398-329B-4A73-8A55-E2A779792D19}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96437587340387
+                                },
+                                "Name": "srcEndpoint=(NetworkHealthComponentTypeId::Getter: Uuid), destEndpoint=(GatherEntitiesbyComponentSphere: ComponentId)",
+                                "Components": {
+                                    "Component_[8853221410604676761]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 8853221410604676761,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96115464793187
+                                            },
+                                            "slotId": {
+                                                "m_id": "{DB1DE106-13B4-40C1-8AC9-FDA1FB47C61E}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96154119498851
+                                            },
+                                            "slotId": {
+                                                "m_id": "{7844882A-9533-4DD9-8B4C-D603A2BE64D0}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96441882307683
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Out), destEndpoint=(NetworkHealthComponentTypeId::Getter: In)",
+                                "Components": {
+                                    "Component_[12158945016356031948]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 12158945016356031948,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96055335251043
+                                            },
+                                            "slotId": {
+                                                "m_id": "{BC191F77-AE00-4246-866E-65E2C34A52B7}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96115464793187
+                                            },
+                                            "slotId": {
+                                                "m_id": "{285C18A0-4CB7-444D-80AB-A7E66AAB5B07}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96446177274979
+                                },
+                                "Name": "srcEndpoint=(Get Variable: Number), destEndpoint=(GatherEntitiesbyComponentSphere: Radius)",
+                                "Components": {
+                                    "Component_[7997393725609151316]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 7997393725609151316,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96055335251043
+                                            },
+                                            "slotId": {
+                                                "m_id": "{0FBC7B23-8910-4810-BB0B-322FDF13B678}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96154119498851
+                                            },
+                                            "slotId": {
+                                                "m_id": "{CA21A757-F63C-4A18-ADC6-735DC9A77594}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96450472242275
+                                },
+                                "Name": "srcEndpoint=(GetWorldTranslation: Vector3), destEndpoint=(GatherEntitiesbyComponentSphere: Position)",
+                                "Components": {
+                                    "Component_[7909373484904155225]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 7909373484904155225,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96179889302627
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E886274D-9298-449E-A73E-65C41A331710}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96154119498851
+                                            },
+                                            "slotId": {
+                                                "m_id": "{A57C112E-AA49-43F6-BD93-ECD4EA4CF602}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96454767209571
+                                },
+                                "Name": "srcEndpoint=(GatherEntitiesbyComponentSphere: On In), destEndpoint=(For Each: In)",
+                                "Components": {
+                                    "Component_[7346047842312635108]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 7346047842312635108,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96154119498851
+                                            },
+                                            "slotId": {
+                                                "m_id": "{9354E84E-57AD-4964-AF99-CE86A259602E}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96093989956707
+                                            },
+                                            "slotId": {
+                                                "m_id": "{EB9B11B1-39CA-4277-BF41-DFD255249B86}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 96459062176867
+                                },
+                                "Name": "srcEndpoint=(GatherEntitiesbyComponentSphere: Entities), destEndpoint=(For Each: Source)",
+                                "Components": {
+                                    "Component_[10656391282603553921]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 10656391282603553921,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 96154119498851
+                                            },
+                                            "slotId": {
+                                                "m_id": "{7E2ABB2A-EC1E-4F92-8EBA-F6F85DBBD610}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 96093989956707
+                                            },
+                                            "slotId": {
+                                                "m_id": "{0CDB3DDC-0074-4488-B713-2548D6D8C60A}"
                                             }
                                         }
                                     }
@@ -6481,100 +6610,13 @@
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 2267351748472
+                                "id": 96042450349155
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "Constructs": [
-                                            {
-                                                "Type": 1,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Mod 4, so value goes from 4 to 0 a total of ExplodeTimes over the course of the match",
-                                                            "BackgroundColor": [
-                                                                0.9800000190734863,
-                                                                0.9700000286102295,
-                                                                0.6499999761581421
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                1240.0,
-                                                                -720.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{7A81309D-4CFF-4582-8C63-CDC64C3261FD}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "Type": 3,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Apply Damage to Players",
-                                                            "BackgroundColor": [
-                                                                0.9137254953384399,
-                                                                0.6627451181411743,
-                                                                0.2666666805744171
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
-                                                            "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 360.0,
-                                                            "DisplayWidth": 2720.0,
-                                                            "PersistentGroupedId": [
-                                                                "{AF65F10A-303E-41B1-9F80-D33D8DE4983A}",
-                                                                "{1C228C3F-E550-40E7-8205-F34A64B55F7E}",
-                                                                "{EB97E6EA-1F3E-4DE5-BAC2-F969E47A12A9}",
-                                                                "{21EBAECA-F098-4351-AF40-A6C27CA3C969}",
-                                                                "{05F09E39-C1AF-40CE-8D26-9EE39A529985}",
-                                                                "{42019F2A-39DA-4BE2-8582-2961061E8F73}",
-                                                                "{0C80C305-8AE0-497F-9280-E2240DAFD22E}",
-                                                                "{E78310D6-B742-4BB2-AAD1-A9B2F8AA67DC}"
-                                                            ]
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                2840.0,
-                                                                -200.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{CEBE614C-0870-4F60-8873-58A8E5362E9E}"
-                                                        }
-                                                    }
-                                                }
-                                            },
                                             {
                                                 "Type": 3,
                                                 "DataContainer": {
@@ -6619,175 +6661,6 @@
                                                         "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                                             "$type": "PersistentIdComponentSaveData",
                                                             "PersistentId": "{F9009D09-7245-4983-9D17-02FBBABAC9D2}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "Type": 3,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Update Idle Effects",
-                                                            "BackgroundColor": [
-                                                                0.46666666865348816,
-                                                                0.8117647171020508,
-                                                                0.658823549747467
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
-                                                            "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 283.0,
-                                                            "DisplayWidth": 1200.0,
-                                                            "PersistentGroupedId": [
-                                                                "{52F1A63B-0E5A-4457-B498-B1B84965055B}",
-                                                                "{48FAFE51-E62A-4F5E-8D69-749A93AB3E99}",
-                                                                "{44C55FFA-6850-416B-91E4-A79D892D4922}"
-                                                            ]
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                1600.0,
-                                                                -920.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{2DBBB59E-43A0-4842-952A-D9928769213A}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "Type": 1,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Detect when lifetime wraps, that triggers an explosion",
-                                                            "BackgroundColor": [
-                                                                0.9800000190734863,
-                                                                0.9700000286102295,
-                                                                0.6499999761581421
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                1780.0,
-                                                                -480.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{6E3C9BA2-EADB-4C71-8AA4-CC53CB4FAB33}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "Type": 3,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Play Explosion",
-                                                            "BackgroundColor": [
-                                                                0.46666666865348816,
-                                                                0.8117647171020508,
-                                                                0.658823549747467
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
-                                                            "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 500.0,
-                                                            "DisplayWidth": 2720.0,
-                                                            "PersistentGroupedId": [
-                                                                "{F8BF4548-C827-4C0E-8F87-F399F3100EB0}",
-                                                                "{FC53001E-EAC0-40BE-80B6-AAB1C8FF015D}",
-                                                                "{A7431116-29C2-4270-B449-BAFAED7C5C37}",
-                                                                "{220C00BC-6F1F-44F9-BF0F-C73367191725}",
-                                                                "{4FA61549-F0E4-4166-9172-31B59CFB44CE}",
-                                                                "{6BC46CA3-7795-4CD4-8820-DB1367EC1A6C}",
-                                                                "{F240C86D-E961-4175-9FCE-F176D724F886}",
-                                                                "{3DD5100B-1233-4302-8F8A-F3547F2AC90D}"
-                                                            ]
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                2840.0,
-                                                                -700.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{5E66BB00-4E95-4A9A-9360-C1A765DD1D7B}"
-                                                        }
-                                                    }
-                                                }
-                                            },
-                                            {
-                                                "Type": 1,
-                                                "DataContainer": {
-                                                    "ComponentData": {
-                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                                            "$type": "NodeSaveData"
-                                                        },
-                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
-                                                            "$type": "CommentNodeTextSaveData",
-                                                            "Comment": "Scales from 4xExplodeTimes to 0",
-                                                            "BackgroundColor": [
-                                                                0.9800000190734863,
-                                                                0.9700000286102295,
-                                                                0.6499999761581421
-                                                            ],
-                                                            "FontSettings": {
-                                                                "PixelSize": 16
-                                                            }
-                                                        },
-                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                                            "$type": "GeometrySaveData",
-                                                            "Position": [
-                                                                960.0,
-                                                                -680.0
-                                                            ]
-                                                        },
-                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                                            "$type": "StylingComponentSaveData"
-                                                        },
-                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                                            "$type": "PersistentIdComponentSaveData",
-                                                            "PersistentId": "{FC6CC91A-BC83-4E64-A33A-97BA107F194E}"
                                                         }
                                                     }
                                                 }
@@ -6880,12 +6753,269 @@
                                                         }
                                                     }
                                                 }
+                                            },
+                                            {
+                                                "Type": 1,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Detect when lifetime wraps, that triggers an explosion",
+                                                            "BackgroundColor": [
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                1780.0,
+                                                                -480.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{6E3C9BA2-EADB-4C71-8AA4-CC53CB4FAB33}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 3,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Apply Damage to Players",
+                                                            "BackgroundColor": [
+                                                                0.9137254953384399,
+                                                                0.6627451181411743,
+                                                                0.2666666805744171
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
+                                                            "$type": "NodeGroupFrameComponentSaveData",
+                                                            "DisplayHeight": 340.0,
+                                                            "DisplayWidth": 2860.0,
+                                                            "PersistentGroupedId": [
+                                                                "{AF65F10A-303E-41B1-9F80-D33D8DE4983A}",
+                                                                "{21EBAECA-F098-4351-AF40-A6C27CA3C969}",
+                                                                "{E78310D6-B742-4BB2-AAD1-A9B2F8AA67DC}",
+                                                                "{AE5956D5-B608-4F81-92D4-17718D1B3DAA}",
+                                                                "{301910B6-893E-4EE3-848F-220D41D5B090}",
+                                                                "{EB97E6EA-1F3E-4DE5-BAC2-F969E47A12A9}",
+                                                                "{05F09E39-C1AF-40CE-8D26-9EE39A529985}",
+                                                                "{0C80C305-8AE0-497F-9280-E2240DAFD22E}",
+                                                                "{42019F2A-39DA-4BE2-8582-2961061E8F73}"
+                                                            ]
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                2840.0,
+                                                                -180.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{CEBE614C-0870-4F60-8873-58A8E5362E9E}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 1,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Scales from 4xExplodeTimes to 0",
+                                                            "BackgroundColor": [
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                960.0,
+                                                                -680.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{FC6CC91A-BC83-4E64-A33A-97BA107F194E}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 3,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Play Explosion",
+                                                            "BackgroundColor": [
+                                                                0.46666666865348816,
+                                                                0.8117647171020508,
+                                                                0.658823549747467
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
+                                                            "$type": "NodeGroupFrameComponentSaveData",
+                                                            "DisplayHeight": 500.0,
+                                                            "DisplayWidth": 2560.0,
+                                                            "PersistentGroupedId": [
+                                                                "{3DD5100B-1233-4302-8F8A-F3547F2AC90D}",
+                                                                "{F240C86D-E961-4175-9FCE-F176D724F886}",
+                                                                "{6BC46CA3-7795-4CD4-8820-DB1367EC1A6C}",
+                                                                "{220C00BC-6F1F-44F9-BF0F-C73367191725}",
+                                                                "{4FA61549-F0E4-4166-9172-31B59CFB44CE}",
+                                                                "{FC53001E-EAC0-40BE-80B6-AAB1C8FF015D}",
+                                                                "{A7431116-29C2-4270-B449-BAFAED7C5C37}",
+                                                                "{F8BF4548-C827-4C0E-8F87-F399F3100EB0}"
+                                                            ]
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                2840.0,
+                                                                -720.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{5E66BB00-4E95-4A9A-9360-C1A765DD1D7B}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 3,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Update Idle Effects",
+                                                            "BackgroundColor": [
+                                                                0.46666666865348816,
+                                                                0.8117647171020508,
+                                                                0.658823549747467
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
+                                                            "$type": "NodeGroupFrameComponentSaveData",
+                                                            "DisplayHeight": 283.0,
+                                                            "DisplayWidth": 1200.0,
+                                                            "PersistentGroupedId": [
+                                                                "{52F1A63B-0E5A-4457-B498-B1B84965055B}",
+                                                                "{48FAFE51-E62A-4F5E-8D69-749A93AB3E99}",
+                                                                "{44C55FFA-6850-416B-91E4-A79D892D4922}"
+                                                            ]
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                1600.0,
+                                                                -920.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{2DBBB59E-43A0-4842-952A-D9928769213A}"
+                                                        }
+                                                    }
+                                                }
+                                            },
+                                            {
+                                                "Type": 1,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "Mod 4, so value goes from 4 to 0 a total of ExplodeTimes over the course of the match",
+                                                            "BackgroundColor": [
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                1240.0,
+                                                                -720.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{7A81309D-4CFF-4582-8C63-CDC64C3261FD}"
+                                                        }
+                                                    }
+                                                }
                                             }
                                         ],
                                         "ViewParams": {
-                                            "Scale": 0.7647511107419935,
-                                            "AnchorX": 3347.494384765625,
-                                            "AnchorY": -921.8685302734375
+                                            "Scale": 0.34757062746676565,
+                                            "AnchorX": -1055.9005126953125,
+                                            "AnchorY": -1743.530517578125
                                         }
                                     }
                                 }
@@ -6893,7 +7023,131 @@
                         },
                         {
                             "Key": {
-                                "id": 2271646715768
+                                "id": 96046745316451
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -240.0,
+                                            -620.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{59667D9C-AADF-4089-87F7-FF671C0AB52C}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96051040283747
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2360.0,
+                                            -860.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{52F1A63B-0E5A-4457-B498-B1B84965055B}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96055335251043
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3600.0,
+                                            -120.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{05F09E39-C1AF-40CE-8D26-9EE39A529985}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96059630218339
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            2860.0,
+                                            -660.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{F240C86D-E961-4175-9FCE-F176D724F886}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96063925185635
                             },
                             "Value": {
                                 "ComponentData": {
@@ -6908,7 +7162,7 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             3900.0,
-                                            -640.0
+                                            -660.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -6924,7 +7178,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2275941683064
+                                "id": 96068220152931
                             },
                             "Value": {
                                 "ComponentData": {
@@ -6955,7 +7209,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2280236650360
+                                "id": 96072515120227
                             },
                             "Value": {
                                 "ComponentData": {
@@ -6964,151 +7218,29 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                        "PaletteOverride": "MethodNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3600.0,
-                                            -140.0
+                                            5100.0,
+                                            -660.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
                                         "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".getVariable"
+                                        "SubStyle": ".method"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{05F09E39-C1AF-40CE-8D26-9EE39A529985}"
+                                        "PersistentId": "{F8BF4548-C827-4C0E-8F87-F399F3100EB0}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2284531617656
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "GetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2860.0,
-                                            -640.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".getVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F240C86D-E961-4175-9FCE-F176D724F886}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2288826584952
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            660.0,
-                                            -620.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{FF431501-A9CE-4930-B038-30649C1D9417}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2293121552248
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1780.0,
-                                            -180.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{9521285E-DB86-41D3-8DC6-701E7C9D1A4A}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2297416519544
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "DefaultNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            4340.0,
-                                            -100.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{21EBAECA-F098-4351-AF40-A6C27CA3C969}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2301711486840
+                                "id": 96076810087523
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7139,7 +7271,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2306006454136
+                                "id": 96081105054819
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7148,29 +7280,28 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                        "PaletteOverride": "MathNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -560.0,
-                                            -300.0
+                                            660.0,
+                                            -620.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".setVariable"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{23244910-4A1E-4905-A2F4-F4E9D7E1A9F2}"
+                                        "PersistentId": "{FF431501-A9CE-4930-B038-30649C1D9417}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2310301421432
+                                "id": 96085400022115
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7184,8 +7315,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            5240.0,
-                                            -100.0
+                                            5400.0,
+                                            -80.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7201,7 +7332,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2314596388728
+                                "id": 96089694989411
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7210,13 +7341,44 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            -560.0,
-                                            -620.0
+                                            1780.0,
+                                            -180.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{9521285E-DB86-41D3-8DC6-701E7C9D1A4A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96093989956707
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4500.0,
+                                            -80.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7224,14 +7386,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{2AE75BB4-1644-40BA-8996-B519C036B17A}"
+                                        "PersistentId": "{21EBAECA-F098-4351-AF40-A6C27CA3C969}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2323186323320
+                                "id": 96098284924003
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7262,7 +7424,38 @@
                         },
                         {
                             "Key": {
-                                "id": 2331776257912
+                                "id": 96102579891299
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "SetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -560.0,
+                                            -300.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".setVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{23244910-4A1E-4905-A2F4-F4E9D7E1A9F2}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96106874858595
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7277,7 +7470,7 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             3160.0,
-                                            -440.0
+                                            -460.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7293,7 +7486,68 @@
                         },
                         {
                             "Key": {
-                                "id": 2336071225208
+                                "id": 96111169825891
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "TimeNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            -560.0,
+                                            -620.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{2AE75BB4-1644-40BA-8996-B519C036B17A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96115464793187
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            3900.0,
+                                            -120.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{AE5956D5-B608-4F81-92D4-17718D1B3DAA}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96119759760483
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7307,8 +7561,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            4640.0,
-                                            -100.0
+                                            4340.0,
+                                            -660.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7317,76 +7571,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{42019F2A-39DA-4BE2-8582-2961061E8F73}"
+                                        "PersistentId": "{6BC46CA3-7795-4CD4-8820-DB1367EC1A6C}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2340366192504
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            3160.0,
-                                            -640.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{A7431116-29C2-4270-B449-BAFAED7C5C37}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2344661159800
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1260.0,
-                                            -620.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{C7B00191-EC4B-48E1-9FA6-6489D6F854BA}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2348956127096
+                                "id": 96124054727779
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7401,7 +7593,7 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             4640.0,
-                                            -640.0
+                                            -660.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7417,7 +7609,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2353251094392
+                                "id": 96128349695075
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7448,7 +7640,38 @@
                         },
                         {
                             "Key": {
-                                "id": 2357546061688
+                                "id": 96132644662371
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "GetVariableNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4800.0,
+                                            -80.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".getVariable"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{42019F2A-39DA-4BE2-8582-2961061E8F73}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96136939629667
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7463,7 +7686,7 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             3160.0,
-                                            -100.0
+                                            -660.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7472,14 +7695,135 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{EB97E6EA-1F3E-4DE5-BAC2-F969E47A12A9}"
+                                        "PersistentId": "{A7431116-29C2-4270-B449-BAFAED7C5C37}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2361841028984
+                                "id": 96141234596963
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1260.0,
+                                            -620.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{C7B00191-EC4B-48E1-9FA6-6489D6F854BA}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96145529564259
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            1780.0,
+                                            -400.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{2298D09C-FB6F-49E2-A0FA-45D84357BD16}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96149824531555
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MathNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            5100.0,
+                                            -80.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{E78310D6-B742-4BB2-AAD1-A9B2F8AA67DC}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96154119498851
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "DefaultNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            4200.0,
+                                            -80.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{301910B6-893E-4EE3-848F-220D41D5B090}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 96158414466147
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7513,128 +7857,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2366135996280
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            1780.0,
-                                            -400.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{2298D09C-FB6F-49E2-A0FA-45D84357BD16}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2370430963576
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MathNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            4940.0,
-                                            -100.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{E78310D6-B742-4BB2-AAD1-A9B2F8AA67DC}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2374725930872
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            -240.0,
-                                            -620.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{59667D9C-AADF-4089-87F7-FF671C0AB52C}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2379020898168
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "TimeNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            2860.0,
-                                            -100.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{0C80C305-8AE0-497F-9280-E2240DAFD22E}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 2383315865464
+                                "id": 96162709433443
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7664,7 +7887,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2387610832760
+                                "id": 96167004400739
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7694,7 +7917,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2391905800056
+                                "id": 96171299368035
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7724,7 +7947,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2396200767352
+                                "id": 96175594335331
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7755,7 +7978,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2400495734648
+                                "id": 96179889302627
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7769,8 +7992,8 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            3900.0,
-                                            -100.0
+                                            3160.0,
+                                            -80.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7779,14 +8002,14 @@
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{1C228C3F-E550-40E7-8205-F34A64B55F7E}"
+                                        "PersistentId": "{EB97E6EA-1F3E-4DE5-BAC2-F969E47A12A9}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2404790701944
+                                "id": 96184184269923
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7795,29 +8018,28 @@
                                     },
                                     "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
                                         "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                        "PaletteOverride": "TimeNodeTitlePalette"
                                     },
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            2360.0,
-                                            -860.0
+                                            2860.0,
+                                            -80.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
+                                        "$type": "StylingComponentSaveData"
                                     },
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{52F1A63B-0E5A-4457-B498-B1B84965055B}"
+                                        "PersistentId": "{0C80C305-8AE0-497F-9280-E2240DAFD22E}"
                                     }
                                 }
                             }
                         },
                         {
                             "Key": {
-                                "id": 2409085669240
+                                "id": 96188479237219
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7832,7 +8054,7 @@
                                         "$type": "GeometrySaveData",
                                         "Position": [
                                             3600.0,
-                                            -640.0
+                                            -660.0
                                         ]
                                     },
                                     "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -7847,7 +8069,7 @@
                         },
                         {
                             "Key": {
-                                "id": 2413380636536
+                                "id": 96192774204515
                             },
                             "Value": {
                                 "ComponentData": {
@@ -7874,78 +8096,12 @@
                                     }
                                 }
                             }
-                        },
-                        {
-                            "Key": {
-                                "id": 32722964844408
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "GetVariableNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            4340.0,
-                                            -640.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".getVariable"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{6BC46CA3-7795-4CD4-8820-DB1367EC1A6C}"
-                                    }
-                                }
-                            }
-                        },
-                        {
-                            "Key": {
-                                "id": 62753376178040
-                            },
-                            "Value": {
-                                "ComponentData": {
-                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
-                                        "$type": "NodeSaveData"
-                                    },
-                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
-                                        "$type": "GeneralNodeTitleComponentSaveData",
-                                        "PaletteOverride": "MethodNodeTitlePalette"
-                                    },
-                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
-                                        "$type": "GeometrySaveData",
-                                        "Position": [
-                                            5100.0,
-                                            -640.0
-                                        ]
-                                    },
-                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
-                                        "$type": "StylingComponentSaveData",
-                                        "SubStyle": ".method"
-                                    },
-                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
-                                        "$type": "PersistentIdComponentSaveData",
-                                        "PersistentId": "{F8BF4548-C827-4C0E-8F87-F399F3100EB0}"
-                                    }
-                                }
-                            }
                         }
                     ],
                     "StatisticsHelper": {
                         "InstanceCounter": [
                             {
                                 "Key": 955089921810928021,
-                                "Value": 1
-                            },
-                            {
-                                "Key": 2525416239769970093,
                                 "Value": 1
                             },
                             {
@@ -7975,6 +8131,14 @@
                             {
                                 "Key": 11000802260220917925,
                                 "Value": 2
+                            },
+                            {
+                                "Key": 11934378609147116901,
+                                "Value": 1
+                            },
+                            {
+                                "Key": 12155763068564192235,
+                                "Value": 1
                             },
                             {
                                 "Key": 12259493282421020587,


### PR DESCRIPTION
Updates the shield generator script canvas to use the new entity gather by component node. This fixes the inconsistent damage the shield generator was applying to players when it explodes.

![image](https://user-images.githubusercontent.com/82241079/230468193-c170a61d-32a6-46dc-9baf-e53f34093b73.png)

![image](https://user-images.githubusercontent.com/82241079/230468041-b2f8b6e3-ed89-4768-9ea6-bd99bbcebb24.png)
