### PR TITLE
Added "disconnect" call to script to reset the multiplayer state to allow LoadLevel to work

### DIFF
--- a/scriptcanvas/ClientDisconnect.scriptcanvas
+++ b/scriptcanvas/ClientDisconnect.scriptcanvas
@@ -5,7 +5,7 @@
     "ClassData": {
         "m_scriptCanvas": {
             "Id": {
-                "id": 63723511289631
+                "id": 41296274672356
             },
             "Name": "Script Canvas Graph",
             "Components": {
@@ -16,7 +16,7 @@
                         "m_nodes": [
                             {
                                 "Id": {
-                                    "id": 63744986126111
+                                    "id": 41317749508836
                                 },
                                 "Name": "SC-Node(ExecuteConsoleCommand)",
                                 "Components": {
@@ -100,7 +100,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 63740691158815
+                                    "id": 41313454541540
                                 },
                                 "Name": "EBusEventHandler",
                                 "Components": {
@@ -341,7 +341,88 @@
                             },
                             {
                                 "Id": {
-                                    "id": 63736396191519
+                                    "id": 47163199998692
+                                },
+                                "Name": "SC-Node(ExecuteConsoleCommand)",
+                                "Components": {
+                                    "Component_[17382034980001092472]": {
+                                        "$type": "{E42861BD-1956-45AE-8DD7-CCFC1E3E5ACF} Method",
+                                        "Id": 17382034980001092472,
+                                        "Slots": [
+                                            {
+                                                "id": {
+                                                    "m_id": "{365E1DAE-26DC-42E8-9DC2-E4AE1A04B08F}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "String",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 2
+                                                },
+                                                "DataType": 1
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{E061744B-A882-4069-B606-F3F0036C2941}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "In",
+                                                "Descriptor": {
+                                                    "ConnectionType": 1,
+                                                    "SlotType": 1
+                                                }
+                                            },
+                                            {
+                                                "id": {
+                                                    "m_id": "{C7F2B1D8-93A2-4B0B-98B2-BFDE5E7E34B1}"
+                                                },
+                                                "contracts": [
+                                                    {
+                                                        "$type": "SlotTypeContract"
+                                                    }
+                                                ],
+                                                "slotName": "Out",
+                                                "Descriptor": {
+                                                    "ConnectionType": 2,
+                                                    "SlotType": 1
+                                                }
+                                            }
+                                        ],
+                                        "Datums": [
+                                            {
+                                                "isOverloadedStorage": false,
+                                                "scriptCanvasType": {
+                                                    "m_type": 5
+                                                },
+                                                "isNullPointer": false,
+                                                "$type": "{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9} AZStd::string",
+                                                "value": "disconnect",
+                                                "label": "Command"
+                                            }
+                                        ],
+                                        "methodType": 0,
+                                        "methodName": "ExecuteConsoleCommand",
+                                        "className": "ConsoleRequestBus",
+                                        "inputSlots": [
+                                            {
+                                                "m_id": "{365E1DAE-26DC-42E8-9DC2-E4AE1A04B08F}"
+                                            }
+                                        ],
+                                        "prettyClassName": "ConsoleRequestBus"
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 41309159574244
                                 },
                                 "Name": "SC-Node(EqualTo)",
                                 "Components": {
@@ -490,7 +571,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 63732101224223
+                                    "id": 41304864606948
                                 },
                                 "Name": "SC-Node(TimeDelayNodeableNode)",
                                 "Components": {
@@ -631,7 +712,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 63727806256927
+                                    "id": 41300569639652
                                 },
                                 "Name": "ReceiveScriptEvent",
                                 "Components": {
@@ -929,35 +1010,7 @@
                         "m_connections": [
                             {
                                 "Id": {
-                                    "id": 63749281093407
-                                },
-                                "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(ExecuteConsoleCommand: In)",
-                                "Components": {
-                                    "Component_[18339910822672896418]": {
-                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
-                                        "Id": 18339910822672896418,
-                                        "sourceEndpoint": {
-                                            "nodeId": {
-                                                "id": 63732101224223
-                                            },
-                                            "slotId": {
-                                                "m_id": "{5BB44F12-9009-4193-961B-8E2F6CC538FB}"
-                                            }
-                                        },
-                                        "targetEndpoint": {
-                                            "nodeId": {
-                                                "id": 63744986126111
-                                            },
-                                            "slotId": {
-                                                "m_id": "{8C46EFC2-676D-4B14-A5F0-B58404C64CD0}"
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            {
-                                "Id": {
-                                    "id": 63753576060703
+                                    "id": 41326339443428
                                 },
                                 "Name": "srcEndpoint=(EntityBus Handler: ExecutionSlot:OnEntityActivated), destEndpoint=(Receive Script Event: Connect)",
                                 "Components": {
@@ -966,7 +1019,7 @@
                                         "Id": 9151944094509384703,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 63740691158815
+                                                "id": 41313454541540
                                             },
                                             "slotId": {
                                                 "m_id": "{ECD88DEB-EE0D-4ECC-8583-48E97A5113B2}"
@@ -974,7 +1027,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 63727806256927
+                                                "id": 41300569639652
                                             },
                                             "slotId": {
                                                 "m_id": "{739ED44A-BACE-4B23-9F76-DED2F3A7457C}"
@@ -985,7 +1038,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 63757871027999
+                                    "id": 41330634410724
                                 },
                                 "Name": "srcEndpoint=(Receive Script Event: ScreenToShow), destEndpoint=(Equal To (==): Value A)",
                                 "Components": {
@@ -994,7 +1047,7 @@
                                         "Id": 17600078873613684267,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 63727806256927
+                                                "id": 41300569639652
                                             },
                                             "slotId": {
                                                 "m_id": "{25FC9880-C3C6-4432-AA4F-1C894497F22D}"
@@ -1002,7 +1055,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 63736396191519
+                                                "id": 41309159574244
                                             },
                                             "slotId": {
                                                 "m_id": "{DBE1F264-1D99-4604-8070-B4ADFC8A2A1C}"
@@ -1013,7 +1066,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 63762165995295
+                                    "id": 41334929378020
                                 },
                                 "Name": "srcEndpoint=(Equal To (==): True), destEndpoint=(TimeDelay: Start)",
                                 "Components": {
@@ -1022,7 +1075,7 @@
                                         "Id": 10150836379398510596,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 63736396191519
+                                                "id": 41309159574244
                                             },
                                             "slotId": {
                                                 "m_id": "{4C285E52-9795-47E5-90A5-70936454D2AF}"
@@ -1030,7 +1083,7 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 63732101224223
+                                                "id": 41304864606948
                                             },
                                             "slotId": {
                                                 "m_id": "{89844691-7E99-4E4B-A2CC-7920469B3351}"
@@ -1041,7 +1094,7 @@
                             },
                             {
                                 "Id": {
-                                    "id": 71514581964575
+                                    "id": 41339224345316
                                 },
                                 "Name": "srcEndpoint=(Receive Script Event: ExecutionSlot:SetActiveScreen), destEndpoint=(Equal To (==): In)",
                                 "Components": {
@@ -1050,7 +1103,7 @@
                                         "Id": 5974153072275692349,
                                         "sourceEndpoint": {
                                             "nodeId": {
-                                                "id": 63727806256927
+                                                "id": 41300569639652
                                             },
                                             "slotId": {
                                                 "m_id": "{5C46F887-23F6-4A14-9ADD-03B5E0543328}"
@@ -1058,10 +1111,66 @@
                                         },
                                         "targetEndpoint": {
                                             "nodeId": {
-                                                "id": 63736396191519
+                                                "id": 41309159574244
                                             },
                                             "slotId": {
                                                 "m_id": "{DC73B288-02D4-4667-A0E5-3ED395DF8DC2}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 52205491604196
+                                },
+                                "Name": "srcEndpoint=(TimeDelay: Done), destEndpoint=(ExecuteConsoleCommand: In)",
+                                "Components": {
+                                    "Component_[15414995311809178445]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 15414995311809178445,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 41304864606948
+                                            },
+                                            "slotId": {
+                                                "m_id": "{5BB44F12-9009-4193-961B-8E2F6CC538FB}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 47163199998692
+                                            },
+                                            "slotId": {
+                                                "m_id": "{E061744B-A882-4069-B606-F3F0036C2941}"
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            {
+                                "Id": {
+                                    "id": 53103139769060
+                                },
+                                "Name": "srcEndpoint=(ExecuteConsoleCommand: Out), destEndpoint=(ExecuteConsoleCommand: In)",
+                                "Components": {
+                                    "Component_[13185958598790311973]": {
+                                        "$type": "{64CA5016-E803-4AC4-9A36-BDA2C890C6EB} Connection",
+                                        "Id": 13185958598790311973,
+                                        "sourceEndpoint": {
+                                            "nodeId": {
+                                                "id": 47163199998692
+                                            },
+                                            "slotId": {
+                                                "m_id": "{C7F2B1D8-93A2-4B0B-98B2-BFDE5E7E34B1}"
+                                            }
+                                        },
+                                        "targetEndpoint": {
+                                            "nodeId": {
+                                                "id": 41317749508836
+                                            },
+                                            "slotId": {
+                                                "m_id": "{8C46EFC2-676D-4B14-A5F0-B58404C64CD0}"
                                             }
                                         }
                                     }
@@ -1071,7 +1180,7 @@
                         "m_scriptEventAssets": [
                             [
                                 {
-                                    "id": 63727806256927
+                                    "id": 41300569639652
                                 },
                                 {}
                             ]
@@ -1086,13 +1195,49 @@
                     "GraphCanvasData": [
                         {
                             "Key": {
-                                "id": 63723511289631
+                                "id": 41296274672356
                             },
                             "Value": {
                                 "ComponentData": {
                                     "{5F84B500-8C45-40D1-8EFC-A5306B241444}": {
                                         "$type": "SceneComponentSaveData",
                                         "Constructs": [
+                                            {
+                                                "Type": 1,
+                                                "DataContainer": {
+                                                    "ComponentData": {
+                                                        "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                                            "$type": "NodeSaveData"
+                                                        },
+                                                        "{524D8380-AC09-444E-870E-9CEF2535B4A2}": {
+                                                            "$type": "CommentNodeTextSaveData",
+                                                            "Comment": "The \"disconnect\" is required here because once a client has connected to a server for the first time, it won't be able to initiate a level load without calling a client-side disconnect to reset the state.",
+                                                            "BackgroundColor": [
+                                                                0.9800000190734863,
+                                                                0.9700000286102295,
+                                                                0.6499999761581421
+                                                            ],
+                                                            "FontSettings": {
+                                                                "PixelSize": 16
+                                                            }
+                                                        },
+                                                        "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                                            "$type": "GeometrySaveData",
+                                                            "Position": [
+                                                                960.0,
+                                                                220.0
+                                                            ]
+                                                        },
+                                                        "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                                            "$type": "StylingComponentSaveData"
+                                                        },
+                                                        "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                                            "$type": "PersistentIdComponentSaveData",
+                                                            "PersistentId": "{587F771B-FC38-4C05-8A31-6002D71FF144}"
+                                                        }
+                                                    }
+                                                }
+                                            },
                                             {
                                                 "Type": 3,
                                                 "DataContainer": {
@@ -1114,23 +1259,23 @@
                                                         },
                                                         "{6F4811ED-BD83-4A2A-8831-58EEA4020D57}": {
                                                             "$type": "NodeGroupFrameComponentSaveData",
-                                                            "DisplayHeight": 520.0,
-                                                            "DisplayWidth": 2260.0,
+                                                            "DisplayHeight": 547.0,
+                                                            "DisplayWidth": 2400.0,
                                                             "PersistentGroupedId": [
-                                                                "{6FDF698F-ACB9-4747-AA27-E23A3DA8FEC3}",
-                                                                "{1E80C9AA-C1A2-4313-9310-1EE8E5127DC8}",
-                                                                "{4B7B33DD-6E65-4A51-A4B7-F2E91BA9DAB4}",
+                                                                "{89868DAB-1712-4C78-AE33-0014BDC142EA}",
                                                                 "{282BB238-27B1-482D-A39E-A42B99C55EA9}",
-                                                                "{E008D29B-1194-4DD3-83CD-71A9BD9442C5}",
+                                                                "{4B7B33DD-6E65-4A51-A4B7-F2E91BA9DAB4}",
+                                                                "{C21F9316-8419-4C35-BAFE-536829F5C78A}",
+                                                                "{1E80C9AA-C1A2-4313-9310-1EE8E5127DC8}",
                                                                 "{496A1DBA-E33D-4AA7-AA49-C533AFA7E519}",
-                                                                "{C21F9316-8419-4C35-BAFE-536829F5C78A}"
+                                                                "{587F771B-FC38-4C05-8A31-6002D71FF144}"
                                                             ]
                                                         },
                                                         "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                                             "$type": "GeometrySaveData",
                                                             "Position": [
                                                                 -800.0,
-                                                                180.0
+                                                                160.0
                                                             ]
                                                         },
                                                         "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
@@ -1155,7 +1300,7 @@
                         },
                         {
                             "Key": {
-                                "id": 63727806256927
+                                "id": 41300569639652
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1198,7 +1343,7 @@
                         },
                         {
                             "Key": {
-                                "id": 63732101224223
+                                "id": 41304864606948
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1228,7 +1373,7 @@
                         },
                         {
                             "Key": {
-                                "id": 63736396191519
+                                "id": 41309159574244
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1258,7 +1403,7 @@
                         },
                         {
                             "Key": {
-                                "id": 63740691158815
+                                "id": 41313454541540
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1292,7 +1437,7 @@
                         },
                         {
                             "Key": {
-                                "id": 63744986126111
+                                "id": 41317749508836
                             },
                             "Value": {
                                 "ComponentData": {
@@ -1306,7 +1451,7 @@
                                     "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
                                         "$type": "GeometrySaveData",
                                         "Position": [
-                                            1000.0,
+                                            1300.0,
                                             360.0
                                         ]
                                     },
@@ -1317,6 +1462,37 @@
                                     "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
                                         "$type": "PersistentIdComponentSaveData",
                                         "PersistentId": "{C21F9316-8419-4C35-BAFE-536829F5C78A}"
+                                    }
+                                }
+                            }
+                        },
+                        {
+                            "Key": {
+                                "id": 47163199998692
+                            },
+                            "Value": {
+                                "ComponentData": {
+                                    "{24CB38BB-1705-4EC5-8F63-B574571B4DCD}": {
+                                        "$type": "NodeSaveData"
+                                    },
+                                    "{328FF15C-C302-458F-A43D-E1794DE0904E}": {
+                                        "$type": "GeneralNodeTitleComponentSaveData",
+                                        "PaletteOverride": "MethodNodeTitlePalette"
+                                    },
+                                    "{7CC444B1-F9B3-41B5-841B-0C4F2179F111}": {
+                                        "$type": "GeometrySaveData",
+                                        "Position": [
+                                            960.0,
+                                            360.0
+                                        ]
+                                    },
+                                    "{B0B99C8A-03AF-4CF6-A926-F65C874C3D97}": {
+                                        "$type": "StylingComponentSaveData",
+                                        "SubStyle": ".method"
+                                    },
+                                    "{B1F49A35-8408-40DA-B79E-F1E3B64322CE}": {
+                                        "$type": "PersistentIdComponentSaveData",
+                                        "PersistentId": "{89868DAB-1712-4C78-AE33-0014BDC142EA}"
                                     }
                                 }
                             }
@@ -1342,7 +1518,7 @@
                             },
                             {
                                 "Key": 13774516393157610292,
-                                "Value": 1
+                                "Value": 2
                             }
                         ]
                     }


### PR DESCRIPTION
The MultiplayerSystemComponent has logic that prevents a client from initiating "LoadLevel" at any point after the client has connected to a server for the first time, even if a disconnect occurs. However, the "disconnect" console command will reset the client-side state back to uninitialized, allowing the LoadLevel to succeed. This change to the game's ClientDisconnect state calls "disconnect" explicitly before calling "LoadLevel" so that it can successfully navigate back to the start screen. (Side note - this is why testing the feature with using "disconnect" on the client always worked :( )

![image](https://user-images.githubusercontent.com/82224783/233486655-74915d75-25ce-4886-add2-5608c59d3ba2.png)

This potentially should get fixed in the Multiplayer Gem as well in the development branch, GHI entered here: https://github.com/o3de/o3de/issues/15771 . But since it can't get fixed in the stabilization branch, the workaround in this PR is required.