### PR TITLE
Fixed audio not working in unified launcher

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -102,6 +102,7 @@ ly_add_target(
             Gem::PhysX
             Gem::PopcornFX.Static
             Gem::Multiplayer
+            Gem::AudioSystem.API
         PRIVATE
             Gem::LmbrCentral.Static
             Gem::Multiplayer.Unified.Static


### PR DESCRIPTION
This is part of the fix for audio not working in the MultiplayerSample unified launcher. The unified target now properly relies on the `AudioSystem.API`.

The other part of this fix is in the O3DE repo to add the proper aliases in the audio gems so they can be depended on in the unified launcher: https://github.com/o3de/o3de/pull/16565