### PR TITLE
Changed registry keys so that they end up in final pak files.

### DIFF
--- a/Registry/settings.multiplayersample_gamelauncher.setreg
+++ b/Registry/settings.multiplayersample_gamelauncher.setreg
@@ -1,11 +1,10 @@
 {
-    "Amazon": {
-        "AzCore": {
-            "Runtime": {
-                "ConsoleCommands": {
-                    "cl_serverAddr": "127.0.0.1",
-                    "loadlevel": "startmenu"
-                }
+    "O3DE": {
+       "Autoexec": {
+            "ConsoleCommands": {
+                "r_displayInfo": 3,
+                "cl_serverAddr": "127.0.0.1",
+                "loadlevel": "startmenu"
             }
         }
     }

--- a/Registry/settings.multiplayersample_gamelauncher.setreg
+++ b/Registry/settings.multiplayersample_gamelauncher.setreg
@@ -2,7 +2,7 @@
     "O3DE": {
        "Autoexec": {
             "ConsoleCommands": {
-                "r_displayInfo": 3,
+                "r_displayInfo": 0,
                 "cl_serverAddr": "127.0.0.1",
                 "loadlevel": "startmenu"
             }

--- a/Registry/settings.multiplayersample_unifiedlauncher.setreg
+++ b/Registry/settings.multiplayersample_unifiedlauncher.setreg
@@ -1,11 +1,10 @@
 {
-    "Amazon": {
-        "AzCore": {
-            "Runtime": {
-                "ConsoleCommands": {
-                    "cl_serverAddr": "127.0.0.1",
-                    "loadlevel": "startmenu"
-                }
+    "O3DE": {
+       "Autoexec": {
+            "ConsoleCommands": {
+                "r_displayInfo": 3,
+                "cl_serverAddr": "127.0.0.1",
+                "loadlevel": "newstarbase"
             }
         }
     }

--- a/Registry/settings.multiplayersample_unifiedlauncher.setreg
+++ b/Registry/settings.multiplayersample_unifiedlauncher.setreg
@@ -2,7 +2,7 @@
     "O3DE": {
        "Autoexec": {
             "ConsoleCommands": {
-                "r_displayInfo": 3,
+                "r_displayInfo": 0,
                 "cl_serverAddr": "127.0.0.1",
                 "loadlevel": "newstarbase"
             }


### PR DESCRIPTION
Small touchup to the checked-in setreg files so that the values end up in the pak builds.

Per the documentation ( https://www.o3de.org/docs/user-guide/settings/issue-az-console-commands/ ), `Amazon/Core/Runtime/ConsoleCommands` and `O3DE/Autoexec/ConsoleCommands` are both used by non-pak builds, but only the latter is processed by the Asset Processor into the bootstrap.game.*.setreg files that are put into the pak builds. 

The previous setreg files worked fine in regular profile builds, but didn't have any effect on settings in pak builds. The new files work for both.

Tested:
* Editor - went into game mode and verified that the Editor launched the ServerLauncher correctly and connected to it.
* Standard profile builds of GameLauncher / ServerLauncher - verified that ServerLauncher worked with its typical command line of `--project-path="D:/github/o3de-multiplayersample" -rhi=null -NullRenderer -sv_terminateOnPlayerExit=false`, and GameLauncher worked with its typical command line of `--project-path="D:/github/o3de-multiplayersample" `
* Pak monolithic profile builds of GameLauncher / ServerLauncher - verifed that ServerLauncher worked with its typical command line of `--console-command-file=launch_server.cfg --rhi=null -NullRenderer -bg_ConnectToAssetProcessor=0 -sys_PakPriority=2 -sv_terminateOnPlayerExit=false` and GameLauncher worked with `-bg_ConnectToAssetProcessor=0 -sys_PakPriority=2`

Adding a Registry/settings.multiplayersample_gamelauncher.setreg file to the final pak build directory allowed the GameLauncher to run without those command-line arguments:
```
{
    "O3DE": {
            "Autoexec": {
                "ConsoleCommands": {
                    "bg_ConnectToAssetProcessor": 0,
                    "sys_PakPriority": 2
                 }
            }
    }
}  
```