### PR TITLE
UnifiedLauncher Can Connect to GameLift Server

### DIFF
--- a/MPSGameLift/Code/CMakeLists.txt
+++ b/MPSGameLift/Code/CMakeLists.txt
@@ -108,12 +108,13 @@ ly_add_target(
             AZ::AzFramework
             Gem::Multiplayer
             Gem::LyShine
-
         PRIVATE
             Gem::Multiplayer.Unified.Static
             Gem::AWSCore.Static
             Gem::AWSGameLift.Client.Static
             Gem::LyShine.Static
+    RUNTIME_DEPENDENCIES
+        Gem::AWSGameLift.Clients
 )
 
 # Here add ${gem_name} target, it depends on the Private Object library and Public API interface
@@ -177,6 +178,11 @@ ly_add_target(
             Gem::${gem_name}.API
         PRIVATE
             Gem::${gem_name}.Unified.Private.Object
+            Gem::Multiplayer.Unified.Static
+            Gem::AWSCore.Static
+            Gem::AWSGameLift.Client.Static  # Unified launchers are considered clients to GameLift
+    RUNTIME_DEPENDENCIES
+        Gem::AWSGameLift.Clients
 )
 
 # By default, we will specify that the above target ${gem_name} would be used by


### PR DESCRIPTION
Change allows unified launcher to act as a GameLift client in order to connect to GameLift server.
Fixes #406 

Tested by connecting Unified Launcher to a GameLift server
Tested by running UnifiedLauncher and ensuring AZ_TRAIT_CLIENT is still 1 and AZ_TRAIT_SERVER is still 1
Tested by running ServerLauncher and ensuring AZ_TRAIT_CLIENT is still 0 and AZ_TRAIT_SERVER is still 1
Tested by running GameLauncher and ensuring AZ_TRAIT_CLIENT is still 1 and AZ_TRAIT_SERVER is still 0