### PR TITLE
Energy ball package build debugging

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/EnergyBallComponent.h
+++ b/Gem/Code/Source/Components/Multiplayer/EnergyBallComponent.h
@@ -29,6 +29,12 @@ namespace MultiplayerSample
 #endif
 
     private:
+        void DebugDraw();
+        AZ::ScheduledEvent m_debugDrawEvent{ [this]()
+        {
+            DebugDraw();
+        }, AZ::Name("EnergyBallDebugDraw") };
+
         GameEffect m_effect;
     };
 


### PR DESCRIPTION
Adds debug code to debug draw energy balls. This will help determine whether the invisible energy balls is a pak related asset issue or if this is a tick, update, or replication issue.