### PR TITLE
Removing Terrain Gradient Until Crash Fixed

### DIFF
--- a/Levels/NewStarbase/NewStarbase.prefab
+++ b/Levels/NewStarbase/NewStarbase.prefab
@@ -4466,15 +4466,6 @@
                         }
                     ]
                 },
-                "Component_[5695910287028415257]": {
-                    "$type": "EditorTerrainHeightGradientListComponent",
-                    "Id": 5695910287028415257,
-                    "Configuration": {
-                        "GradientEntities": [
-                            "Entity_[303237221671612]"
-                        ]
-                    }
-                },
                 "Component_[6443032894395858262]": {
                     "$type": "EditorDisabledCompositionComponent",
                     "Id": 6443032894395858262
@@ -4531,23 +4522,6 @@
                         }
                     ]
                 },
-                "Component_[12178218586544688227]": {
-                    "$type": "EditorImageGradientComponent",
-                    "Id": 12178218586544688227,
-                    "Previewer": {
-                        "BoundsEntity": "Entity_[303237221671612]"
-                    },
-                    "Configuration": {
-                        "StreamingImageAsset": {
-                            "assetId": {
-                                "guid": "{DC2BA756-531B-59C5-B82C-51D0DC0C37F9}",
-                                "subId": 1000
-                            },
-                            "assetHint": "canyon-barren/cb_height_gsi32.exr.streamingimage"
-                        },
-                        "MipIndex": 3
-                    }
-                },
                 "Component_[15562687561878570883]": {
                     "$type": "EditorVisibilityComponent",
                     "Id": 15562687561878570883
@@ -4555,18 +4529,6 @@
                 "Component_[18206104094828342886]": {
                     "$type": "EditorPendingCompositionComponent",
                     "Id": 18206104094828342886
-                },
-                "Component_[18385456839477541139]": {
-                    "$type": "EditorGradientTransformComponent",
-                    "Id": 18385456839477541139,
-                    "Configuration": {
-                        "ShapeReference": "",
-                        "Bounds": [
-                            1024.0,
-                            1024.0,
-                            64.0
-                        ]
-                    }
                 },
                 "Component_[46111268970549813]": {
                     "$type": "EditorEntitySortComponent",


### PR DESCRIPTION
Removing terrain gradient until crash issue is fixed (https://github.com/o3de/o3de/issues/17255)

Tested by opening NewStarbase in level editor and seeing the editor no longer crashes.