### PR TITLE
fix(cmake): GameLauncher build pulls bare MultiplayerSample gem (closes #500)

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -182,6 +182,19 @@ ly_create_alias(NAME MultiplayerSample.Tools    NAMESPACE Gem TARGETS Gem::Multi
 ly_create_alias(NAME MultiplayerSample.Clients  NAMESPACE Gem TARGETS Gem::MultiplayerSample.Client)
 ly_create_alias(NAME MultiplayerSample.Servers  NAMESPACE Gem TARGETS Gem::MultiplayerSample.Server)
 ly_create_alias(NAME MultiplayerSample.Unified  NAMESPACE Gem TARGETS Gem::MultiplayerSample)
+# Ensure the bare unified MultiplayerSample target (used by AssetProcessor
+# at asset-bake time via the Builders alias above) is built whenever the
+# Client or Server variants are built. Without this, building only
+# MultiplayerSample.GameLauncher leaves AssetProcessor unable to load the
+# gem at bake time -- breaks ScriptCanvas asset compilation that needs
+# BehaviorContext from this gem. Closes #500.
+if (TARGET MultiplayerSample.Client AND TARGET MultiplayerSample)
+    add_dependencies(MultiplayerSample.Client MultiplayerSample)
+endif()
+if (TARGET MultiplayerSample.Server AND TARGET MultiplayerSample)
+    add_dependencies(MultiplayerSample.Server MultiplayerSample)
+endif()
+
 
 ################################################################################
 # Gem dependencies


### PR DESCRIPTION
## Problem

Building only `MultiplayerSample.GameLauncher` produces `libMultiplayerSample.Client.so` but NOT the bare `libMultiplayerSample.so`. AssetProcessor loads the bare gem at asset-bake time (via the `Builders` alias declared at `Gem/Code/CMakeLists.txt:180`), so the gem's BehaviorContext isn't available during AP bake.

Failure mode logged in AssetBuilder during a clean single-target build:

```
AssetBuilder: Module: Attempting to load module:libMultiplayerSample.so
AssetBuilder: Module: libMultiplayerSample.so: cannot open shared object file: No such file or directory
AssetBuilder: E: ComponentApplication: Failed to load dynamic library at path "libMultiplayerSample.so".
```

This is the issue tracked at #500.

## Fix

Add explicit `add_dependencies` so that building the Client or Server launcher variants transitively builds the bare gem too. TARGET guards keep monolithic builds working.

This is the minimum-surface fix; an alternative would be engine-side AP changes to look for variant `.so` files at bake time, but that's a much bigger surface change.

## Verification

End-to-end on Fedora 44 / NVIDIA RTX 2080 Ti with o3de2605 engine RPM. Same `cmake --build --target MultiplayerSample.GameLauncher` invocation in both rows (no extra targets, no workaround):

|                                              | Before fix | After fix |
|----------------------------------------------|-----------:|----------:|
| `libMultiplayerSample.Client.so` built       | yes        | yes       |
| `libMultiplayerSample.so` (bare) built       | **no**     | **yes**   |
| AssetProcessorBatch failed jobs              | **2**      | **0**     |
| AssetProcessorBatch errors reported          | **1184**   | **0**     |
| `libMultiplayerSample.so: cannot open` log   | 6+         | 0         |

Specific scriptcanvas jobs that flipped pass/fail: `WeaponImpactDecal.scriptcanvas`, `ShieldGeneratorRoundEffects.scriptcanvas`.

The integration suite at https://github.com/nickschuetz/o3de-rpm/blob/main/tests/multiplayersample-build-test.sh exercises a full clean clone + RPM install + cmake + ninja + AP bake + GameLauncher smoke; it currently works around this issue by building both targets explicitly. With this PR applied, the explicit-bare-target workaround can be retired (kept for backward-compat against older sample versions).