### PR TITLE
Automatically Connect Client to Proper AWS Region

### DIFF
--- a/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.cpp
+++ b/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.cpp
@@ -129,15 +129,7 @@ namespace MPSGameLift
             gameLiftArn = fleetArn.GetString();
         }
 
-        const uint32_t regionIndex = 3; // Region is the 4th value in a GameLift Arn. arn:aws:gamelift:<region>
-        AZStd::vector<AZStd::string> tokenizedGameLiftArn;
-        AZ::StringFunc::Tokenize(gameLiftArn, tokenizedGameLiftArn, ":");
-
-        if (tokenizedGameLiftArn.size() >= regionIndex)
-        {
-            m_region = tokenizedGameLiftArn[regionIndex];
-        }
-
+        m_region = AWSCore::Util::ExtractRegion(gameLiftArn);
         if (m_region.empty())
         {
             UiTextBus::Event(m_jsonParseFailTextUi, &UiTextInterface::SetText, "Failed to extract AWS region. Provide either a valid GameSessionId or FleetArn!");

--- a/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.cpp
+++ b/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.cpp
@@ -10,7 +10,6 @@
 
 #include <AzCore/Serialization/SerializeContext.h>
 #include <AzCore/Serialization/EditContext.h>
-#include <AzCore/StringFunc/StringFunc.h>
 
 #include <LyShine/Bus/UiButtonBus.h>
 #include <LyShine/Bus/UiCursorBus.h>

--- a/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.h
+++ b/MPSGameLift/Code/Source/Components/UI/UiGameLiftConnectWithPlayerSessionData.h
@@ -49,5 +49,6 @@ namespace MPSGameLift
         AZ::EntityId m_connectToHostFailedUi;
         AZ::EntityId m_jsonParseFailTextUi;
         Multiplayer::SessionConnectionConfig m_sessionConnectionConfig;
+        AZStd::string m_region;
     };
 } // namespace MultiplayerSample

--- a/MPSGameLift/Code/Source/MPSGameLiftClientSystemComponent.cpp
+++ b/MPSGameLift/Code/Source/MPSGameLiftClientSystemComponent.cpp
@@ -8,7 +8,6 @@
 #include "MPSGameLiftClientSystemComponent.h"
 
 #include <AzCore/Serialization/SerializeContext.h>
-#include <Request/AWSGameLiftRequestBus.h>
 #include <Request/AWSGameLiftSessionRequestBus.h>
 #include <Request/AWSGameLiftJoinSessionRequest.h>
 
@@ -45,8 +44,10 @@ namespace MPSGameLift
 
     void MPSGameLiftClientSystemComponent::Activate()
     {
-        AWSGameLift::AWSGameLiftRequestBus::Broadcast(&AWSGameLift::AWSGameLiftRequestBus::Events::ConfigureGameLiftClient, "");
+        auto loadLevelCommand = AZStd::string::format("LoadLevel %s", "mpsgamelift/prefabs/GameLiftConnectJsonMenu.spawnable");
+        AZ::Interface<AZ::IConsole>::Get()->PerformCommand(loadLevelCommand.c_str());        
     } 
+
     void MPSGameLiftClientSystemComponent::Deactivate()
     {
     }

--- a/MPSGameLift/Code/Source/MPSGameLiftClientSystemComponent.cpp
+++ b/MPSGameLift/Code/Source/MPSGameLiftClientSystemComponent.cpp
@@ -7,6 +7,7 @@
 
 #include "MPSGameLiftClientSystemComponent.h"
 
+#include <Framework/Util.h>
 #include <AzCore/Serialization/SerializeContext.h>
 #include <Request/AWSGameLiftJoinSessionRequest.h>
 #include <Request/AWSGameLiftRequestBus.h>
@@ -72,15 +73,8 @@ namespace MPSGameLift
 
         // Configure the GameLift client with the proper region; 
         // Note: fallback region is defined inside default_aws_resource_mappings.json
