### PR TITLE
Fix AWS Compiler Error

### DIFF
--- a/MPSGameLift/gem.json
+++ b/MPSGameLift/gem.json
@@ -21,6 +21,8 @@
     "documentation_url": "Link to any documentation of your Gem",
     "dependencies": [
         "AWSGameLift", 
+        "AWSClientAuth",
+        "HttpRequestor",
         "LyShine"
     ],
     "repo_uri": "",


### PR DESCRIPTION
Adding AWS gems as dependency for MPSGameLift gem. 
Fixes compiler error
```
CMake Error at D:/prj/o3de/cmake/LYWrappers.cmake:561 (target_link_libraries):
  Target "MPSGameLift" links to:

    Gem::AWSClientAuth.Static

  but the target was not found.
```