### PR TITLE
Update viewsrg.srgi and scenesrg.srgi after O3DE PR18498

### DIFF
--- a/ShaderLib/scenesrg.srgi
+++ b/ShaderLib/scenesrg.srgi
@@ -13,6 +13,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/SceneSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup SceneSrg : SRG_PerScene
 {
 /* Intentionally Empty. Helps define the SrgSemantic for SceneSrg once.*/

--- a/ShaderLib/viewsrg.srgi
+++ b/ShaderLib/viewsrg.srgi
@@ -13,6 +13,10 @@
 
 #include <Atom/Features/SrgSemantics.azsli>
 
+#define AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+#include <Atom/Feature/Common/Assets/ShaderResourceGroups/ViewSrgIncludesAll.azsli>
+#undef AZ_COLLECTING_PARTIAL_SRG_INCLUDES
+
 partial ShaderResourceGroup ViewSrg : SRG_PerView
 {
 /* Intentionally Empty. Helps define the SrgSemantic for ViewSrg once.*/


### PR DESCRIPTION
O3DE [PR18498](https://github.com/o3de/o3de/pull/18498) introduced a breaking change which requires all projects to update `scenesrg.srgi` and `viewsrg.srgi` to be updated to the new project template, this PR updates this for the o3de-multiplayersample project.