### PR TITLE
Added a cvar that will enable shadow cascade optimization whereby you…

### DIFF
--- a/Registry/multiplayersample.setreg
+++ b/Registry/multiplayersample.setreg
@@ -19,9 +19,14 @@
 					"ImageSystemDescriptor": {
 						"SystemStreamingImagePoolSize": 0,
 						"SystemAttachmentImagePoolSize": 0,
-                        "SystemStreamingImagePoolMipBias": 1
+						"SystemStreamingImagePoolMipBias": 1
 					}
 				}
+			}
+		},
+		"Autoexec": {
+			"ConsoleCommands": {
+				"r_shadowCascadeExtrusionAmount": 20
 			}
 		}
 	}


### PR DESCRIPTION
… can reject octree nodes that dont intersect with camera frustum.

Companion PR in the core engine - https://github.com/o3de/o3de/pull/16032