### PR TITLE
Remove AWS Dependencies by Default

### DIFF
--- a/Gem/Code/enabled_gems.cmake
+++ b/Gem/Code/enabled_gems.cmake
@@ -40,11 +40,7 @@ set(ENABLED_GEMS
     LmbrCentral
     LyShine
     LyShineExamples
-    HttpRequestor
     Atom
-    AWSCore
-    AWSClientAuth
-    AWSMetrics
     Presence
     LocalUser
     SaveData

--- a/MPSGameLift/Code/CMakeLists.txt
+++ b/MPSGameLift/Code/CMakeLists.txt
@@ -246,7 +246,6 @@ if(PAL_TRAIT_BUILD_HOST_TOOLS)
                 Gem::AWSCore.Static
                 Gem::AWSGameLift.Client.Static
                 Gem::AWSClientAuth.Static
-                AZ::AWSNativeSDKInit
                 Gem::HttpRequestor.Static
                 $<TARGET_OBJECTS:Gem::${gem_name}.Unified.Private.Object>
     )

--- a/MPSGameLift/README.md
+++ b/MPSGameLift/README.md
@@ -2,9 +2,10 @@
 
 ## Install MPSGameLift Gem
 
-1. Open MultiplayerSample/project.json
+1. Open _MultiplayerSample/project.json_
     1. Add `"MPSGameLift"` to `external_subdirectories`
     1. Add `"MPSGameLift"` to `gem_names`
+1. [Download and register AWS gems for O3DE](https://github.com/aws/o3de-repo/blob/main/README.md) 
 1. Compile MultiplayerSample 
 
 ## Setup Instructions

--- a/MPSGameLift/README.md
+++ b/MPSGameLift/README.md
@@ -1,6 +1,11 @@
 # MultiplayerSample GameLift Integration Gem
 
-Enable this gem for MultiplayerSample in order to enable AWS GameLift integration.
+## Install MPSGameLift Gem
+
+1. Open MultiplayerSample/project.json
+    1. Add `"MPSGameLift"` to `external_subdirectories`
+    1. Add `"MPSGameLift"` to `gem_names`
+1. Compile MultiplayerSample 
 
 ## Setup Instructions
 

--- a/project.json
+++ b/project.json
@@ -14,8 +14,7 @@
     "icon_path": "preview.png",
     "engine": "o3de",
     "external_subdirectories": [
-        "Gem",
-        "MPSGameLift"
+        "Gem"
     ],
     "gem_names": [
         "character_mps",


### PR DESCRIPTION
Remove AWS dependencies by default. 
Add instructions for installing MPSGameLift demo sub-gem.