### PR TITLE
Stop Generating 2 Player Sessions

### DIFF
--- a/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.cpp
+++ b/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.cpp
@@ -20,7 +20,9 @@
 
 #include <Multiplayer/Session/SessionRequests.h>
 #include <Request/AWSGameLiftSessionRequestBus.h>
-
+#include <AzCore/Jobs/JobContext.h>
+#include <AzCore/Jobs/JobFunction.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
 
 namespace MPSGameLift
 {
@@ -59,7 +61,6 @@ namespace MPSGameLift
 
     void UiGameLiftConnectWithPlayerSessionData::Activate()
     {
-        Multiplayer::SessionAsyncRequestNotificationBus::Handler::BusConnect();
         UiCursorBus::Broadcast(&UiCursorInterface::IncrementVisibleCounter);
 
         // Listen for button presses
@@ -84,8 +85,6 @@ namespace MPSGameLift
     {
         m_onConnectToHostFailed.Disconnect();
         UiCursorBus::Broadcast(&UiCursorInterface::DecrementVisibleCounter);
-
-        Multiplayer::SessionAsyncRequestNotificationBus::Handler::BusDisconnect();
     }
 
     void UiGameLiftConnectWithPlayerSessionData::OnJSONChanged(const AZStd::string& gameLiftJsonString)
@@ -95,12 +94,12 @@ namespace MPSGameLift
 
         if (gameLiftJsonString.empty())
         {
-            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Please provide GameLift GameSessionId and PlayerSessionId in JSON format!");
+            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Please provide GameLift player connection information in JSON format!");
             return;
         }
         
         // Parse GameLift JSON
-        m_request = {};
+        m_sessionConnectionConfig = {};
         rapidjson::Document document;
         document.Parse(gameLiftJsonString.c_str());
 
@@ -110,35 +109,51 @@ namespace MPSGameLift
             return;
         }
 
-        if (!document.HasMember("GameSessionId"))
-        {
-            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Missing GameSessionId!");
-            return;
-        }
-
+        // Alert the user if any information is missing from the JSON they provided
         if (!document.HasMember("PlayerSessionId"))
         {
             UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Missing PlayerSessionId!");
             return;
         }
 
-        const rapidjson::Value& gameSessionId = document["GameSessionId"];
-        if (!gameSessionId.IsString())
+        if (!document.HasMember("IpAddress") && !document.HasMember("DnsName"))
         {
-            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Invalid GameSessionId!");
+            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Must provide either an IpAddress or DnsName!");
             return;
+        }
+
+        if (!document.HasMember("Port"))
+        {
+            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Missing Port!");
+            return;
+        }
+
+        const rapidjson::Value& port = document["Port"];
+        if (!port.IsUint())
+        {
+            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Invalid Port!");
+            return;
+        }
+
+        // Fill out SessionConnectionConfig and try connecting to host
+        if (document.HasMember("IpAddress"))
+        {
+            const rapidjson::Value& ipAddress = document["IpAddress"];
+            m_sessionConnectionConfig.m_ipAddress = ipAddress.GetString();
+        }
+
+        if (document.HasMember("DnsName"))
+        {
+            const rapidjson::Value& dnsName = document["DnsName"];
+            m_sessionConnectionConfig.m_dnsName = dnsName.GetString();
         }
 
         const rapidjson::Value& playerSessionId = document["PlayerSessionId"];
-        if (!playerSessionId.IsString())
-        {
-            UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Invalid PlayerSessionId!");
-            return;
-        }
+
+        m_sessionConnectionConfig.m_port = aznumeric_cast<uint16_t>(port.GetUint());
+        m_sessionConnectionConfig.m_playerSessionId = playerSessionId.GetString();
 
         UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "");
-        m_request.m_sessionId = gameSessionId.GetString();
-        m_request.m_playerId = playerSessionId.GetString();
         UiInteractableBus::Event(m_connectButtonUi, &UiInteractableInterface::SetIsHandlingEvents, true);
     }
 
