### PR TITLE
MPSGameLift: Adding GameLift Runtime Dependencies

### DIFF
--- a/MPSGameLift/Code/CMakeLists.txt
+++ b/MPSGameLift/Code/CMakeLists.txt
@@ -64,7 +64,6 @@ ly_add_target(
             Gem::AWSCore.Static
             Gem::AWSGameLift.Client.Static
             Gem::LyShine.Static
-
 )
 
 ly_add_target(
@@ -137,7 +136,6 @@ ly_add_target(
             Gem::AWSCore.Static
             Gem::AWSGameLift.Client.Static
             Gem::${gem_name}.Client.Private.Object
-
     RUNTIME_DEPENDENCIES
         Gem::AWSGameLift.Clients
 )
@@ -159,7 +157,6 @@ ly_add_target(
         PRIVATE
             Gem::Multiplayer.Server.Static
             Gem::${gem_name}.Server.Private.Object
-
     RUNTIME_DEPENDENCIES
         Gem::AWSGameLift.Servers
 )

--- a/MPSGameLift/Code/CMakeLists.txt
+++ b/MPSGameLift/Code/CMakeLists.txt
@@ -137,6 +137,9 @@ ly_add_target(
             Gem::AWSCore.Static
             Gem::AWSGameLift.Client.Static
             Gem::${gem_name}.Client.Private.Object
+
+    RUNTIME_DEPENDENCIES
+        Gem::AWSGameLift.Clients
 )
 
 ly_add_target(
@@ -156,6 +159,9 @@ ly_add_target(
         PRIVATE
             Gem::Multiplayer.Server.Static
             Gem::${gem_name}.Server.Private.Object
+
+    RUNTIME_DEPENDENCIES
+        Gem::AWSGameLift.Servers
 )
 
 ly_add_target(

--- a/MPSGameLift/Scripts/export_gamelift_server_package.py
+++ b/MPSGameLift/Scripts/export_gamelift_server_package.py
@@ -52,7 +52,7 @@ while not args.code and not args.assets:
 
 # Help user choose their compiler if they didn't specify via command-line
 while not args.generator:
-    user_input = input('Select generator:\n 1. Visual Studio 16\n 2. Visual Studio 17.\n Quit(q)\n')
+    user_input = input('Select generator:\n 1. Visual Studio 16 (2019)\n 2. Visual Studio 17 (2022).\n Quit(q)\n')
     if user_input == '1':
         args.generator = "Visual Studio 16"
     if user_input == '2':
@@ -65,10 +65,7 @@ build_folder = os.path.join(o3de_context.project_path, "build", "windows")
 # Build code
 if (args.code):
     # Enable GameLift gems
-    o3de_logger.info(f"Enabling AWSGameLift and MPSGameLift gem")
-    if (enable_gem.enable_gem_in_project(gem_name="AWSGameLift", project_path=o3de_context.project_path) != 0):
-        quit()
-
+    o3de_logger.info(f"Enabling MPSGameLift gem")
     if (enable_gem.enable_gem_in_project(gem_name="MPSGameLift", project_path=o3de_context.project_path) != 0):
         quit()
 


### PR DESCRIPTION
Adding GameLift runtime dependencies for MPSGameLift so that the GameLift system components are added.

Fixes https://github.com/o3de/o3de/issues/15829

Tested by adding MPSGameLift to project.json gem dependencies, and then running the gamelauncher, serverlauncher, and unifiedlauncher and seeing everything work as normal (not crash)