### PR TITLE
Upgrade Popcorn Fx Assets to 2.17.3

### DIFF
--- a/Levels/PopcornFxTest/PopcornFxTest.prefab
+++ b/Levels/PopcornFxTest/PopcornFxTest.prefab
@@ -1,0 +1,2368 @@
+{
+    "ContainerEntity": {
+        "Id": "Entity_[1146574390643]",
+        "Name": "Level",
+        "Components": {
+            "Component_[10641544592923449938]": {
+                "$type": "EditorInspectorComponent",
+                "Id": 10641544592923449938
+            },
+            "Component_[12039882709170782873]": {
+                "$type": "EditorOnlyEntityComponent",
+                "Id": 12039882709170782873
+            },
+            "Component_[12265484671603697631]": {
+                "$type": "EditorPendingCompositionComponent",
+                "Id": 12265484671603697631
+            },
+            "Component_[14126657869720434043]": {
+                "$type": "EditorEntitySortComponent",
+                "Id": 14126657869720434043,
+                "Child Entity Order": [
+                    "Entity_[1176639161715]",
+                    "Entity_[928771026303]",
+                    "Entity_[1143519391103]",
+                    "Entity_[1147814358399]",
+                    "Entity_[1152109325695]",
+                    "Entity_[1156404292991]",
+                    "Entity_[1164994227583]",
+                    "Entity_[1169289194879]",
+                    "Entity_[1173584162175]",
+                    "Entity_[1177879129471]",
+                    "Entity_[1182174096767]",
+                    "Entity_[1186469064063]",
+                    "Entity_[1190764031359]",
+                    "Entity_[1195058998655]",
+                    "Entity_[1199353965951]",
+                    "Entity_[1203648933247]",
+                    "Entity_[1207943900543]",
+                    "Entity_[1212238867839]",
+                    "Entity_[1216533835135]",
+                    "Entity_[56076151106943]",
+                    "Entity_[56080446074239]"
+                ]
+            },
+            "Component_[15230859088967841193]": {
+                "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                "Id": 15230859088967841193,
+                "Parent Entity": ""
+            },
+            "Component_[16239496886950819870]": {
+                "$type": "EditorDisabledCompositionComponent",
+                "Id": 16239496886950819870
+            },
+            "Component_[5688118765544765547]": {
+                "$type": "EditorEntityIconComponent",
+                "Id": 5688118765544765547
+            },
+            "Component_[7247035804068349658]": {
+                "$type": "EditorPrefabComponent",
+                "Id": 7247035804068349658
+            },
+            "Component_[9307224322037797205]": {
+                "$type": "EditorLockComponent",
+                "Id": 9307224322037797205
+            },
+            "Component_[9562516168917670048]": {
+                "$type": "EditorVisibilityComponent",
+                "Id": 9562516168917670048
+            },
+            "LocalViewBookmarkComponent": {
+                "$type": "LocalViewBookmarkComponent",
+                "Id": 13138551526165522046,
+                "LocalBookmarkFileName": "PopcornFxTest_16933436010590627.setreg"
+            }
+        }
+    },
+    "Entities": {
+        "Entity_[1143519391103]": {
+            "Id": "Entity_[1143519391103]",
+            "Name": "fx_laserpistol_blast",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 16343262008972791423
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14986218819144858366
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11153533240519832905
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9111738922202435957
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13229341886719026767
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12546851132144712600
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4619271124847750069
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13954859556944637498
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 265519063798167489,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{1BB94CA2-0BA0-5EC6-BE46-9B1F51D66CB9}"
+                        },
+                        "assetHint": "popcornfx/particles/laserpistol/fx_laserpistol_blast.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color 01",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color 02",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Distortion Power",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AAAAADjVQj/+7WU/AACAPwAAAEAAAAAAAAAAAAAAAAD+7WU/ZePSPgAAAAAAAIA/AACAPwAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.7610659599304199,
+                                            0.8981627225875854
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 2.0
+                                    },
+                                    {
+                                        "Color": [
+                                            0.8981627225875854,
+                                            0.4118911325931549,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4588856313148543056,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1147814358399]": {
+            "Id": "Entity_[1147814358399]",
+            "Name": "fx_laserpistol",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10191685168267642285
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 998314039009069059
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 18128715023317621113
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7230337278885314854
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1785944969556313858
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 8788724498066848570
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5399730405276604310
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13787171385958502312
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 8617419959920050849,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{4DFC6F87-5EFD-5B52-B29B-F58C2E7A4954}"
+                        },
+                        "assetHint": "popcornfx/particles/laserpistol/fx_laserpistol.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color 01",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color 02",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Max Length",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Laser lifetime",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AAAAADjVQj/+7WU/AACAPwAAgD8AAAAAAAAAAAAAAAD+7WU/ZePSPgAAAAAAAIA/AABIQgAAAAAAAAAAAAAAADMzsz4AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.7610659599304199,
+                                            0.8981627225875854
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "Color": [
+                                            0.8981627225875854,
+                                            0.4118911325931549,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 50.0
+                                    },
+                                    {
+                                        "ValueFX": 0.3499999940395355
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11258466643347165221,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1152109325695]": {
+            "Id": "Entity_[1152109325695]",
+            "Name": "fx_laserpistol_ray",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 273969774222450237
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3111558598553180655
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17244740759260739549
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17734941280082865846
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6987918409595847065
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7156055258747047342
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 2847398237677587177
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4228419518248085407
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 9256609597621033796,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{123FCBB4-016F-56D6-9DEC-BD329101C46F}"
+                        },
+                        "assetHint": "popcornfx/particles/laserpistol/fx_laserpistol_ray.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color 01",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color 02",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Max Length",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Laser lifetime",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Hit Position",
+                                "Type": 33
+                            }
+                        ],
+                        "AttributesRawData": "AAAAADjVQj/+7WU/AACAPwAAgD8AAAAAAAAAAAAAAAD+7WU/ZePSPgAAAAAAAIA/AABIQgAAAAAAAAAAAAAAAAAAAD4AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAA"
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.7610659599304199,
+                                            0.8981627225875854
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "Color": [
+                                            0.8981627225875854,
+                                            0.4118911325931549,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 50.0
+                                    },
+                                    {
+                                        "ValueFX": 0.125
+                                    },
+                                    {
+                                        "ValueFY": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 3274751969007861515,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1156404292991]": {
+            "Id": "Entity_[1156404292991]",
+            "Name": "fx_laserpistol_display",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5358806213475008254
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 13119409075585584450
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4318725037321817962
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9314775661251236929
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15822496558293591106
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14906516257665906854
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5419444483022864076
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11653125665573319769
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 13115477726053540962,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{1EB9EB5B-57F2-5483-934F-F99136266306}"
+                        },
+                        "assetHint": "popcornfx/particles/laserpistol/fx_laserpistol_display.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color 01",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color 02",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Max Length",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Laser lifetime",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AAAAADjVQj/+7WU/AACAPwAAgD8AAAAAAAAAAAAAAAD+7WU/ZePSPgAAAAAAAIA/AABIQgAAAAAAAAAAAAAAADMzsz4AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.7610659599304199,
+                                            0.8981627225875854
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "Color": [
+                                            0.8981627225875854,
+                                            0.4118911325931549,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 50.0
+                                    },
+                                    {
+                                        "ValueFX": 0.3499999940395355
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7184757449597545233,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1159459292531]": {
+            "Id": "Entity_[1159459292531]",
+            "Name": "Ground",
+            "Components": {
+                "Component_[12260880513256986252]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12260880513256986252
+                },
+                "Component_[13711420870643673468]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13711420870643673468
+                },
+                "Component_[138002849734991713]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 138002849734991713
+                },
+                "Component_[16578565737331764849]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16578565737331764849,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[16919232076966545697]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 16919232076966545697
+                },
+                "Component_[4228479570410194639]": {
+                    "$type": "EditorStaticRigidBodyComponent",
+                    "Id": 4228479570410194639
+                },
+                "Component_[5182430712893438093]": {
+                    "$type": "EditorMaterialComponent",
+                    "Id": 5182430712893438093
+                },
+                "Component_[5245524694917323904]": {
+                    "$type": "EditorColliderComponent",
+                    "Id": 5245524694917323904,
+                    "ColliderConfiguration": {
+                        "Position": [
+                            0.0,
+                            0.0,
+                            -0.5
+                        ],
+                        "MaterialSlots": {
+                            "Slots": [
+                                {
+                                    "Name": "Entire object"
+                                }
+                            ]
+                        }
+                    },
+                    "ShapeConfiguration": {
+                        "ShapeType": 1,
+                        "Box": {
+                            "Configuration": [
+                                512.0,
+                                512.0,
+                                1.0
+                            ]
+                        }
+                    },
+                    "DebugDrawSettings": {
+                        "LocallyEnabled": false
+                    }
+                },
+                "Component_[5675108321710651991]": {
+                    "$type": "AZ::Render::EditorMeshComponent",
+                    "Id": 5675108321710651991,
+                    "Controller": {
+                        "Configuration": {
+                            "ModelAsset": {
+                                "assetId": {
+                                    "guid": "{0CD745C0-6AA8-569A-A68A-73A3270986C4}",
+                                    "subId": 277889906
+                                },
+                                "assetHint": "objects/groudplane/groundplane_512x512m.azmodel"
+                            }
+                        }
+                    }
+                },
+                "Component_[5681893399601237518]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5681893399601237518
+                },
+                "Component_[592692962543397545]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 592692962543397545
+                },
+                "Component_[7090012899106946164]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7090012899106946164
+                },
+                "Component_[9410832619875640998]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9410832619875640998
+                }
+            }
+        },
+        "Entity_[1163754259827]": {
+            "Id": "Entity_[1163754259827]",
+            "Name": "Camera",
+            "Components": {
+                "Component_[11895140916889160460]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11895140916889160460
+                },
+                "Component_[16880285896855930892]": {
+                    "$type": "{CA11DA46-29FF-4083-B5F6-E02C3A8C3A3D} EditorCameraComponent",
+                    "Id": 16880285896855930892,
+                    "Controller": {
+                        "Configuration": {
+                            "Field of View": 55.0
+                        }
+                    }
+                },
+                "Component_[17187464423780271193]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17187464423780271193
+                },
+                "Component_[17495696818315413311]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 17495696818315413311
+                },
+                "Component_[18086214374043522055]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 18086214374043522055,
+                    "Parent Entity": "Entity_[1176639161715]",
+                    "Transform Data": {
+                        "Translate": [
+                            -2.3000001907348633,
+                            -3.9368600845336914,
+                            1.0
+                        ],
+                        "Rotate": [
+                            -2.050307512283325,
+                            1.9552897214889526,
+                            -43.623355865478516
+                        ]
+                    }
+                },
+                "Component_[2654521436129313160]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 2654521436129313160
+                },
+                "Component_[5265045084611556958]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5265045084611556958
+                },
+                "Component_[7169798125182238623]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 7169798125182238623
+                },
+                "Component_[7255796294953281766]": {
+                    "$type": "GenericComponentWrapper",
+                    "Id": 7255796294953281766,
+                    "m_template": {
+                        "$type": "FlyCameraInputComponent"
+                    }
+                },
+                "Component_[8866210352157164042]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 8866210352157164042
+                },
+                "Component_[9129253381063760879]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9129253381063760879
+                }
+            }
+        },
+        "Entity_[1164994227583]": {
+            "Id": "Entity_[1164994227583]",
+            "Name": "fx_malfunctionningshieldgenerator_buildup",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1248899223398807616
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 1331131054103078738
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13069592346059453228
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5948712552568140686
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 2888046258457310218
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9146488221585680068
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 8982691687678082051
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7117017782936712004
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 13514278166002061698,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{534A3BC1-C25D-5395-A5DF-A48E1C689501}"
+                        },
+                        "assetHint": "popcornfx/particles/malfunctionningshieldgenerator/fx_malfunctionningshieldgenerator_buildup.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAQAAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 4.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15215980944911946364,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1169289194879]": {
+            "Id": "Entity_[1169289194879]",
+            "Name": "fx_malfunctionningshieldgenerator_idle",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6546863338556287012
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 11139734789047139611
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4341654753341202112
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 12179570988519756508
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 7136825723222244122
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2085964359287115573
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11044142330779218794
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 4324252587631683340
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 11959683512564414311,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{CF441123-DD6C-5965-836B-746E8A9A990A}"
+                        },
+                        "assetHint": "popcornfx/particles/malfunctionningshieldgenerator/fx_malfunctionningshieldgenerator_idle.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Frequency",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAQAAAAAAAAAAAAAAAAAAAgEAAAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 4.0
+                                    },
+                                    {
+                                        "ValueFX": 4.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 16956544146927469666,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1173584162175]": {
+            "Id": "Entity_[1173584162175]",
+            "Name": "fx_malfunctionningshieldgenerator_explosion",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3622260739165620421
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 199038223771293236
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2502022933807504600
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3168057311789455125
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 5258206482094483653
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 5938559357046123626
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 315699165197645481
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 9212065777415479168
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 15057647489160046149,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{6D7AE0BE-B867-516A-8ECB-ECD5E8F14366}"
+                        },
+                        "assetHint": "popcornfx/particles/malfunctionningshieldgenerator/fx_malfunctionningshieldgenerator_explosion.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Distortion Power",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Smoke Color",
+                                "Type": 34
+                            }
+                        ],
+                        "AttributesRawData": "AACAQAAAAAAAAAAAAAAAAAAAwD8AAAAAAAAAAAAAAACf6QU/UQL1PkBNmj4AAIA/"
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 4.0
+                                    },
+                                    {
+                                        "ValueFX": 1.5
+                                    },
+                                    {
+                                        "Color": [
+                                            0.5230960249900818,
+                                            0.4785332977771759,
+                                            0.30137062072753906
+                                        ]
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 14930195088910031150,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1176639161715]": {
+            "Id": "Entity_[1176639161715]",
+            "Name": "Atom Default Environment",
+            "Components": {
+                "Component_[10757302973393310045]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 10757302973393310045,
+                    "Parent Entity": "Entity_[1146574390643]"
+                },
+                "Component_[14505817420424255464]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14505817420424255464,
+                    "ComponentOrderEntryArray": [
+                        {
+                            "ComponentId": 10757302973393310045
+                        }
+                    ]
+                },
+                "Component_[14988041764659020032]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 14988041764659020032
+                },
+                "Component_[15900837685796817138]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15900837685796817138
+                },
+                "Component_[3298767348226484884]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3298767348226484884
+                },
+                "Component_[4076975109609220594]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 4076975109609220594
+                },
+                "Component_[5679760548946028854]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5679760548946028854
+                },
+                "Component_[5855590796136709437]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 5855590796136709437,
+                    "Child Entity Order": [
+                        "Entity_[1180934129011]",
+                        "Entity_[1163754259827]",
+                        "Entity_[1159459292531]"
+                    ]
+                },
+                "Component_[9277695270015777859]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 9277695270015777859
+                }
+            }
+        },
+        "Entity_[1177879129471]": {
+            "Id": "Entity_[1177879129471]",
+            "Name": "fx_energycollector",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7065182316615443212
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5134374633381785062
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2789367422380837263
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7445916913060332915
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17743413235343103805
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 17486329957278998916
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 10658085352968317372
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 13776220077097931991
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 6699832273338070802,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{10D382AB-A8B6-5224-8C65-5C72BE106FD2}"
+                        },
+                        "assetHint": "popcornfx/particles/malfunctionningshieldgenerator/fx_energycollector.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color 2",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Color 1",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Distortion Power",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Min point size",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AAAAAIGAgDsAAIA/AACAPwAAAADT0VE/AACAPwAAgD8AAEBAAAAAAAAAAAAAAAAAAAAgQAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.003921568859368563,
+                                            1.0
+                                        ]
+                                    },
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.8196079134941101,
+                                            1.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 3.0
+                                    },
+                                    {
+                                        "ValueFX": 2.5
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 5823732669343469284,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1180934129011]": {
+            "Id": "Entity_[1180934129011]",
+            "Name": "Global Sky",
+            "Components": {
+                "Component_[11231930600558681245]": {
+                    "$type": "AZ::Render::EditorHDRiSkyboxComponent",
+                    "Id": 11231930600558681245,
+                    "Controller": {
+                        "Configuration": {
+                            "CubemapAsset": {
+                                "assetId": {
+                                    "guid": "{215E47FD-D181-5832-B1AB-91673ABF6399}",
+                                    "subId": 1000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_skyboxcm.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[1428633914413949476]": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1428633914413949476
+                },
+                "Component_[14936200426671614999]": {
+                    "$type": "AZ::Render::EditorImageBasedLightComponent",
+                    "Id": 14936200426671614999,
+                    "Controller": {
+                        "Configuration": {
+                            "diffuseImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 3000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_ibldiffuse.exr.streamingimage"
+                            },
+                            "specularImageAsset": {
+                                "assetId": {
+                                    "guid": "{3FD09945-D0F2-55C8-B9AF-B2FD421FE3BE}",
+                                    "subId": 2000
+                                },
+                                "assetHint": "lightingpresets/highcontrast/goegap_4k_iblglobalcm_iblspecular.exr.streamingimage"
+                            }
+                        }
+                    }
+                },
+                "Component_[14994774102579326069]": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14994774102579326069
+                },
+                "Component_[15417479889044493340]": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15417479889044493340
+                },
+                "Component_[15826613364991382688]": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15826613364991382688
+                },
+                "Component_[1665003113283562343]": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 1665003113283562343
+                },
+                "Component_[3704934735944502280]": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 3704934735944502280
+                },
+                "Component_[5698542331457326479]": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5698542331457326479
+                },
+                "Component_[6644513399057217122]": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6644513399057217122,
+                    "Parent Entity": "Entity_[1176639161715]"
+                },
+                "Component_[931091830724002070]": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 931091830724002070
+                }
+            }
+        },
+        "Entity_[1182174096767]": {
+            "Id": "Entity_[1182174096767]",
+            "Name": "fx_energyballtrap_explosion",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3444471501587458920
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 15116701031834040336
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 12389591133361547169
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 17532383302627410325
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4499064886749699101
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 9112857704686798163
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14922079500199066807
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14174582705064069883
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 10794202883578832349,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{D49CE200-BF8B-5DBF-98BD-14CF7C480D45}"
+                        },
+                        "assetHint": "popcornfx/particles/energyballtrap/fx_energyballtrap_explosion.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color Intensity",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 17961365573260249899,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1186469064063]": {
+            "Id": "Entity_[1186469064063]",
+            "Name": "fx_energyballtrap_projectile",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 7717466502528258899
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 17407430349508173292
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 2838886404786314666
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 3037644658579215133
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 15586426135518491610
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 3110462108262737750
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3944545150642523380
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 11286947804567123271
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 753079937360430663,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{4981130E-D6A9-54D3-A693-2B957A15051F}"
+                        },
+                        "assetHint": "popcornfx/particles/energyballtrap/fx_energyballtrap_projectile.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color Intensity",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12337674356999393081,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1190764031359]": {
+            "Id": "Entity_[1190764031359]",
+            "Name": "fx_energyballtrap_buildup",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 10049864397573801455
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14479585196533513005
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 13247150067931002996
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 7076570973355142645
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6956761202098518377
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 12227671644644059153
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 3669386853402600411
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 16747957325058523551
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 1783250089769868846,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{F16C718B-7B3D-5F6B-877C-0CA15AAE7544}"
+                        },
+                        "assetHint": "popcornfx/particles/energyballtrap/fx_energyballtrap_buildup.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color Intensity",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AAAAQAAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 2.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 15221516425686546976,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1195058998655]": {
+            "Id": "Entity_[1195058998655]",
+            "Name": "fx_defenseturret_blast",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 5634238115111849340
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 8483256604338090386
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 9171058176236875993
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6758303308722974804
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 4548365936157005698
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 13929578280404345491
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5345563290031242185
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 3223549083996222042
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 14438008809867750168,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{5A84D0E0-8BF2-5478-B3B9-900F5548754D}"
+                        },
+                        "assetHint": "popcornfx/particles/defenseturret/fx_defenseturret_blast.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color1",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Color2",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color Intensity",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAP9gY0z4AAAAAAACAP1C/8T4AAAAAAACAPwAAgD8AAIA/AAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            1.0,
+                                            0.41229891777038574,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "Color": [
+                                            0.47216272354125977,
+                                            0.0,
+                                            1.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6023672217631220600,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1199353965951]": {
+            "Id": "Entity_[1199353965951]",
+            "Name": "fx_defenseturret_explosion",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12151669155207511997
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 12026811888312139329
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3914913837028709105
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6609140056887176506
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1468831830591551579
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 14063641524064587798
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 11995408431120424050
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 7494001868808025514
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 4693728091709959320,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{FAEA4FC5-78DF-5608-8DA2-88C6CFB1D281}"
+                        },
+                        "assetHint": "popcornfx/particles/defenseturret/fx_defenseturret_explosion.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color1",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Color2",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Impact Normal",
+                                "Type": 33
+                            },
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color Intensity",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAP9gY0z4AAAAAAACAP1C/8T4AAAAAAACAPwAAgD8AAAAAAAAAAAAAgD8AAAAAAACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            1.0,
+                                            0.41229891777038574,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "Color": [
+                                            0.47216272354125977,
+                                            0.0,
+                                            1.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFZ": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 7382528931352583020,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1203648933247]": {
+            "Id": "Entity_[1203648933247]",
+            "Name": "fx_defenseturret_projectile",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 1878741014393033085
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4765110582234062326
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 4713863692779719639
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 5151803230027680875
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 6056186305943991786
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 7323196746682713025
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 18198427932846455595
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8543408920847989329
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 18275821908141062690,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{EAD91758-94E3-597E-94CF-FB52F72B7252}"
+                        },
+                        "assetHint": "popcornfx/particles/defenseturret/fx_defenseturret_projectile.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Fire Rate",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color1",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Color2",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Color Intensity",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Global Scale",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AABAQAAAAAAAAAAAAAAAAAAAgD/YGNM+AAAAAAAAgD9Qv/E+AAAAAAAAgD8AAIA/AACAPwAAAAAAAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 3.0
+                                    },
+                                    {
+                                        "Color": [
+                                            1.0,
+                                            0.41229891777038574,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "Color": [
+                                            0.47216272354125977,
+                                            0.0,
+                                            1.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 6921131242866810586,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1207943900543]": {
+            "Id": "Entity_[1207943900543]",
+            "Name": "fx_bubblegun_projectile",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 12009781533505747005
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4155036822211851885
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 14805673579961146472
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6352589284700312085
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 1571620428385725168
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10335359323908447922
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 5177065071873577728
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 15225593736673275774
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 4869263845641210512,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{DB9F4732-99BC-5A53-BBBB-1B32E9852F54}"
+                        },
+                        "assetHint": "popcornfx/particles/bubblegun/fx_bubblegun_projectile.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Distortion Power",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Trail Lifetime",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAPwAAAAAAAAAAAAAAAAAA4EAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAA"
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 7.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12655365194438511281,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1212238867839]": {
+            "Id": "Entity_[1212238867839]",
+            "Name": "fx_bubblegun_blast",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 3204775720818700143
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 6334192147308243835
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 8864431935210353742
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 13536972726153701710
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 13296123026176030427
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2073257115062117310
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 14488649638274157908
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 14903977253587892968
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 7617088476308664969,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{8D79CA21-1BF9-59A5-8C2F-FE52D54B9E6B}"
+                        },
+                        "assetHint": "popcornfx/particles/bubblegun/fx_bubblegun_blast.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Distortion Power",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAPwAAAAAAAAAAAAAAAAAAQEAAAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 3.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11964939769226534636,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[1216533835135]": {
+            "Id": "Entity_[1216533835135]",
+            "Name": "fx_bubblegun_explosion",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 13126519615088155373
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 781199444337976142
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 11364416865352741980
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 4030694008269739625
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 17812634305225241523
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 10907998636758245203
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 9799360017990330046
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 5182982848326156359
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 5874537298775551379,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{6BAABCAA-C35A-5462-BF44-40A4AD099D70}"
+                        },
+                        "assetHint": "popcornfx/particles/bubblegun/fx_bubblegun_explosion.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAPwAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 11620678066385164253,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[56076151106943]": {
+            "Id": "Entity_[56076151106943]",
+            "Name": "fx_jumppad",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 9625301404119145239
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 5366927864060091788
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 3532974174062086
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 9910065071484291211
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11088561353819720138
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 4339105054264854482
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 17333772842252459408
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 17889098554599048196
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 8307787940418320299,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{3FD29CAB-9815-5751-BFE2-31C5795D03EC}"
+                        },
+                        "assetHint": "popcornfx/particles/fx_jumppad.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "GlobalScale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Launch",
+                                "Type": 1
+                            },
+                            {
+                                "Name": "Range",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Brightness",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Bursts",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "DistortionPower",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "mpmZPwAAAAAAAAAAAAAAAAAAAAAAAIA/GFRAPgAAgD8AAAAAAAAAAAAAAAAAAAAAAACAPwAAAAAAAAAAAAAAAAAAoEAAAAAAAAAAAAAAAAAAAIA/AAAAAAAAAAAAAAAAAAAAQAAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 2.0
+                                    }
+                                ]
+                            },
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            1.0,
+                                            0.18782079219818115
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 5.0
+                                    }
+                                ]
+                            },
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            },
+                            {
+                                "Attributes": [
+                                    {}
+                                ]
+                            },
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.2000000476837158
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 12033211432284610797,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[56080446074239]": {
+            "Id": "Entity_[56080446074239]",
+            "Name": "vfx_speedpowerup",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 6960108783883542110
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 14479818020875463408
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 6510454528728520975
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 14959881970115845084
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 11767935133653003070
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 2135808271615630717
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 15190257985373765581
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 8466186270910554913
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 3033227461685338225,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{B336373A-DB43-5C4D-BD1D-5DF6D7CA0BF7}"
+                        },
+                        "assetHint": "popcornfx/particles/vfx_speedpowerup.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "GlobalScale",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Particules Count",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color_Wind",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "duration",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AACAPwAAAAAAAAAAAAAAAAAAIEEAAAAAAAAAAAAAAAAAAIA/nJB+PyFTZD8AAIA/AACgQAAAAAAAAAAAAAAAAA=="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "ValueFX": 1.0
+                                    },
+                                    {
+                                        "ValueFX": 10.0
+                                    },
+                                    {
+                                        "Color": [
+                                            1.0,
+                                            0.994394063949585,
+                                            0.8918934464454651
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 5.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 558899713102612311,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        },
+        "Entity_[928771026303]": {
+            "Id": "Entity_[928771026303]",
+            "Name": "fx_laserpistol_explosion",
+            "Components": {
+                "EditorDisabledCompositionComponent": {
+                    "$type": "EditorDisabledCompositionComponent",
+                    "Id": 14657463832913524207
+                },
+                "EditorEntityIconComponent": {
+                    "$type": "EditorEntityIconComponent",
+                    "Id": 4225839230796828173
+                },
+                "EditorEntitySortComponent": {
+                    "$type": "EditorEntitySortComponent",
+                    "Id": 15683168837511880730
+                },
+                "EditorInspectorComponent": {
+                    "$type": "EditorInspectorComponent",
+                    "Id": 6507144395361865695
+                },
+                "EditorLockComponent": {
+                    "$type": "EditorLockComponent",
+                    "Id": 3751560435738538956
+                },
+                "EditorOnlyEntityComponent": {
+                    "$type": "EditorOnlyEntityComponent",
+                    "Id": 16605518749823107653
+                },
+                "EditorPendingCompositionComponent": {
+                    "$type": "EditorPendingCompositionComponent",
+                    "Id": 146804015628051927
+                },
+                "EditorVisibilityComponent": {
+                    "$type": "EditorVisibilityComponent",
+                    "Id": 1729292892203598445
+                },
+                "PopcornFXEmitterEditorComponent": {
+                    "$type": "PopcornFXEmitterEditorComponent",
+                    "Id": 6561034548320863792,
+                    "Enable": false,
+                    "ParticleSystem": {
+                        "assetId": {
+                            "guid": "{899C6C52-65FD-5C1F-B2A8-3BC8048DDABC}"
+                        },
+                        "assetHint": "popcornfx/particles/laserpistol/fx_laserpistol_explosion.pkfx"
+                    },
+                    "PrewarmTime": 0.0,
+                    "AttributeList": {
+                        "Attributes": [
+                            {
+                                "Name": "Color 01",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Global Size",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Color 02",
+                                "Type": 34
+                            },
+                            {
+                                "Name": "Max Length",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Laser lifetime",
+                                "Type": 31
+                            },
+                            {
+                                "Name": "Hit Position",
+                                "Type": 33
+                            },
+                            {
+                                "Name": "Hit Normal",
+                                "Type": 33
+                            },
+                            {
+                                "Name": "Distortion Power",
+                                "Type": 31
+                            }
+                        ],
+                        "AttributesRawData": "AAAAADjVQj/+7WU/AACAPwAAAEAAAAAAAAAAAAAAAAD+7WU/ZePSPgAAAAAAAIA/AABIQgAAAAAAAAAAAAAAADMzsz4AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgL8AAAAAAAAAAAAAgD8AAAAAAAAAAAAAAAA="
+                    },
+                    "EditorAttributeList": {
+                        "AttributeCategories": [
+                            {
+                                "Attributes": [
+                                    {
+                                        "Color": [
+                                            0.0,
+                                            0.7610659599304199,
+                                            0.8981627225875854
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 2.0
+                                    },
+                                    {
+                                        "Color": [
+                                            0.8981627225875854,
+                                            0.4118911325931549,
+                                            0.0
+                                        ]
+                                    },
+                                    {
+                                        "ValueFX": 50.0
+                                    },
+                                    {
+                                        "ValueFX": 0.3499999940395355
+                                    },
+                                    {},
+                                    {
+                                        "ValueFY": -1.0
+                                    },
+                                    {
+                                        "ValueFX": 1.0
+                                    }
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "TransformComponent": {
+                    "$type": "{27F1E1A1-8D9D-4C3B-BD3A-AFB9762449C0} TransformComponent",
+                    "Id": 4646147641998418243,
+                    "Parent Entity": "Entity_[1146574390643]"
+                }
+            }
+        }
+    }
+}

--- a/PopcornFX/PopcornProject.pkproj
+++ b/PopcornFX/PopcornProject.pkproj
@@ -1,4 +1,4 @@
-Version = 2.17.2.17892;
+Version = 2.17.3.18088;
 CProjectSettings	$D857A09F
 {
 	General = "$35A36C4E";


### PR DESCRIPTION
Upgrading PopcornFx assets from 2.17.2 to 2.17.3]
Created a new level _PopcornFxTest_ for devs to quickly open and enable all of the particle fx to see if they are working.

Relates to: https://github.com/o3de/o3de-multiplayersample-assets/pull/164

Note: The package file changed, but individual fx files were already up-to-date
![image](https://github.com/o3de/o3de-multiplayersample/assets/32776221/2df91f20-a35d-4d58-808d-b5d41fe1d44d)
