### PR TITLE
Fix Linux type conversion errors

### DIFF
--- a/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp
+++ b/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp
@@ -125,7 +125,7 @@ namespace MultiplayerSample
     uint8_t MultiplayerSampleUserSettings::GetMasterVolume()
     {
         // Default to full volume (100)
-        uint64_t masterVolume = 100;
+        AZ::u64 masterVolume = 100;
 
         if (auto* registry = AZ::SettingsRegistry::Get(); registry != nullptr)
         {
@@ -158,13 +158,13 @@ namespace MultiplayerSample
                 }
             }
 
-            registry->Set(m_masterVolumeKey.c_str(), aznumeric_cast<uint64_t>(masterVolume));
+            registry->Set(m_masterVolumeKey.c_str(), aznumeric_cast<AZ::u64>(masterVolume));
         }
     }
 
     int16_t MultiplayerSampleUserSettings::GetTextureQuality()
     {
-        int64_t textureQuality = 1;
+        AZ::s64 textureQuality = 1;
 
         if (auto* registry = AZ::SettingsRegistry::Get(); registry != nullptr)
         {
@@ -184,7 +184,7 @@ namespace MultiplayerSample
                 pool->SetMipBias(textureQuality);
             }
 
-            registry->Set(m_textureQualityKey.c_str(), aznumeric_cast<int64_t>(textureQuality));
+            registry->Set(m_textureQualityKey.c_str(), aznumeric_cast<AZ::s64>(textureQuality));
         }
     }
 
@@ -227,8 +227,8 @@ namespace MultiplayerSample
 
     AZStd::pair<uint32_t, uint32_t> MultiplayerSampleUserSettings::GetResolution()
     {
-        uint64_t width = 1920;
-        uint64_t height = 1080;
+        AZ::u64 width = 1920;
+        AZ::u64 height = 1080;
 
         if (auto* registry = AZ::SettingsRegistry::Get(); registry != nullptr)
         {
@@ -276,8 +276,8 @@ namespace MultiplayerSample
                 }
             }
 
-            registry->Set(m_resolutionWidthKey.c_str(), aznumeric_cast<uint64_t>(resolution.first));
-            registry->Set(m_resolutionHeightKey.c_str(), aznumeric_cast<uint64_t>(resolution.second));
+            registry->Set(m_resolutionWidthKey.c_str(), aznumeric_cast<AZ::u64>(resolution.first));
+            registry->Set(m_resolutionHeightKey.c_str(), aznumeric_cast<AZ::u64>(resolution.second));
         }
     }
 


### PR DESCRIPTION
Fix Linux build issues with latest changes

* Removes registry type warnings of the form

```
/data/workspace/o3de-multiplayersample/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp:279:23: error: call to member function 'Set' is ambiguous
            registry->Set(m_resolutionWidthKey.c_str(), aznumeric_cast<uint64_t>(resolution.first));
            ~~~~~~~~~~^~~
/data/workspace/o3de/Code/Framework/AzCore/./AzCore/Settings/SettingsRegistry.h:295:22: note: candidate function
        virtual bool Set(AZStd::string_view path, bool value) = 0;
                     ^
/data/workspace/o3de/Code/Framework/AzCore/./AzCore/Settings/SettingsRegistry.h:300:22: note: candidate function
        virtual bool Set(AZStd::string_view path, s64 value) = 0;
                     ^
/data/workspace/o3de/Code/Framework/AzCore/./AzCore/Settings/SettingsRegistry.h:301:22: note: candidate function
        virtual bool Set(AZStd::string_view path, u64 value) = 0;
                     ^
/data/workspace/o3de/Code/Framework/AzCore/./AzCore/Settings/SettingsRegistry.h:306:22: note: candidate function
        virtual bool Set(AZStd::string_view path, double value) = 0;
                     ^
In file included from /data/workspace/o3de-multiplayersample/build/linux/External/Gem-f6f5d0f3/Code/CMakeFiles/MultiplayerSample.dir/Unity/unity_0_cxx.cxx:5:
/data/workspace/o3de-multiplayersample/Gem/Code/Source/UserSettings/Mu
```