### PR TITLE
Mps export feedback patch

### DIFF
--- a/ExportScripts/export_standalone_monolithic_windows.py
+++ b/ExportScripts/export_standalone_monolithic_windows.py
@@ -200,7 +200,7 @@ if __name__ == "__main__":
     parser.add_argument('-aof', '--archive-output-format',
                         type=str,
                         help="Format of archive to create from the output directory",
-                        choices=["none", "zip", "gzip", "bz2", "xz"], default="none")
+                        choices=["zip", "gzip", "bz2", "xz"], default="zip")
     parser.add_argument('-bnmt', '--build-non-mono-tools', action='store_true')
     parser.add_argument('-nmbp', '--non-mono-build-path', type=pathlib.Path, default=None)
     parser.add_argument('-mbp', '--mono-build-path', type=pathlib.Path, default=None)
@@ -253,7 +253,7 @@ if __name__ == "__main__":
     if not asset_bundler_batch_path.is_file():
         logger.error(f"AssetBundlerBatch not found at path '{asset_bundler_batch_path}'. In order to bundle the data for MPS, this executable must be present!")
         logger.error("To correct this issue, do 1 of the following: "
-                     "1) use the --build-non-mono-tools flag in the CLI parameters"
+                     "1) Use the --build-non-mono-tools flag in the CLI parameters"
                      "2) If you are trying to build in a project-centric fashion, please switch to engine-centric for this export script"
                      f"3) Build AssetBundlerBatch by hand and make sure it is available at {asset_bundler_batch_path}"
                      "4) Set the --non-mono-build-path to point at a directory which contains this executable")


### PR DESCRIPTION
This PR is for addressing feedback left at the end of the previous PR: https://github.com/o3de/o3de-multiplayersample/pull/433

This PR also includes a fix for the following issue: https://github.com/o3de/o3de-multiplayersample/issues/438

#### Testing
The export script has now been tested with the development branch and main branch of o3de and o3de-multiplayer-sample on windows.

The script is able to create a release bundle ready for play using both the release and profile configurations.

#### Out of Scope
This PR does not address adding a testing/validation layer for the script, nor the ability to swap to project-centric  mode. That will be included in a future PR. This is just to fix issues with the existing script.
This script is also only tested for windows. There will be a dedicated PR for updating the script to be cross platform for Linux.