### PR TITLE
revert(cmake): undo #501 add_dependencies (caused Linux launcher abort); document dual-target build in README instead

### DIFF
--- a/Gem/Code/CMakeLists.txt
+++ b/Gem/Code/CMakeLists.txt
@@ -182,19 +182,6 @@ ly_create_alias(NAME MultiplayerSample.Tools    NAMESPACE Gem TARGETS Gem::Multi
 ly_create_alias(NAME MultiplayerSample.Clients  NAMESPACE Gem TARGETS Gem::MultiplayerSample.Client)
 ly_create_alias(NAME MultiplayerSample.Servers  NAMESPACE Gem TARGETS Gem::MultiplayerSample.Server)
 ly_create_alias(NAME MultiplayerSample.Unified  NAMESPACE Gem TARGETS Gem::MultiplayerSample)
-# Ensure the bare unified MultiplayerSample target (used by AssetProcessor
-# at asset-bake time via the Builders alias above) is built whenever the
-# Client or Server variants are built. Without this, building only
-# MultiplayerSample.GameLauncher leaves AssetProcessor unable to load the
-# gem at bake time -- breaks ScriptCanvas asset compilation that needs
-# BehaviorContext from this gem. Closes #500.
-if (TARGET MultiplayerSample.Client AND TARGET MultiplayerSample)
-    add_dependencies(MultiplayerSample.Client MultiplayerSample)
-endif()
-if (TARGET MultiplayerSample.Server AND TARGET MultiplayerSample)
-    add_dependencies(MultiplayerSample.Server MultiplayerSample)
-endif()
-
 
 ################################################################################
 # Gem dependencies

--- a/README.md
+++ b/README.md
@@ -200,7 +200,9 @@ This command outputs all the project binaries in the project's build directory (
    cmake --build build/linux --target Editor --target MultiplayerSample.GameLauncher MultiplayerSample.ServerLauncher --config profile
    ```
    Binary files will be output in `build/linux/bin/profile`.
-   
+
+   > **Note (Linux, headless / launcher-only builds):** if you're building only launcher targets without `Editor` (e.g. on a CI runner with no graphical environment), also add `--target MultiplayerSample` to the command. The Editor's `Tools` alias normally pulls in the bare `MultiplayerSample` gem variant, which AssetProcessor needs at bake time for BehaviorContext (otherwise `.scriptcanvas` bakes referencing MultiplayerSample components fail with "Failed to load dynamic library at path libMultiplayerSample.so"). Building the Editor brings it in implicitly; headless builds need to ask for it explicitly.
+
 ## Step 4: Run The Project
 
 MultiplayerSampleProject is a multiplayer game, and this means there are several options to launch it.


### PR DESCRIPTION

## Summary

Reverts the cmake change merged in PR #501 (commit `09f162375964`) and replaces it with a one-paragraph README note that addresses #500 the right way. The cmake change in #501 was the wrong fix shape; full diagnosis in #501's closing comment.

## Why the revert is needed

PR #501 was merged at 13:54 UTC today. Subsequent testing on Linux today established that the `add_dependencies(MultiplayerSample.Client MultiplayerSample)` line introduces a hard runtime crash. The engine's gem walker treats `MANUALLY_ADDED_DEPENDENCIES` of a `GEM_MODULE` target as a runtime LOAD dep, not just a build-order dep. Both `libMultiplayerSample.so` and `libMultiplayerSample.Client.so` get loaded into the launcher; both `MultiplayerSampleModule::m_userSettings` instances call `BusConnect` on a Single-handler-policy bus; the second connect asserts and the launcher aborts within 1 to 2 seconds of `LEVEL_LOAD_END`. Filed and verified earlier today, full chain documented in the closing comment of #501.

Current state of upstream `development`: the broken `add_dependencies` is in. Anyone pulling dev tip and building `MultiplayerSample.GameLauncher` on Linux currently hits the abort. This PR restores the previous behavior and addresses #500 with the doc note instead.

## What the doc note covers

The original #500 symptom (`AssetProcessorBatch` can't find `libMultiplayerSample.so` for scriptcanvas bake) only manifests when the build flow targets launchers WITHOUT Editor. The existing standard documented Linux build invocation (`--target Editor --target ...`) doesn't hit this because Editor's `Tools` alias on the gem pulls the bare gem variant in implicitly. Headless / launcher-only builds need to ask for the bare target explicitly.

## Who hits this

- **CI runners skipping Editor** to cut build time on asset-bake validation. Editor pulls Qt + AzToolsFramework + the editor UI stack, which is heavyweight. Asset-bake CI doesn't need any of that.
- **Dedicated server builds.** Cloud server fleets deploying `MultiplayerSample.ServerLauncher` only. Editor on a server image is dead weight.
- **Containerized / headless asset bake pipelines.** Docker/podman build images for reproducible asset baking typically don't include GUI dependencies.
- **Distribution packagers** (RPM, .deb, Snap, Flatpak, Arch user-repo) building MPS for end-user redistribution. Build hosts don't run Editor; runtime + baked assets are what ships.
- **New contributors following launcher-only tutorials.** Confusing scriptcanvas error with no obvious explanation is a real onboarding hurdle.
- **The project's own existing docs.** `Documentation/PackedAssetBuilds.md` line 93 shows `cmake --build build\mono --target MultiplayerSample.GameLauncher MultiplayerSample.ServerLauncher MultiplayerSample.UnifiedLauncher` without Editor; that flow already has this issue latent on Linux.
- **Prevents the wrong-cmake-fix cycle.** Without this note, the next person hitting #500 will try the same `add_dependencies` pattern that PR #501 used, which introduces the runtime crash described in #501's closing comment. Documenting the right path stops the trap from being walked into again.

## Verification

On Fedora 44 / o3de2605 RPM, with the revert applied and `--target MultiplayerSample` added:

```
cmake --build build/linux --target MultiplayerSample.GameLauncher --target MultiplayerSample --config profile
$ENGINE/bin/Linux/profile/Default/AssetProcessorBatch --project-path=$(pwd) --platforms=linux
# Zero scriptcanvas failures. Zero "Failed to load dynamic library at path libMultiplayerSample.so" errors.

$BUILD/bin/profile/MultiplayerSample.GameLauncher \
    --project-path=$(pwd) \
    --regset="/O3DE/Autoexec/ConsoleCommands/bg_ConnectToAssetProcessor=0"
# Loads startmenu cleanly. UI interactive (IP entry / Join Game / Quit all work). No abort over 30+ seconds.
```

Without `--target MultiplayerSample`, same flow reproduces the #500 scriptcanvas failures.

With the merged #501's add_dependencies in place (the current dev-tip state), the same launcher invocation aborts within 1 to 2 seconds with SIGABRT inside `MultiplayerSampleUserSettings::MultiplayerSampleUserSettings()` -> `BusConnect`. Closing comment on #501 has the full repro and stack trace.

Closes #500.
