### PR TITLE
Fixed crash in unified launcher when showing the scoreboard

### DIFF
--- a/Gem/Code/Source/Components/Multiplayer/MatchPlayerCoinsComponent.cpp
+++ b/Gem/Code/Source/Components/Multiplayer/MatchPlayerCoinsComponent.cpp
@@ -23,15 +23,16 @@ namespace MultiplayerSample
 
     void MatchPlayerCoinsComponent::OnActivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
-        if (IsNetEntityRoleClient())
-        {
-            AZ::Interface<MatchPlayerCoinsComponent>::Register(this);
-        }
+#if AZ_TRAIT_CLIENT
+        AZ::Interface<MatchPlayerCoinsComponent>::Register(this);
+#endif
     }
 
     void MatchPlayerCoinsComponent::OnDeactivate([[maybe_unused]] Multiplayer::EntityIsMigrating entityIsMigrating)
     {
+#if AZ_TRAIT_CLIENT
         AZ::Interface<MatchPlayerCoinsComponent>::Unregister(this);
+#endif
     }
 
     AZStd::vector<PlayerCoinState> MatchPlayerCoinsComponent::GetPlayerCoinCounts() const


### PR DESCRIPTION
Fixed crash when using the unified launcher for MPS when attempting to show the scoreboard (by pressing TAB or at the end of a round). This was because the `MatchPlayerCoinsComponent` was checking the net entity role to determine when it should register its interface, when it should really be checking the `AZ_TRAIT_CLIENT` define, which will be true for both the normal client and the unified client.

Tested both the unified and game launchers and verified the scoreboard works properly for both.