### PR TITLE
Project-related updates for Multiplayer sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _savebackup/
 [Uu]ser/
 Sounds/wwise_project/*.wsettings
 CMakeUserPresets.json
+*.code-workspace

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,18 @@
+{
+    "version": 4,
+    "cmakeMinimumRequired": {
+        "major": 3,
+        "minor": 23,
+        "patch": 0
+    },
+    "include": [
+        "user/cmake/engine/CMakePresets.json"
+    ],
+    "buildPresets": [
+        {
+            "name": "build_profile",
+            "description": "",
+            "displayName": ""
+        }
+    ]
+}

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -7,12 +7,5 @@
     },
     "include": [
         "user/cmake/engine/CMakePresets.json"
-    ],
-    "buildPresets": [
-        {
-            "name": "build_profile",
-            "description": "",
-            "displayName": ""
-        }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -9,3 +9,4 @@
         "user/cmake/engine/CMakePresets.json"
     ]
 }
+

--- a/project.json
+++ b/project.json
@@ -26,5 +26,6 @@
         "particlefx_mps",
         "pbr_material_pack_mps",
         "PopcornFX"
-    ]
+    ],
+    "engine_version": "2.1.0"
 }


### PR DESCRIPTION
Minor updates to project related files to better support VS Code
- Add *.code-workspace to gitignore to support multi-root workspaces (project-central)
- Add new CMakePresets.json (which is now in the create project template) to enable presets to work
- Add missing 'engine_version' project.json entry
