### PR TITLE
Removing deprecated function call from multiplayer sample settings

### DIFF
--- a/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp
+++ b/Gem/Code/Source/UserSettings/MultiplayerSampleUserSettings.cpp
@@ -398,10 +398,6 @@ namespace MultiplayerSample
                     isFullscreen, windowHandle,
                     &AzFramework::WindowRequestBus::Events::GetFullScreenState);
 
-                AzFramework::WindowRequestBus::Event(
-                    windowHandle,
-                    &AzFramework::WindowRequestBus::Events::SetEnableCustomizedResolution, fullscreen);
-
                 if (isFullscreen != fullscreen) 
                 {
                     m_changingResolution = true;


### PR DESCRIPTION
Multiplayer sample was failing to compile because of an error caused by a warning about a deprecated function call.