@@ -162,9 +177,16 @@ namespace MPSGameLift
             // Enable blocker ui while we attempt connection
             UiElementBus::Event(m_attemptConnectionBlockerUi, &UiElementInterface::SetIsEnabled, true);
 
-            AWSGameLift::AWSGameLiftSessionAsyncRequestBus::Broadcast(
-                &AWSGameLift::AWSGameLiftSessionAsyncRequestBus::Events::JoinSessionAsync, m_request);
-            return;
+            if (auto clientRequestHandler = AZ::Interface<Multiplayer::ISessionHandlingClientRequests>::Get())
+            {
+                clientRequestHandler->RequestPlayerJoinSession(m_sessionConnectionConfig);
+            }
+            else
+            {
+                AZ_Assert(false, "UiGameLiftConnectWithPlayerSessionData failed to connect because there's no ISessionHandlingClientRequests registered. " 
+                    "Please update code to ensure an ISessionHandlingClientRequests has been created before trying to connect this client to a host!");
+            }
+
         }
         
         if (buttonEntityId == m_connectToHostFailedUi)
@@ -178,17 +200,5 @@ namespace MPSGameLift
     {
         UiElementBus::Event(m_attemptConnectionBlockerUi, &UiElementInterface::SetIsEnabled, false);
         UiElementBus::Event(m_connectToHostFailedUi, &UiElementInterface::SetIsEnabled, true);
-    }
-
-    void UiGameLiftConnectWithPlayerSessionData::OnJoinSessionAsyncComplete(bool joinSessionsResponse)
-    {
-        UiElementBus::Event(m_attemptConnectionBlockerUi, &UiElementInterface::SetIsEnabled, false);
-
-        if (!joinSessionsResponse)
-        {
-            UiElementBus::Event(m_connectToHostFailedUi, &UiElementInterface::SetIsEnabled, true);
-        }
-    }
-
-    
+    }    
 } // namespace MultiplayerSample

--- a/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.h
+++ b/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.h
@@ -11,8 +11,7 @@
 #include <AzCore/Component/Component.h>
 #include <Multiplayer/IMultiplayer.h>
 
-#include <Request/AWSGameLiftJoinSessionRequest.h>
-#include <Multiplayer/Session/ISessionRequests.h>
+#include <Multiplayer/Session/ISessionHandlingRequests.h>
 
 namespace MPSGameLift
 {
@@ -21,8 +20,7 @@ namespace MPSGameLift
      * \brief An example ui component used for connecting to GameLift using a user-provided JSON string that contains the game-session-id and player-session-id.
     */
     class UiGameLiftConnectWithPlayerSessionData
-        : public AZ::Component,
-          Multiplayer::SessionAsyncRequestNotificationBus::Handler
+        : public AZ::Component
     {
     public:
         AZ_COMPONENT(MPSGameLift::UiGameLiftConnectWithPlayerSessionData, "{328C97C3-D4BC-4A07-94F1-E1462908FC7A}");
@@ -36,13 +34,7 @@ namespace MPSGameLift
         void Activate() override;
         void Deactivate() override;
 
-    private:
-        //! Multiplayer::SessionAsyncRequestNotificationBus overrides...
-        void OnCreateSessionAsyncComplete(const AZStd::string& ) override {}
-        void OnSearchSessionsAsyncComplete(const Multiplayer::SearchSessionsResponse& ) override {}
-        void OnJoinSessionAsyncComplete(bool joinSessionsResponse) override;
-        void OnLeaveSessionAsyncComplete() override {}
-        
+    private:        
         // Listen for disconnect events to know if connecting to the host server failed
         void OnConnectToHostFailed();
         Multiplayer::EndpointDisconnectedEvent::Handler m_onConnectToHostFailed{[this]([[maybe_unused]] Multiplayer::MultiplayerAgentType agent) { OnConnectToHostFailed(); }};
@@ -56,6 +48,6 @@ namespace MPSGameLift
         AZ::EntityId m_attemptConnectionBlockerUi;
         AZ::EntityId m_connectToHostFailedUi;
         AZ::EntityId m_jsonParseFailTextUi;
-        AWSGameLift::AWSGameLiftJoinSessionRequest m_request;
+        Multiplayer::SessionConnectionConfig m_sessionConnectionConfig;
     };
 } // namespace MultiplayerSample