-        AZStd::string region;
-        const uint32_t regionIndex = 3; // Region is the 4th value in a GameLift Arn. arn:aws:gamelift:<region>
-        AZStd::vector<AZStd::string> tokenizedGameLiftArn;
-        AZ::StringFunc::Tokenize(gameSessionId, tokenizedGameLiftArn, ":");
-        if (tokenizedGameLiftArn.size() >= regionIndex)
-        {
-            region = tokenizedGameLiftArn[regionIndex];
-        }
-        
+        AZStd::string region = AWSCore::Util::ExtractRegion(gameSessionId);
+
         AWSGameLift::AWSGameLiftRequestBus::Broadcast(&AWSGameLift::AWSGameLiftRequestBus::Events::ConfigureGameLiftClient, region);
 
         AWSGameLift::AWSGameLiftSessionAsyncRequestBus::Broadcast(

--- a/MPSGameLift/Code/Source/MPSGameLiftClientSystemComponent.h
+++ b/MPSGameLift/Code/Source/MPSGameLiftClientSystemComponent.h
@@ -30,6 +30,8 @@ namespace MPSGameLift
         void Activate() override;
         void Deactivate() override;
 
+        // Join a GameLift game session.
+        // Internally, GameLift will use the game session id to generate new player session id and pass it back to this client as a ticket for connecting to the host server on GameLift.
         void JoinSession(const AZ::ConsoleCommandContainer& consoleFunctionParameters);
         AZ_CONSOLEFUNC(MPSGameLiftClientSystemComponent, JoinSession, AZ::ConsoleFunctorFlags::DontReplicate, "Join an existing game session");
 

--- a/MPSGameLift/Documentation/GameLift.md
+++ b/MPSGameLift/Documentation/GameLift.md
@@ -14,12 +14,6 @@ This README covers optional setup, testing and running on [Amazon GameLift](http
     ```
     Even if you have already installed the AWS CLI, ensure it is updated as some commands may not be available on older versions.
 
-1. Work in progress (WiP) step: Add your AWS region to Config/default_aws_resource_mappings.json (example: "Region": "us-west-2")
-
-    a. Currently needed otherwise when the client initializes GameLift there will be an error about not having a region.
-
-    b. This step will be removed once we properly parse the game-session data which contains the fleet-id, region-id, etc  
-
 1. Use Export Project to Compile Code and Build Assets
 
     ```sh
@@ -150,7 +144,7 @@ If the operation fails, make sure the server is running. Ensure that `InitSDK` a
 ### Start Client
 
 ```sh
-<path-to-multiplayer-sample>\build\windows_mono\bin\profile\MultiplayerSample.GameLauncher.exe -bg_ConnectToAssetProcessor=0 --loadlevel="mpsgamelift/prefabs/GameLiftConnectJsonMenu.spawnable"
+<path-to-multiplayer-sample>\build\windows_mono\bin\profile\MultiplayerSample.GameLauncher.exe -bg_ConnectToAssetProcessor=0
 ```
 
 Once started, the client should show a text area where the session information needs to be pasted into. You may need to press `~` on your keyboard to open the console and release the cursor from being bound to the client window.
@@ -192,7 +186,7 @@ Record BuildId for the next step. Example: **build-1a23bc4d-456e-78fg-h9i0-jk1l2
 After running this command it'll take about an hour for the fleet to activate. Check the status on the GameLift dashboard. 
 
 ```sh
-aws gamelift create-fleet --region <Region> --name GameLiftO3DTest2016 --ec2-instance-type c5.large --fleet-type ON_DEMAND --build-id <BuildId> --runtime-configuration "GameSessionActivationTimeoutSeconds=300, ServerProcesses=[{LaunchPath=C:\game\MultiplayerSample.ServerLauncher.exe, Parameters= --rhi=null -sys_PakPriority=2 -NullRenderer -sv_terminateOnPlayerExit=true -bg_ConnectToAssetProcessor=0 --sv_gameLiftEnabled=true --sv_dedicated_host_onstartup=false --console-command-file=launch_server.cfg, ConcurrentExecutions=1}]" --ec2-inbound-permissions "FromPort=33450,ToPort=34449,IpRange=0.0.0.0/0,Protocol=UDP"
+aws gamelift create-fleet --region <Region> --name GameLiftO3DTest --ec2-instance-type c5.large --fleet-type ON_DEMAND --build-id <BuildId> --runtime-configuration "GameSessionActivationTimeoutSeconds=300, ServerProcesses=[{LaunchPath=C:\game\MultiplayerSample.ServerLauncher.exe, Parameters= --rhi=null -sys_PakPriority=2 -NullRenderer -sv_terminateOnPlayerExit=true -bg_ConnectToAssetProcessor=0 --sv_gameLiftEnabled=true --sv_dedicated_host_onstartup=false --console-command-file=launch_server.cfg, ConcurrentExecutions=1}]" --ec2-inbound-permissions "FromPort=33450,ToPort=34449,IpRange=0.0.0.0/0,Protocol=UDP"
 ```
 ---
 **NOTE**
@@ -212,7 +206,7 @@ Record GameSessionId for the next step. Example: **arn:aws:gamelift:us-west-2::g
 
 Launch the game client with:
 ```sh
-<path-to-multiplayer-sample>\build\windows_mono\bin\profile\MultiplayerSample.GameLauncher.exe -bg_ConnectToAssetProcessor=0 --loadlevel="mpsgamelift/prefabs/GameLiftConnectJsonMenu.spawnable"
+<path-to-multiplayer-sample>\build\windows_mono\bin\profile\MultiplayerSample.GameLauncher.exe -bg_ConnectToAssetProcessor=0
 ```
 ```sh
 aws gamelift create-player-session --region <Region> --game-session-id <GameSessionId> --player-id Player1


### PR DESCRIPTION
1) Automatically extract the AWS region via from the game session id (thus avoiding developers having to hand-set the region inside of a config)
3) If MPS Gamelift gem is enabled, automatically open the GameLift Connect Menu on startup (avoids confusing issue where users could load the level even though the gem isn't enabled. This way, if that menu doesn't load, you'll know right away that the gem hasn't been enabled)
2) Updated README to remove manual steps

Fixes #434

Tested by:
1) Connect GameLauncher to GameLift server via MPSGameLiftClientSystemComponent.JoinSession console command
2) Connect GameLauncher to GameLift server via JSON connection menu