### PR TITLE
Fixing PostProcessParent.pass to reference correct Taa pass.

### DIFF
--- a/Passes/PostProcessParent.pass
+++ b/Passes/PostProcessParent.pass
@@ -86,7 +86,7 @@
                 },
                 {
                     "Name": "TaaPass",
-                    "TemplateName": "TaaTemplate",
+                    "TemplateName": "TaaParentTemplate",
                     "Enabled": true,
                     "Connections": [
                         {


### PR DESCRIPTION
This PR is dependent upon https://github.com/o3de/o3de/pull/15645. Once that change goes in this file will need to be updated to reference the correct pass.