### PR TITLE
Fix UI in GameplayTest.

### DIFF
--- a/Levels/GameplayTest/GameplayTest.prefab
+++ b/Levels/GameplayTest/GameplayTest.prefab
@@ -120,14 +120,14 @@
                     "Entity_[15464591867054]",
                     "Entity_[15473181801646]",
                     "Entity_[15481771736238]",
-                    "Entity_[873004712589]",
                     "Instance_[1238918361381]/ContainerEntity",
                     "Instance_[990233405078]/ContainerEntity",
                     "Instance_[44514490248300]/ContainerEntity",
                     "Instance_[2090718165100]/ContainerEntity",
                     "Entity_[58675766534237]",
                     "Entity_[65620728651869]",
-                    "Instance_[6302654760100]/ContainerEntity"
+                    "Instance_[6302654760100]/ContainerEntity",
+                    "Instance_[10391347535934]/ContainerEntity"
                 ]
             }
         }
@@ -11842,17 +11842,6 @@
                         "$type": "MultiplayerSample::MatchPlayerCoinsComponent"
                     }
                 },
-                "Component_[3709937876037180985]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 3709937876037180985,
-                    "m_template": {
-                        "$type": "UiCanvasAssetRefComponent",
-                        "CanvasAssetRef": {
-                            "AssetPath": "uicanvases/basichud.uicanvas"
-                        },
-                        "IsAutoLoad": true
-                    }
-                },
                 "Component_[5143246854913296527]": {
                     "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
                     "Id": 5143246854913296527,
@@ -12040,60 +12029,6 @@
                     "Id": 9914289529455341679
                 }
             }
-        },
-        "Entity_[873004712589]": {
-            "Id": "Entity_[873004712589]",
-            "Name": "In Game Menu",
-            "Components": {
-                "Component_[10973769579758943127]": {
-                    "$type": "EditorInspectorComponent",
-                    "Id": 10973769579758943127
-                },
-                "Component_[13892978883605229067]": {
-                    "$type": "EditorPendingCompositionComponent",
-                    "Id": 13892978883605229067
-                },
-                "Component_[16221779430861293146]": {
-                    "$type": "EditorDisabledCompositionComponent",
-                    "Id": 16221779430861293146
-                },
-                "Component_[16377069407396552235]": {
-                    "$type": "EditorVisibilityComponent",
-                    "Id": 16377069407396552235
-                },
-                "Component_[199753144438342893]": {
-                    "$type": "EditorEntitySortComponent",
-                    "Id": 199753144438342893
-                },
-                "Component_[2280755623652026535]": {
-                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
-                    "Id": 2280755623652026535,
-                    "Parent Entity": "Entity_[356758116574]"
-                },
-                "Component_[4368122420119951993]": {
-                    "$type": "EditorEntityIconComponent",
-                    "Id": 4368122420119951993
-                },
-                "Component_[438967016699456639]": {
-                    "$type": "EditorLockComponent",
-                    "Id": 438967016699456639
-                },
-                "Component_[5604360131636598685]": {
-                    "$type": "EditorOnlyEntityComponent",
-                    "Id": 5604360131636598685
-                },
-                "Component_[9355518200202427665]": {
-                    "$type": "GenericComponentWrapper",
-                    "Id": 9355518200202427665,
-                    "m_template": {
-                        "$type": "UiCanvasAssetRefComponent",
-                        "CanvasAssetRef": {
-                            "AssetPath": "uicanvases/ingamemenu.uicanvas"
-                        },
-                        "IsAutoLoad": true
-                    }
-                }
-            }
         }
     },
     "Instances": {
@@ -12119,6 +12054,26 @@
                     "op": "replace",
                     "path": "/ContainerEntity/Components/Component_[8875781117888677262]/Transform Data/Translate/2",
                     "value": 0.8977532386779785
+                }
+            ]
+        },
+        "Instance_[10391347535934]": {
+            "Source": "Prefabs/UI.prefab",
+            "Patches": [
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[11968026641926863763]/Parent Entity",
+                    "value": "../Entity_[356758116574]"
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[11968026641926863763]/Transform Data/Translate/1",
+                    "value": 12.499994277954102
+                },
+                {
+                    "op": "replace",
+                    "path": "/ContainerEntity/Components/Component_[11968026641926863763]/Transform Data/Translate/2",
+                    "value": 4.017059803009033
                 }
             ]
         },


### PR DESCRIPTION
The GameplayTest level was nearly unusable because it had the InGameMenu screen always visible. I removed the BasicHUD and InGameMenu screens from the level and replaced it with the UI prefab, which includes both of those, the settings screen, the disconnect screen, and the UI manager.

The InGameMenu now only shows up when pressing Esc or 1, the settings screen works, etc.