### PR TITLE
Fix compile and python errors from the export script

### DIFF
--- a/ExportScripts/export_mps.py
+++ b/ExportScripts/export_mps.py
@@ -98,7 +98,7 @@ def export_multiplayer_sample(ctx: exp.O3DEScriptExportContext,
         if should_build_server_launcher:
             launcher_type |= exp.LauncherType.SERVER
         if should_build_headless_server_launcher:
-            launcher_type |= exp.LauncherType.HEADLESS
+            launcher_type |= exp.LauncherType.HEADLESS_SERVER
         if should_build_unified_launcher:
             launcher_type |= exp.LauncherType.UNIFIED
 

--- a/ExportScripts/export_mps.py
+++ b/ExportScripts/export_mps.py
@@ -126,7 +126,7 @@ def export_multiplayer_sample(ctx: exp.O3DEScriptExportContext,
                                                               required=True)
         logger.info(f"Using '{asset_bundler_path}' to bundle the assets.")
         expected_bundles_path = exp.bundle_assets(ctx=ctx,
-                                                  selected_platform=selected_platform,
+                                                  selected_platforms=[selected_platform],
                                                   seedlist_paths=validated_seedslist_paths,
                                                   seedfile_paths=[],
                                                   tools_build_path=tools_build_path,

--- a/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp
+++ b/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp
@@ -261,7 +261,9 @@ namespace MultiplayerSample
                 {
                     auto ssrOptions = reflectionFeatureProcessor->GetSSROptions();
                     ssrOptions.m_enable = (reflectionType != SpecularReflections::None);
-                    ssrOptions.m_rayTracing = (reflectionType == SpecularReflections::ScreenSpaceAndRaytracing);
+                    ssrOptions.m_reflectionMethod = (reflectionType == SpecularReflections::ScreenSpaceAndRaytracing) ?
+                                                    AZ::Render::SSROptions::ReflectionMethod::RayTracing :
+                                                    AZ::Render::SSROptions::ReflectionMethod::ScreenSpace;
                     reflectionFeatureProcessor->SetSSROptions(ssrOptions);
                 }
             }


### PR DESCRIPTION
Fixes the following build errors when building against the latest o3de development (commit f35b02e8dc78084eae621ff9cea898daa493e553)

```
In file included from /data/workspace/o3de-multiplayersample/build/tools/External/Gem-f6f5d0f3/Code/CMakeFiles/MultiplayerSample.dir/Unity/unity_0_cxx.cxx:5:
/data/workspace/o3de-multiplayersample/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp:264:32: error: no member named 'm_rayTracing' in 'AZ::Render::SSROptions'
                    ssrOptions.m_rayTracing = (reflectionType == SpecularReflections::ScreenSpaceAndRaytracing) ? 
                    ~~~~~~~~~~ ^
```

Also fixes the following python error during the project export script
```
 File "/data/workspace/o3de-multiplayersample/ExportScripts/export_mps.py", line 248, in <module>
    export_multiplayer_sample(ctx=o3de_context,
  File "/data/workspace/o3de-multiplayersample/ExportScripts/export_mps.py", line 101, in export_multiplayer_sample
    launcher_type |= exp.LauncherType.HEADLESS
  File "/root/.o3de/Python/packages/python-3.10.13-rev2-linux/python/lib/python3.10/enum.py", line 437, in __getattr__
    raise AttributeError(name) from None
AttributeError: HEADLESS
```
```
TypeError: bundle_assets() got an unexpected keyword argument 'selected_platform
```
