### PR TITLE
Fix formatting error related to linux integer types

### DIFF
--- a/MPSGameLift/Code/Source/MatchmakingSystemComponent.cpp
+++ b/MPSGameLift/Code/Source/MatchmakingSystemComponent.cpp
@@ -264,7 +264,7 @@ namespace MPSGameLift
         AZStd::string httpLatenciesParam;
         for (auto const& [region, latencyMs] : regionalLatencies)
         {
-            httpLatenciesParam += AZStd::string::format("%s_%lld ", region.c_str(), latencyMs.count());
+            httpLatenciesParam += AZStd::string::format("%s_%" PRIi64, region.c_str(), latencyMs.count());
         }
 
         httpLatenciesParam.pop_back();  // pop the trailing white-space


### PR DESCRIPTION
Fixes the following Linux compile error:
```
PRIu64/home/o3de/github/o3de-multiplayersample/MPSGameLift/Code/Source/MatchmakingSystemComponent.cpp:267:85: error: format specifies type 'long long' but the argument has type 'std::chrono::duration<long, std::ratio<1, 1000>>::rep' (aka 'long') [-Werror,-Wformat]
            httpLatenciesParam += AZStd::string::format("%s_%lld ", region.c_str(), latencyMs.count());
```