--- a/MPSGameLift/Documentation/GameLift.md
+++ b/MPSGameLift/Documentation/GameLift.md
@@ -154,11 +154,6 @@ If the operation fails, make sure the server is running. Ensure that `InitSDK` a
 ```
 
 Once started, the client should show a text area where the session information needs to be pasted into. You may need to press `~` on your keyboard to open the console and release the cursor from being bound to the client window.
-It is recommended to prepare this JSON object in advance as the `PlayerSessionId` generated in the next step is only valid for 60 seconds.
-
-```json
-{ "GameSessionId": "<GameSessionId>", "PlayerId": "PlayerId", "PlayerSessionId": "<PlayerSessionId>" }
-```
 
 ### Create a Player Session
 
@@ -173,7 +168,7 @@ Record the `PlayerSessionId` for the next steps. Example: **psess-1a2b3c45-d6e7-
 
 ### Connect the Client
 
-Add the `PlayerSessionId` into the JSON and paste the JSON into the textarea inside the Client, then press "Connect".
+Copy and paste the player session JSON table output into the textarea inside the Client, then press "Connect".
 The client should now successfully connect to your local server.
 
 
@@ -229,7 +224,18 @@ Record PlayerSessionId and use this in the game immediately because it expires a
 
 ---
 
-Paste in the game session and player session and click Connect. 
+Paste the player session JSON table output into the textbox and press "Connect".
+For example,
 ```json
-{ "GameSessionId": "<GameSessionId>", "PlayerId": "player_id", "PlayerSessionId": "<PlayerSessionId>" }
+    {
+        "PlayerSessionId": "psess-6a9a7352-8ee9-407f-ad06-cd09ba7c3ca2",
+        "PlayerId": "Player1",
+        "GameSessionId": "arn:aws:gamelift:us-west-2::gamesession/fleet-1b49cff7-eb2b-4f74-866a-959da3e9cf1f/custom-location-1/gsess-5850bac5-d4fb-4588-a489-c3b62bd5f099",
+        "FleetId": "fleet-1b49cff7-eb2b-4f74-866a-959da3e9cf1f",
+        "FleetArn": "arn:aws:gamelift:us-west-2:353687041169:fleet/fleet-1b49cff7-eb2b-4f74-866a-959da3e9cf1f",
+        "CreationTime": "2023-06-08T14:32:12.811000-07:00",
+        "Status": "RESERVED",
+        "IpAddress": "127.0.0.1",
+        "Port": 33450
+    }
 ```

--- a/MPSGameLift/UICanvases/GameLiftConnectJson.uicanvas
+++ b/MPSGameLift/UICanvases/GameLiftConnectJson.uicanvas
@@ -1952,7 +1952,7 @@
 									<Class name="AZ::Component" field="BaseClass1" type="{EDFCB2CF-F75D-43BE-B26B-F35821B29247}">
 										<Class name="AZ::u64" field="Id" value="10420096347349500043" type="{D6597933-47CD-4FC8-B911-63F3E2B0993A}"/>
 									</Class>
-									<Class name="AZStd::string" field="Text" value="&lt;fail message&gt;" type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
+									<Class name="AZStd::string" field="Text" value="Validate player session data and try again." type="{03AAAB3F-5C47-5A66-9EBC-D5FA4DB353C9}"/>
 									<Class name="bool" field="MarkupEnabled" value="false" type="{A0CA880C-AFE4-43CB-926C-59AC48496112}"/>
 									<Class name="Color" field="Color" value="1.0000000 1.0000000 1.0000000 1.0000000" type="{7894072A-9050-4F0F-901B-34B1A0D29417}"/>
 									<Class name="float" field="Alpha" value="1.0000000" type="{EA2C3E90-AFBE-44D4-A90D-FAAF79BAF93D}"/>


### PR DESCRIPTION
Fix to properly use the player session data. 
Before this change the menu was using a AWS method to create a new player session... in this case, the developer already has the player session

Fixes #431 